### PR TITLE
core: logger: Remove world-readable bit from logfile

### DIFF
--- a/src/firewall/core/logger.py
+++ b/src/firewall/core/logger.py
@@ -30,6 +30,7 @@ import syslog
 import traceback
 import fcntl
 import os.path
+import os
 
 # ---------------------------------------------------------------------------
 
@@ -134,7 +135,14 @@ class FileLog(LogTarget):
     def open(self):
         if self.fd:
             return
-        self.fd = open(self.filename, self.mode)
+        flags = os.O_CREAT | os.O_WRONLY
+        if self.mode.startswith('a'):
+            flags |= os.O_APPEND
+        self.fd = os.open(self.filename, flags, 0o640)
+        # Make sure that existing file has correct perms
+        os.fchmod(self.fd, 0o640)
+        # Make it an object
+        self.fd = os.fdopen(self.fd, self.mode)
         fcntl.fcntl(self.fd, fcntl.F_SETFD, fcntl.FD_CLOEXEC)
 
     def write(self, data, level, logger, is_debug=0):


### PR DESCRIPTION
The firewalld logfile was created with the 'read' bit set for all users
which could potentially reveal information about the firewall
configuration to unauthorised users. As such, we need to make use of
the low-level I/O facilities of the 'os' module to drop that bit during
file opening and creation.

Co-Authored-By: Matthias Gerstner <matthias.gerstner@suse.com>