### PR TITLE
services: renamed RH-Satellite-6 to foreman

### DIFF
--- a/config/services/foreman.xml
+++ b/config/services/foreman.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
-  <short>Red Hat Satellite 6</short>
-  <description>Red Hat Satellite 6 is a systems management server that can be used to configure new systems, subscribe to updates, and maintain installations in distributed environments.</description>
+  <short>Foreman</short>
+  <description>Foreman is a systems management server that can be used to configure new systems, subscribe to updates, and maintain installations in distributed environments. It's also known as Red Hat Satellite 6. This service should be applied both to Satellite Server and Capsule.</description>
   <port protocol="tcp" port="53"/>
   <port protocol="udp" port="53"/>
   <port protocol="udp" port="67-69"/>
@@ -13,5 +13,6 @@
   <port protocol="tcp" port="8000"/>
   <port protocol="tcp" port="8080"/>
   <port protocol="tcp" port="8140"/>
+  <port protocol="tcp" port="8443"/>
   <port protocol="tcp" port="9090"/>
 </service>


### PR DESCRIPTION
We like to reference our project rather than product. Also, I've added missing
8443 port which is required:

https://access.redhat.com/documentation/en-us/red_hat_satellite/6.3/html/installation_guide/preparing_your_environment_for_installation#ports_prerequisites