### PR TITLE
Use preferred location for AppData files

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -7,7 +7,7 @@ desktopdir = $(datadir)/applications
 desktop_DATA = $(desktop_FILES:.in=)
 
 appdata_FILES = firewall-config.appdata.xml.in
-appdatadir = $(datadir)/appdata/
+appdatadir = $(datadir)/metainfo/
 appdata_DATA = $(appdata_FILES:.in=)
 
 applet_desktop_FILES = firewall-applet.desktop.in


### PR DESCRIPTION
The AppStream metadata files should be placed in /usr/share/metainfo/.

Refer to https://wiki.debian.org/AppStream/Guidelines for details.

Fixes: #360