### PR TITLE
src: firewall: Add support for SUSE ifcfg scripts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,11 @@ AC_ARG_WITH([bashcompletiondir],
        [BASHCOMPLETIONDIR=$withval], [BASHCOMPLETIONDIR="${datadir}/bash-completion/completions"])
 AC_SUBST(BASHCOMPLETIONDIR)
 
+AC_ARG_WITH([ifcfgdir],
+       AS_HELP_STRING([--with-ifcfgdir=DIR], [The ifcfg configuration directory]),
+       [IFCFGDIR=$withval], [IFCFGDIR="/etc/sysconfig/network-scripts"])
+AC_SUBST(IFCFGDIR)
+
 # Extend PATH to include /sbin etc in case we are building as non-root
 FW_TOOLS_PATH="$PATH:/usr/local/sbin:/sbin:/usr/sbin"
 

--- a/doc/xml/Makefile.am
+++ b/doc/xml/Makefile.am
@@ -2,7 +2,8 @@ XSLTPROC = xsltproc
 
 EXTRA_DIST = $(HTMLS:../html/%.html=%.xml) \
 	authors.xml notes.xml seealso.xml errorcodes.xml \
-	transform-man.xsl.in transform-html.xsl.in
+	transform-man.xsl.in transform-html.xsl.in \
+	firewalld.xml.in firewall-cmd.xml.in firewallctl.xml.in
 
 man_MANS = $(man1_MANS) $(man5_MANS)
 HTMLS = $(man1_MANS:../man/man1/%.1=../html/%.html) $(man5_MANS:../man/man5/%.5=../html/%.html)
@@ -28,8 +29,10 @@ man5_MANS = \
 	../man/man5/firewalld.zone.5 \
 	../man/man5/firewalld.zones.5
 
+XML_FIREWALLD_DEPS=firewalld.xml firewall-cmd.xml firewallctl.xml
+
 CLEAN_FILES = *~ errorcodes.xml
-DISTCLEANFILES = $(man_MANS) $(HTMLS) transform-*.xsl
+DISTCLEANFILES = $(man_MANS) $(HTMLS) transform-*.xsl $(XML_FIREWALLD_DEPS)
 
 #SGML_CATALOG_FILES
 #XSLTPROC_FLAGS = --catalogs --nonet --xinclude
@@ -44,17 +47,17 @@ all: $(man_MANS) $(HTMLS)
 clean:
 	-test -z "$(CLEAN_FILES)" || rm -f $(CLEAN_FILES)
 
-../man/man1/firewall-cmd.1: errorcodes.xml
+../man/man1/firewall-cmd.1: errorcodes.xml firewall-cmd.xml
 
-../html/firewall-cmd.html: errorcodes.xml
+../html/firewall-cmd.html: errorcodes.xml firewall-cmd.xml
 
-../man/man1/%.1: %.xml authors.xml notes.xml seealso.xml transform-man.xsl
+../man/man1/%.1: %.xml authors.xml notes.xml seealso.xml transform-man.xsl $(XML_FIREWALLD_DEPS)
 	$(XSLTPROC) -o $@ $(XSLTPROC_MAN_FLAGS) $<
 
-../man/man5/%.5: %.xml authors.xml notes.xml seealso.xml transform-man.xsl
+../man/man5/%.5: %.xml authors.xml notes.xml seealso.xml transform-man.xsl $(XML_FIREWALLD_DEPS)
 	$(XSLTPROC) -o $@ $(XSLTPROC_MAN_FLAGS) $<
 
-../html/%.html: %.xml authors.xml notes.xml seealso.xml transform-html.xsl
+../html/%.html: %.xml authors.xml notes.xml seealso.xml transform-html.xsl $(XML_FIREWALLD_DEPS)
 	$(XSLTPROC) -o $@ $(XSLTPROC_HTML_FLAGS) $<
 
 errorcodes.xml: ../../src/firewall/errors.py
@@ -67,9 +70,16 @@ errorcodes.xml: ../../src/firewall/errors.py
 edit = sed \
 	-e 's|\@PREFIX\@|$(prefix)|' \
 	-e 's|\@SYSCONFDIR\@|$(sysconfdir)|' \
-	-e 's|\@PACKAGE_STRING\@|$(PACKAGE_STRING)|'
+	-e 's|\@PACKAGE_STRING\@|$(PACKAGE_STRING)|' \
+	-e 's|\@IFCFGDIR\@|$(IFCFGDIR)|'
 
 transform-man.xsl: transform-man.xsl.in
 	$(edit) $< >$@
 transform-html.xsl: transform-html.xsl.in
+	$(edit) $< >$@
+firewall-cmd.xml: firewall-cmd.xml.in
+	$(edit) $< >$@
+firewalld.xml: firewalld.xml.in
+	$(edit) $< >$@
+firewallctl.xml: firewallctl.xml.in
 	$(edit) $< >$@

--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -910,7 +910,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
 	    </para>
 	    <para>
 	      As a end user you don't need this in most cases, because NetworkManager (or legacy network service) adds interfaces into zones automatically (according to <option>ZONE=</option> option from ifcfg-<replaceable>interface</replaceable> file) if <replaceable>NM_CONTROLLED=no</replaceable> is not set.
-	      You should do it only if there's no /etc/sysconfig/network-scripts/ifcfg-<replaceable>interface</replaceable> file.
+	      You should do it only if there's no @IFCFGDIR@/ifcfg-<replaceable>interface</replaceable> file.
 	      If there is such file and you add interface to zone with this <option>--add-interface</option> option, make sure the zone is the same in both cases, otherwise the behaviour would be undefined.
 	      Please also have a look at the <citerefentry><refentrytitle>firewalld</refentrytitle><manvolnum>1</manvolnum></citerefentry> man page in the <replaceable>Concepts</replaceable> section.
 	      For permanent association of interface with a zone, see also 'How to set or change a zone for a connection?' in <citerefentry><refentrytitle>firewalld.zones</refentrytitle><manvolnum>5</manvolnum></citerefentry>.

--- a/doc/xml/firewallctl.xml.in
+++ b/doc/xml/firewallctl.xml.in
@@ -601,7 +601,7 @@
 	    </para>
 	    <para>
 	      As a end user you don't need to create or change zone bindings of interfaces in most cases, because NetworkManager (or legacy network service) adds interfaces into zones automatically (according to <option>ZONE=</option> option from ifcfg-<replaceable>interface</replaceable> file) if <replaceable>NM_CONTROLLED=no</replaceable> is not set.
-	      You should do it only if there's no /etc/sysconfig/network-scripts/ifcfg-<replaceable>interface</replaceable> file.
+	      You should do it only if there's no @IFCFGDIR@/ifcfg-<replaceable>interface</replaceable> file.
 	      If there is such file and you add interface to zone with this <option>--add-interface</option> option, make sure the zone is the same in both cases, otherwise the behaviour would be undefined.
 	      Please also have a look at the <citerefentry><refentrytitle>firewalld</refentrytitle><manvolnum>1</manvolnum></citerefentry> man page in the <replaceable>Concepts</replaceable> section.
 	      For permanent association of interface with a zone, see also 'How to set or change a zone for a connection?' in <citerefentry><refentrytitle>firewalld.zones</refentrytitle><manvolnum>5</manvolnum></citerefentry>.

--- a/doc/xml/firewalld.xml.in
+++ b/doc/xml/firewalld.xml.in
@@ -130,7 +130,7 @@
     </para>
     <para>
       You can add these interfaces to a zone with <command>firewall-cmd [--permanent] --zone=<replaceable>zone</replaceable> --add-interface=<replaceable>interface</replaceable></command>.
-      If there is a /etc/sysconfig/network-scripts/ifcfg-<replaceable>interface</replaceable> file, firewalld tries to change the ZONE=<replaceable>zone</replaceable> setting in this file.
+	  If there is a @IFCFGDIR@/ifcfg-<replaceable>interface</replaceable> file, firewalld tries to change the ZONE=<replaceable>zone</replaceable> setting in this file.
     </para>
     <para>
       If firewalld gets reloaded, it will restore the interface bindings that were in place before reloading to keep interface bindings stable in the case of NetworkManager uncontrolled interfaces.

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -88,7 +88,7 @@ FIREWALLD_DIRECT = ETC_FIREWALLD + '/direct.xml'
 LOCKDOWN_WHITELIST = ETC_FIREWALLD + '/lockdown-whitelist.xml'
 
 SYSCONFIGDIR = '/etc/sysconfig'
-IFCFGDIR = SYSCONFIGDIR + '/network-scripts'
+IFCFGDIR = "@IFCFGDIR@"
 
 SYSCTL_CONFIG = '/etc/sysctl.conf'
 

--- a/src/firewall/core/fw_ifcfg.py
+++ b/src/firewall/core/fw_ifcfg.py
@@ -36,11 +36,13 @@ def search_ifcfg_of_interface(interface):
     if not os.path.exists(config.IFCFGDIR):
         return None
 
+    # RedHat puts ifcfg files in 'network-scripts'
+    suseifcfg = not "network-scripts" in config.IFCFGDIR
     filename = "%s/ifcfg-%s" % (config.IFCFGDIR, interface)
     if os.path.exists(filename):
         ifcfg_file = ifcfg(filename)
         ifcfg_file.read()
-        if ifcfg_file.get("DEVICE") == interface:
+        if ifcfg_file.get("DEVICE") == interface or suseifcfg:
             return ifcfg_file
 
     for filename in sorted(os.listdir(config.IFCFGDIR)):


### PR DESCRIPTION
The SUSE ifcfg scripts are in /etc/sysconfig/network directory so
look there as well when searching for ifcfg files. Moreover, the SUSE
ifcfg files do not use the DEVICE parameter so we don't have to look for
it when we try to determine if the ifcfg file is the one handling the
interface we are interested in. However, we need to check if the
ETHERDEVICE parameter exists because it's used when we create VLANs.