### PR TITLE
firewall/core/fw_nm: nm_get_zone_of_connection return type fix

### DIFF
--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -75,21 +75,21 @@ def nm_get_zone_of_connection(connection):
 
     con = nm_get_client().get_connection_by_uuid(connection)
     if con is None:
-        return False
+        return None
 
     setting_con = con.get_setting_connection()
     if setting_con is None:
-        return False
+        return None
 
     try:
         if con.get_flags() & (NM.SettingsConnectionFlags.NM_GENERATED
                               | NM.SettingsConnectionFlags.NM_VOLATILE):
-            return False
+            return ""
     except AttributeError:
         # Prior to NetworkManager 1.12, we can only guess
         # that a connection was generated/volatile.
         if con.get_unsaved():
-            return False
+            return ""
 
     zone = setting_con.get_zone()
     if zone is None:


### PR DESCRIPTION
Hello,

As explained in #370, when using NetworkManager the automatically generated connections (such as `docker0` for the interface with the same name) make `nm_get_zone_of_connection` return False which in turn makes `firewall-config` crash.

This pull request basically changes the return values of `nm_get_zone_of_connection` so that it matches the old behavior in version 0.6.0 by returning None, except for a generated connection in which case it returns the empty string so the default zone is used by firewalld.

Let me know if this is useful.

Thanks