### PR TITLE
services: Add lightning-network related services

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -132,6 +132,8 @@ CONFIG_FILES = \
 	services/bitcoin-testnet-rpc.xml \
 	services/bitcoin-testnet.xml \
 	services/bitcoin.xml \
+	services/lightning-network.xml \
+	services/lightning-network-testnet.xml \
 	services/ceph-mon.xml \
 	services/ceph.xml \
 	services/cfengine.xml \

--- a/config/services/lightning-network-testnet.xml
+++ b/config/services/lightning-network-testnet.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Lightning Network testnet</short>
+  <description>The default port used by Lightning Network testnet.  Enable this option if you plan to be a Lightning Network node.</description>
+  <port protocol="tcp" port="19735"/>
+</service>

--- a/config/services/lightning-network.xml
+++ b/config/services/lightning-network.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Lightning Network</short>
+  <description>The default port used by Lightning Network.  Enable this option if you plan to be a Lightning Network node.</description>
+  <port protocol="tcp" port="9735"/>
+</service>


### PR DESCRIPTION
The following ports are used from lightning-network network.

lightning-network 9735/tcp
lightning-network-testnet 19735/tcp