### PR TITLE
Add Spotify local files sync service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -236,6 +236,7 @@ CONFIG_FILES = \
 	services/snmptrap.xml \
 	services/snmp.xml \
 	services/spideroak-lansync.xml \
+	services/spotify-sync.xml \
 	services/squid.xml \
 	services/ssh.xml \
 	services/steam-streaming.xml \

--- a/config/services/spotify-sync.xml
+++ b/config/services/spotify-sync.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Spotify Client Sync</short>
+  <description>The Spotify Client allows you to sync local music files with your phone.</description>
+  <port port="57621" protocol="tcp"/>
+</service>

--- a/config/services/spotify-sync.xml
+++ b/config/services/spotify-sync.xml
@@ -2,5 +2,6 @@
 <service>
   <short>Spotify Client Sync</short>
   <description>The Spotify Client allows you to sync local music files with your phone.</description>
+  <port port="57621" protocol="udp"/>
   <port port="57621" protocol="tcp"/>
 </service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -170,6 +170,7 @@ config/services/smtp.xml
 config/services/snmptrap.xml
 config/services/snmp.xml
 config/services/spideroak-lansync.xml
+config/services/spotify-sync.xml
 config/services/squid.xml
 config/services/ssh.xml
 config/services/steam-streaming.xml


### PR DESCRIPTION
Includes a service file which opens the ports needed by the Spotify client to sync local music files with the Android (maybe iOS too?) app.