### PR TITLE
add Murmur (Mumble server) service

### DIFF
--- a/config/services/murmur.xml
+++ b/config/services/murmur.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Murmur</short>
+  <description>Murmur is the server of the Mumble VoIP chat system.</description>
+  <port protocol="tcp" port="64738"/>
+  <port protocol="udp" port="64738"/>
+</service>


### PR DESCRIPTION
cf.  https://wiki.mumble.info/wiki/Running_Murmur#Settings.2C_Ports.2C_and_Authentication
for the default port

murmur availability: e.g. via the Fedora system repository