### PR TITLE
Add BOOTP services

### DIFF
--- a/config/services/bootp-client.xml
+++ b/config/services/bootp-client.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>bootp-client</short>
+  <description>The Bootstrap Protocol (BOOTP) is a computer networking protocol used in Internet Protocol networks to automatically assign an IP address to network devices from a configuration server.</description>
+  <port protocol="udp" port="68"/>
+  <port protocol="tcp" port="68"/>
+</service>

--- a/config/services/bootp-server.xml
+++ b/config/services/bootp-server.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>bootp-server</short>
+  <description>The Bootstrap Protocol (BOOTP) is a computer networking protocol used in Internet Protocol networks to automatically assign an IP address to network devices from a configuration server.</description>
+  <port protocol="udp" port="67"/>
+  <port protocol="tcp" port="67"/>
+</service>


### PR DESCRIPTION
For RH Sat6 install guide it recommends opening these ports for some hosts.  I've added service definitions here so that they can be called out by name.