### PR TITLE
Add Big Brother service; IANA 1984

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -120,6 +120,7 @@ CONFIG_FILES = \
 	services/apcupsd.xml \
 	services/bacula-client.xml \
 	services/bacula.xml \
+	services/bb.xml \
 	services/bgp.xml \
 	services/bitcoin-rpc.xml \
 	services/bitcoin-testnet-rpc.xml \

--- a/config/services/bb.xml
+++ b/config/services/bb.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Big Brother</short>
+  <description>Big Brother is a plain text protocol for sending and receiving client data, reports, and queries to a BB-compatible monitoring server or proxy. The standard IANA port for a listening Big Brother service is 1984, because of course it is.</description>
+  <port protocol="tcp" port="1984"/>
+  <port protocol="udp" port="1984"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -54,6 +54,7 @@ config/services/amqp.xml
 config/services/apcupsd.xml
 config/services/bacula-client.xml
 config/services/bacula.xml
+config/services/bb.xml
 config/services/bgp.xml
 config/services/bitcoin-rpc.xml
 config/services/bitcoin-testnet-rpc.xml


### PR DESCRIPTION
https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=1984

This port/protocol is still used by compatible monitoring systems such as Xymon. 
TCP is the primary transport layer, but UDP has been reserved for future use.