### PR TITLE
Fix translating labels

### DIFF
--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -10135,10 +10135,10 @@
                             <property name="halign">start</property>
                             <property name="valign">start</property>
                             <items>
-                              <item>accept</item>
-                              <item>reject</item>
-                              <item>drop</item>
-                              <item>mark</item>
+                              <item translatable="yes">accept</item>
+                              <item translatable="yes">reject</item>
+                              <item translatable="yes">drop</item>
+                              <item translatable="yes">mark</item>
                             </items>
                             <signal name="changed" handler="on_richRuleDialog_changed" swapped="no"/>
                           </object>


### PR DESCRIPTION
Fix of https://github.com/firewalld/firewalld/issues/344 was incomplete, the "flags" were not translating and the reported bug was still active. I am proposing a patch which solves the issue for me.