### PR TITLE
Run interface rules even when NetworkManager is active

### DIFF
--- a/src/firewall-cmd
+++ b/src/firewall-cmd
@@ -465,8 +465,9 @@ def try_set_zone_of_interface(_zone, interface):
                 else:
                     cmd.print_msg("The interface is under control of NetworkManager, setting zone to '%s'." % _zone)
                 nm_set_zone_of_connection(_zone, connection)
-                return True
-        return False
+                # Returning True here leads to firewall not set properly
+                # return True
+    return False
 
 parser = argparse.ArgumentParser(usage="see firewall-cmd man page",
                                  add_help=False)


### PR DESCRIPTION
Later versions of firewalld does not run all needed commands when NetworkManager is active