### PR TITLE
src: firewall-config: Fix deletion of connection timer

### DIFF
--- a/src/firewall-config
+++ b/src/firewall-config
@@ -1626,8 +1626,8 @@ class FirewallConfig(object):
 
     def connection_changed(self):
         if self.connection_timer:
-                self.connection_timer = None
                 GLib.source_remove(self.connection_timer)
+                self.connection_timer = None
         if self.fw.connected:
             self.fw.authorizeAll()
             self.statusLabel.set_text(self.connected_label)


### PR DESCRIPTION
The connection timer has to be reset after it's being deleted from the
timer list.