### PR TITLE
Enabling LogDenied fails for ICMP block inversion

### DIFF
--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -2558,9 +2558,9 @@ class FirewallZoneIPTables(FirewallZone):
         zone_transaction.add_chain("filter", "FORWARD_IN")
 
         for ipv in [ "ipv4", "ipv6" ]:
-            rule_idx = 4
             table = "filter"
             for chain in [ "INPUT", "FORWARD_IN" ]:
+                rule_idx = 4
                 _zone = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[chain],
                                                    zone=zone)
 


### PR DESCRIPTION
When LogDenied is enabled, logging rules created for ICMP BLOCKS are incorrectly indexed for both IPv4 and IPv6, leading to the restore tools for each failing to load the new rules. This was caused by the rule_idx variable incorrectly being reset in the outer loop instead of the inner loop. 

As an example, here's a snippet of the IN_external and FWDI_external rules that get generated with the rule_idx set (to `4`) in the outer loop:
```
-N IN_external
-N IN_external_log
-N IN_external_deny
-N IN_external_allow
-I IN_external 1 -j IN_external_log
-I IN_external 2 -j IN_external_deny
-I IN_external 3 -j IN_external_allow
-I INPUT_ZONES 1 -i eth0 -g IN_external
-I FORWARD_OUT_ZONES 1 -o eth0 -g FWDO_external
-N FWDI_external
-N FWDI_external_log
-N FWDI_external_deny
-N FWDI_external_allow
-I FWDI_external 1 -j FWDI_external_log
-I FWDI_external 2 -j FWDI_external_deny
-I FWDI_external 3 -j FWDI_external_allow
-I FORWARD_IN_ZONES 1 -i eth0 -g FWDI_external
-I IN_external 4 -p ipv6-icmp -j LOG --log-prefix "IN_external_ICMP_BLOCK: "
-I IN_external 5 -p ipv6-icmp -j REJECT --reject-with icmp6-adm-prohibited
-I FWDI_external 5 -p ipv6-icmp -j LOG --log-prefix "FWDI_external_ICMP_BLOCK: "
-I FWDI_external 6 -p ipv6-icmp -j REJECT --reject-with icmp6-adm-prohibited
```

Specifically, take note of the FWDI_external rules that are added (abbreviated here for clarity):

```
-I FWDI_external 1 -j FWDI_external_log
-I FWDI_external 2 -j FWDI_external_deny
-I FWDI_external 3 -j FWDI_external_allow
-I FWDI_external 5 -p ipv6-icmp -j LOG --log-prefix "FWDI_external_ICMP_BLOCK: "
-I FWDI_external 6 -p ipv6-icmp -j REJECT --reject-with icmp6-adm-prohibited
````

Because of the placement of `rule_idx = 4`, it's not reset on each `chain`, instead being reset on each `ipv`. This causes the `INPUT` chain to be correctly set for each IP type, but the `FORWARD_IN` ends up off by one. 

Note: I run CentOS 7, which is pinned to version `0.4.4.4` by RedHat. Sadly, this doesn't help me but, I figured it might at least help someone still running on the `0.5` stable line (or me whenever CentOS updates firewalld to 0.5). However, if this isn't the appropriate place to submit this, let me know and I'll send it where requested.

Thanks!,

--
Carl