### PR TITLE
Alternative sysconfig file

### DIFF
--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -77,15 +77,24 @@
     <refsect2 id="help_options">
       <title>Help Options</title>
       <variablelist>
-	<varlistentry>
+        <varlistentry>
           <term><option>-h</option></term>
           <term><option>--help</option></term>
           <listitem>
-	    <para>
-	      Prints a short help text and exists.
-	    </para>
-	  </listitem>
-	</varlistentry>
+            <para>
+              Prints a short help text and exists.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><option>-V</option></term>
+          <term><option>--version</option></term>
+          <listitem>
+            <para>
+              Print the version string of firewalld
+            </para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     </refsect2>
 

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -98,6 +98,21 @@
       </variablelist>
     </refsect2>
 
+    <refsect2 id="import_options">
+      <title>Import Options</title>
+      <variablelist>
+        <varlistentry>
+          <term><option>-f</option></term>
+          <term><option>--system-config-firewall-file</option>=<replaceable>file</replaceable></term>
+          <listitem>
+            <para>
+              Import configuration data from the given configuration file.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </refsect2>
+
     <refsect2 id="status_options">
       <title>Status Options</title>
       <variablelist>

--- a/src/firewall-offline-cmd
+++ b/src/firewall-offline-cmd
@@ -49,6 +49,9 @@ If no options are given, configuration from '/etc/sysconfig/system-config-firewa
 General Options
   -h, --help           Prints a short help text and exists
   -V, --version        Print the version string of firewalld
+  -f, --system-config-firewall-file=<file>
+                       Import configuration data from the given configuration
+                       file.
 
 Lokkit Compatibility Options
   --enabled             Enable firewall (default)
@@ -530,12 +533,10 @@ def __pk_symlink(product='server'):
     else:
         __fail('no such file '+_PK_DIR+_PK_NAME+product+'.policy')
 
-# system-config-firewall: fw_sysconfig
-CONF = '/etc/sysconfig/system-config-firewall'
-def read_sysconfig_args():
+def read_sysconfig_args(sysconfig_file = '/etc/sysconfig/system-config-firewall'):
     filename = None
-    if os.path.exists(CONF) and os.path.isfile(CONF):
-        filename = CONF
+    if os.path.exists(sysconfig_file) and os.path.isfile(sysconfig_file):
+        filename = sysconfig_file
     try:
         f = open(filename, 'r')
     except:
@@ -549,7 +550,11 @@ def read_sysconfig_args():
             continue
         argv.append(line)
     f.close()
-    return argv
+
+    if argv:
+        return parser.parse_args(argv)
+    else:
+        __fail("Opening of '%s' failed, exiting." % sysconfig_file)
 
 ##############################################################################
 
@@ -574,6 +579,8 @@ parser_group_standalone = parser.add_mutually_exclusive_group()
 parser_group_standalone.add_argument("-h", "--help",
                                      action="store_true")
 parser_group_standalone.add_argument("-V", "--version", action="store_true")
+parser_group_standalone.add_argument("-f", "--system-config-firewall-file",
+                                     metavar="<file>")
 parser_group_standalone.add_argument("--policy-server", action="store_true")
 parser_group_standalone.add_argument("--policy-desktop", action="store_true")
 parser_group_standalone.add_argument("--lockdown-on", action="store_true")
@@ -773,11 +780,10 @@ if len(sys.argv) > 1:
     a = parser.parse_args(args)
 else:
     # migrate configuration from /etc/sysconfig/system-config-firewall
-    args = read_sysconfig_args()
-    if args:
-        a = parser.parse_args(args)
-    else:
-        __fail("Opening of '%s' failed, exiting." % CONF)
+    a = read_sysconfig_args()
+
+if a.system_config_firewall_file:
+    a = read_sysconfig_args(a.system_config_firewall_file)
 
 options_lokkit = a.enabled or a.disabled or a.addmodule or a.removemodule or \
                  a.trust or a.masq or a.custom_rules or \


### PR DESCRIPTION
This patchset adds new -f/--system-config-firewall-file options to allow users to set a different file to import firewall configuration from compared to /etc/sysconfig/system-config-firewall
