### PR TITLE
Add nmea-0183 service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -185,6 +185,7 @@ CONFIG_FILES = \
 	services/mysql.xml \
 	services/nfs.xml \
 	services/nfs3.xml \
+	services/nmea-0183.xml \
 	services/nrpe.xml \
 	services/ntp.xml \
 	services/openvpn.xml \

--- a/config/services/nmea-0183.xml
+++ b/config/services/nmea-0183.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>nmea-0183</short>
+  <description>NMEA-0183 Navigational Data server for use with Global Navigation Satellite System (GNSS) devices.</description>
+  <port protocol="tcp" port="10110" />
+  <port protocol="udp" port="10110" />
+</service>


### PR DESCRIPTION
GPS data service offered by GPSD, Gypsy, gps-share, etc. and used by clients like GeoClue.

Port 10110 is registered for the nmea-0183 service with IANA.