### PR TITLE
Add KDE Connect service

### DIFF
--- a/config/services/kdeconnect.xml
+++ b/config/services/kdeconnect.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>KDE Connect</short>
+  <description>KDE Connect is an application to connect your phone to your computer.</description>
+  <port port="1714-1764" protocol="tcp"/>
+  <port port="1714-1764" protocol="udp"/>
+</service>


### PR DESCRIPTION
Includes a service file which opens the ports needed by [KDE Connect](https://community.kde.org/KDEConnect) to communicate with phones.