### PR TITLE
*tables: For opened ports/protocols/etc match ct state new,untracked

### DIFF
--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -872,7 +872,7 @@ class ip4tables(object):
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
         if not rich_rule or rich_rule.action != Rich_Mark:
-            rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW" ]
+            rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW,UNTRACKED" ]
 
         rules = []
         if rich_rule:
@@ -897,7 +897,7 @@ class ip4tables(object):
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
         if not rich_rule or rich_rule.action != Rich_Mark:
-            rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW" ]
+            rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW,UNTRACKED" ]
 
         rules = []
         if rich_rule:
@@ -925,7 +925,7 @@ class ip4tables(object):
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
         if not rich_rule or rich_rule.action != Rich_Mark:
-            rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW" ]
+            rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW,UNTRACKED" ]
 
         rules = []
         if rich_rule:
@@ -975,7 +975,7 @@ class ip4tables(object):
 
         rules.append([ add_del, "%s_allow" % (target), "-t", "filter"]
                      + rule_fragment +
-                     ["-m", "conntrack", "--ctstate", "NEW", "-j", "ACCEPT" ])
+                     ["-m", "conntrack", "--ctstate", "NEW,UNTRACKED", "-j", "ACCEPT" ])
 
         return rules
 
@@ -1019,7 +1019,7 @@ class ip4tables(object):
                                             zone=zone)
         rules.append([ add_del, "%s_allow" % (target),
                      "-t", "filter", "-m", "conntrack",
-                     "--ctstate", "NEW" ] +
+                     "--ctstate", "NEW,UNTRACKED" ] +
                      mark + [ "-j", "ACCEPT" ])
 
         return rules

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -812,7 +812,7 @@ class nftables(object):
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
         rule_fragment += [proto, "dport", "%s" % portStr(port, "-")]
-        rule_fragment += ["ct", "state", "new"]
+        rule_fragment += ["ct", "state", "new,untracked"]
 
         rules = []
         if rich_rule:
@@ -845,7 +845,7 @@ class nftables(object):
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
         rule_fragment = ["meta", "l4proto", protocol]
-        rule_fragment += ["ct", "state", "new"]
+        rule_fragment += ["ct", "state", "new,untracked"]
 
         rules = []
         if rich_rule:
@@ -878,7 +878,7 @@ class nftables(object):
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
         rule_fragment += [proto, "sport", "%s" % portStr(port, "-")]
-        rule_fragment += ["ct", "state", "new"]
+        rule_fragment += ["ct", "state", "new,untracked"]
 
         rules = []
         if rich_rule:
@@ -949,7 +949,7 @@ class nftables(object):
 
         rules.append([add_del, "rule", "inet", "%s" % TABLE_NAME,
                       "filter_%s_allow" % (target)]
-                      + rule_fragment + ["ct", "state", "new", "accept"])
+                      + rule_fragment + ["ct", "state", "new,untracked", "accept"])
 
         return rules
 
@@ -1013,7 +1013,7 @@ class nftables(object):
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[filter_chain],
                                             zone=zone)
         rules.append([add_del, "rule", "inet", "%s" % TABLE_NAME,
-                      "filter_%s_allow" % (target), "ct", "state", "new"]
+                      "filter_%s_allow" % (target), "ct", "state", "new,untracked"]
                       + mark_fragment + ["accept"])
 
         return rules

--- a/src/tests/regression/gh366.at
+++ b/src/tests/regression/gh366.at
@@ -5,21 +5,21 @@ m4_if(nftables, FIREWALL_BACKEND, [
 NFT_LIST_RULES([inet], [filter_IN_public_allow], 0, [dnl
 table inet firewalld {
 chain filter_IN_public_allow {
-tcp dport 22 ct state new accept
-ip6 daddr fe80::/64 udp dport 546 ct state new accept
-ip daddr 224.0.0.251 udp dport 5353 ct state new accept
-ip6 daddr ff02::fb udp dport 5353 ct state new accept
+tcp dport 22 ct state new,untracked accept
+ip6 daddr fe80::/64 udp dport 546 ct state new,untracked accept
+ip daddr 224.0.0.251 udp dport 5353 ct state new,untracked accept
+ip6 daddr ff02::fb udp dport 5353 ct state new,untracked accept
 }
 }
 ])], [
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-ACCEPT tcp -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 ctstate NEW
-ACCEPT udp -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 ctstate NEW
+ACCEPT tcp -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 ctstate NEW,UNTRACKED
+ACCEPT udp -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 ctstate NEW,UNTRACKED
 ])
 IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-ACCEPT tcp ::/0 ::/0 tcp dpt:22 ctstate NEW
-ACCEPT udp ::/0 fe80::/64 udp dpt:546 ctstate NEW
-ACCEPT udp ::/0 ff02::fb udp dpt:5353 ctstate NEW
+ACCEPT tcp ::/0 ::/0 tcp dpt:22 ctstate NEW,UNTRACKED
+ACCEPT udp ::/0 fe80::/64 udp dpt:546 ctstate NEW,UNTRACKED
+ACCEPT udp ::/0 ff02::fb udp dpt:5353 ctstate NEW,UNTRACKED
 ])])])
 
 FWD_CHECK([-q --zone=public --add-service=mdns])


### PR DESCRIPTION
Some valid packets may be untracked and as such "ct state new" won't
match them. A prime example of this is IPv6 neighbor-advertisements. Now
adding the "icmp" service to a zone will match and accept these
untracked packets.

Note: We don't want to fully remove ct state match because we don't want
to match invalid states. This is especially important for the forward
chain.

Fixes: suse bz 1105821