### PR TITLE
samba-client: Add source-port 137/udp

### DIFF
--- a/config/services/samba-client.xml
+++ b/config/services/samba-client.xml
@@ -4,5 +4,6 @@
   <description>This option allows you to access Windows file and printer sharing networks. You need the samba-client package installed for this option to be useful.</description>
   <port protocol="udp" port="137"/>
   <port protocol="udp" port="138"/>
+  <source-port protocol="udp" port="137"/>
   <module name="nf_conntrack_netbios_ns"/>
 </service>


### PR DESCRIPTION
Fixes #266 

I don't know if source-port 138/udp is also needed. For me browsing Windows shares in Nautilus works without it, and in the logs, any time I see SPT=138 I also see DPT=138 which is already covered in the current samba-client.service. I'm no expert at SMB/CIFS and I haven't tested any other case like printers. I opted not to add any rule I haven't confirmed as necessary.

I also don't know if any of this is needed for samba.service as well. My only observation is a `FINAL_REJECT` that blocks browsing remote Windows shares in Nautilus even with samba-client.service enabled, which seems like something it should allow.