### PR TITLE
Add new UPnP client service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -230,6 +230,7 @@ CONFIG_FILES = \
 	services/tinc.xml \
 	services/tor-socks.xml \
 	services/transmission-client.xml \
+	services/upnp-client.xml \
 	services/vdsm.xml \
 	services/vnc-server.xml \
 	services/wbem-https.xml \

--- a/config/services/upnp-client.xml
+++ b/config/services/upnp-client.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>UPnP Client</short>
+  <description>Universal Plug and Play client for auto-configuration of network routers (use only in trusted zones).</description>
+  <source-port port="1900" protocol="udp"/>
+</service>


### PR DESCRIPTION
Important for many desktop programs, especially for home users.

This really really shouldn’t be enabled on public zones, so included
suggestion to only use it in trusted zones in the service description.