### PR TITLE
firewall/core/fw_transaction.py: Remove deduplication in add_rule (RH…

### DIFF
--- a/src/firewall/core/fw_transaction.py
+++ b/src/firewall/core/fw_transaction.py
@@ -46,8 +46,7 @@ class SimpleFirewallTransaction(object):
         del self.fail_funcs[:]
 
     def add_rule(self, ipv, rule):
-        if ipv not in self.rules or rule not in self.rules[ipv]:
-            self.rules.setdefault(ipv, [ ]).append(rule)
+        self.rules.setdefault(ipv, [ ]).append(rule)
 
     def query_rule(self, ipv, rule):
         return ipv in self.rules and rule in self.rules[ipv]


### PR DESCRIPTION
…BZ#1534571)

Loading services from permanent configuration containing the same port numbers
results in desuplication of the rules. This then results in an error if the
second service gets removed from the zone.

This fixes RHBZ#1534571