### PR TITLE
fw_zone: fix erroneous source/destination reversal in rich rule masqu…

### DIFF
--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -1884,9 +1884,8 @@ class FirewallZone(object):
                 target = DEFAULT_ZONE_TARGET.format(
                     chain=SHORTCUTS["FORWARD_OUT"], zone=zone)
                 command = [ ]
-                # reverse source/destination !
-                self.__rule_source(rule.destination, command)
-                self.__rule_destination(rule.source, command)
+                self.__rule_source(rule.source, command)
+                self.__rule_destination(rule.destination, command)
                 command += [ "-m", "conntrack", "--ctstate", "NEW",
                              "-j", "ACCEPT" ]
 


### PR DESCRIPTION
…erade

Specifying "source .." in rich rule masquerade was mistakenly reversed
causing it to match the destination instead. This is not what users
expect. It's expected that "source .." match something internal.

This allows "rule family=ipv4 source address=192.168.123.0/24
masquerade" to masquerade only a subset of the internal network.

Fixes: #80