### PR TITLE
Include reminder that zones must be configured

### DIFF
--- a/doc/xml/firewalld.zones.xml
+++ b/doc/xml/firewalld.zones.xml
@@ -110,7 +110,7 @@
       <title>Which zones are available?</title>
 
       <para>
-	Here are the zones provided by firewalld sorted according to the default trust level of the zones from untrusted to trusted:
+	Below are the zones provided by firewalld sorted according to the default trust level of the zones from untrusted to trusted. The built-in zones are not magically aware of your network layout and will need to be configured by either assigning them network interfaces or source IP address/mask sets.
       </para>
 
 	<variablelist>


### PR DESCRIPTION
It kind of sounds like the zones are auto-configuring. Include reminder that that isn't the case.

I stumbled across a few tutorials for firewalld that all explain that zones are great, but all either glance over them or make it sound like they're automatically configured. Kind of a dangerous misunderstanding, so I thought it was a good idea to clarify.