### PR TITLE
Fixed python3 compatibility in firewall reload

### DIFF
--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -950,8 +950,7 @@ class Firewall(object):
             else:
                 log.info1("New zone '%s'.", zone)
         if len(_zone_interfaces) > 0:
-            keys = _zone_interfaces.keys()
-            for zone in keys:
+            for zone in list(_zone_interfaces.keys()):
                 log.info1("Lost zone '%s', zone interfaces dropped.", zone)
                 del _zone_interfaces[zone]
         del _zone_interfaces

--- a/src/firewall/core/watcher.py
+++ b/src/firewall/core/watcher.py
@@ -61,7 +61,7 @@ class Watcher(object):
             self._blocked.remove(filename)
 
     def clear_timeouts(self):
-        for filename in self._timeouts.keys():
+        for filename in list(self._timeouts.keys()):
             GLib.source_remove(self._timeouts[filename])
             del self._timeouts[filename]
 


### PR DESCRIPTION
Python3 returns the iterator for keys() instead of a list. When used dictionary is changed ( in case of firewall reload, when lost zone has been is removed ) Python3 returns error ( RuntimeError: dictionary changed size during iteration ). To fix this, list has been added, so separate copy of the keys is created and can be safely used in for loop while dictionary is being modified.

This commit also addresses issue #276 