### PR TITLE
Add git service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -146,6 +146,7 @@ CONFIG_FILES = \
 	services/ftp.xml \
 	services/ganglia-client.xml \
 	services/ganglia-master.xml \
+	services/git.xml \
 	services/high-availability.xml \
 	services/https.xml \
 	services/http.xml \

--- a/config/services/git.xml
+++ b/config/services/git.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>git</short>
+  <description>The git daemon for supporting git:// access to git repositories.</description>
+  <port protocol="tcp" port="9418"/>
+</service>


### PR DESCRIPTION
It may be helpful to have the git-daemon pre-defined as a service.  I know I'd use it.