### PR TITLE
add new service IRCd

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -153,6 +153,8 @@ CONFIG_FILES = \
 	services/ipp-client.xml \
 	services/ipp.xml \
 	services/ipsec.xml \
+	services/ircs.xml \
+	services/irc.xml \
 	services/iscsi-target.xml \
 	services/kadmin.xml \
 	services/kerberos.xml \

--- a/config/services/irc.xml
+++ b/config/services/irc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>IRC</short>
+  <description>An IRCd, short for Internet Relay Chat daemon, is server software that implements the IRC protocol.</description>
+  <port protocol="tcp" port="6667"/>
+</service>

--- a/config/services/ircs.xml
+++ b/config/services/ircs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>IRC TLS/SSL</short>
+  <description>An IRCd, short for Internet Relay Chat daemon, is server software that implements the IRC protocol.</description>
+  <port protocol="tcp" port="6697"/>
+</service>


### PR DESCRIPTION
Common ports for IRC daemons are TCP 6665-6669.