### PR TITLE
Add kprop service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -160,6 +160,7 @@ CONFIG_FILES = \
 	services/kibana.xml \
 	services/klogin.xml \
 	services/kpasswd.xml \
+	services/kprop.xml \
 	services/kshell.xml \
 	services/ldaps.xml \
 	services/ldap.xml \

--- a/config/services/kprop.xml
+++ b/config/services/kprop.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>kprop</short>
+  <description>Kerberos KDC Propagation Protocol</description>
+  <port protocol="tcp" port="754"/>
+</service>


### PR DESCRIPTION
This service is used by MIT Kerberos for KDC slave sync.