### PR TITLE
Fix Neighbor Discovery when using drop zone

### DIFF
--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1140,9 +1140,13 @@ class ip6tables(ip4tables):
                        "--icmpv6-type=router-advertisement",
                        "-j", "ACCEPT" ]) # RHBZ#1058505
         rules.append([ "-I", "PREROUTING", "3", "-t", "raw",
+                       "-p", "ipv6-icmp",
+                       "--icmpv6-type=neighbour-advertisement",
+                       "-j", "ACCEPT" ]) # suse bz #1105821
+        rules.append([ "-I", "PREROUTING", "4", "-t", "raw",
                        "-m", "rpfilter", "--invert", "-j", "DROP" ])
         if log_denied != "off":
-            rules.append([ "-I", "PREROUTING", "3", "-t", "raw",
+            rules.append([ "-I", "PREROUTING", "4", "-t", "raw",
                            "-m", "rpfilter", "--invert",
                            "-j", "LOG",
                            "--log-prefix", "rpfilter_DROP: " ])

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1150,4 +1150,19 @@ class ip6tables(ip4tables):
                            "-m", "rpfilter", "--invert",
                            "-j", "LOG",
                            "--log-prefix", "rpfilter_DROP: " ])
+        # We also need to allow these messages to the filter table
+        # because accepting them in the 'raw' table alone will still
+        # make them traverse the rest of the tables.
+        rules.append([ "-I", "INPUT", "1", "-t", "filter",
+                       "-p", "ipv6-icmp",
+                       "--icmpv6-type=neighbour-solicitation",
+                       "-j", "ACCEPT" ])
+        rules.append([ "-I", "INPUT", "2", "-t", "filter",
+                       "-p", "ipv6-icmp",
+                       "--icmpv6-type=router-advertisement",
+                       "-j", "ACCEPT" ])
+        rules.append([ "-I", "INPUT", "3", "-t", "filter",
+                       "-p", "ipv6-icmp",
+                       "--icmpv6-type=neighbour-advertisement",
+                       "-j", "ACCEPT" ])
         return rules

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -1132,6 +1132,13 @@ class nftables(object):
                       "raw_%s" % "PREROUTING",
                       "icmpv6", "type", "{ nd-router-advert, nd-neighbor-advert, nd-neighbor-solicit }",
                       "accept"]) # RHBZ#1058505, RHBZ#1575431 (bug in kernel 4.16-4.17), suse bz #1105821
+        # We also need to allow these messages to the filter table
+        # because accepting them in the 'raw' table alone will still
+        # make them traverse the rest of the tables.
+        rules.append(["insert", "rule", "inet", "%s" % TABLE_NAME,
+                      "filter_%s" % "INPUT",
+                      "icmpv6", "type", "{ nd-router-advert, nd-neighbor-advert, nd-neighbor-solicit }",
+                      "accept"])
 
         return rules
 

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -1130,8 +1130,9 @@ class nftables(object):
                           "oif", "missing", "log", "prefix", "\"rpfilter_DROP: \""])
         rules.append(["insert", "rule", "inet", "%s" % TABLE_NAME,
                       "raw_%s" % "PREROUTING",
-                      "icmpv6", "type", "{ nd-router-advert, nd-neighbor-solicit }",
-                      "accept"]) # RHBZ#1058505, RHBZ#1575431 (bug in kernel 4.16-4.17)
+                      "icmpv6", "type", "{ nd-router-advert, nd-neighbor-advert, nd-neighbor-solicit }",
+                      "accept"]) # RHBZ#1058505, RHBZ#1575431 (bug in kernel 4.16-4.17), suse bz #1105821
+
         return rules
 
     def build_zone_rich_source_destination_rules(self, enable, zone, rich_rule):


### PR DESCRIPTION
This adds two commits needed to fix the ND when an interface belongs to the drop zone

- Patch#1 Accepts neighbour-advertisement message to the 'raw' table
- Patch#2 Accepts all needed ND packets in the filter table which is needed if the default policy on the filter table is 'DROP/REJECT' (eg drop zone)