### PR TITLE
tests: Remove bashism from functions.at

### DIFF
--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -302,8 +302,9 @@ m4_define([CHECK_LOG_AUDIT], [
 
 m4_ifnblank(
     m4_esyscmd([
-        KERNEL_VER=( $(uname -r | tr '.' ' ') )
-        if test ${KERNEL_VER[0]} -eq 4 && test ${KERNEL_VER[1]} -ge 10 || test ${KERNEL_VER[0]} -gt 4; then
+        KERNEL_MAJOR=`uname -r | cut -d. -f1`
+        KERNEL_MINOR=`uname -r | cut -d. -f2`
+        if test ${KERNEL_MAJOR} -eq 4 && test ${KERNEL_MINOR} -ge 10 || test ${KERNEL_MAJOR} -gt 4; then
             echo -n "yes"
         fi
     ]),


### PR DESCRIPTION
This avoids triggering the following error on make check if /bin/sh is
not /bin/bash:

$ make check
make  check-local
make[1]: Verzeichnis „/home/michael/debian/build-area/firewalld-0.6.0/src/tests“ wird betreten
:;{ \
echo 'm4_define([AT_PACKAGE_NAME],[firewalld])' && \
echo 'm4_define([AT_PACKAGE_VERSION],[0.6.0])' && \
echo 'm4_define([AT_PACKAGE_STRING],[firewalld 0.6.0])' && \
echo 'm4_define([AT_PACKAGE_URL],[http://firewalld.org/])' && \
echo 'm4_define([AT_PACKAGE_BUGREPORT],[https://github.com/firewalld/firewalld])'; \
} > "package.m4"
/bin/bash ../../missing --run autom4te --language=autotest -I '.' -o testsuite.tmp testsuite.at
sh: 2: Syntax error: "(" unexpected

Fixes: #357