### PR TITLE
firewall: core: Only apply previous runtime configuration on startup …

### DIFF
--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -1003,18 +1003,19 @@ class Firewall(object):
                         _zone_interfaces[_old_dz][iface]
                     del _zone_interfaces[_old_dz][iface]
 
-        # add interfaces to zones again
-        for zone in self.zone.get_zones():
-            if zone in _zone_interfaces:
-                self.zone.set_settings(zone, { "interfaces":
-                                               _zone_interfaces[zone] })
-                del _zone_interfaces[zone]
-            else:
-                log.info1("New zone '%s'.", zone)
-        if len(_zone_interfaces) > 0:
-            for zone in list(_zone_interfaces.keys()):
-                log.info1("Lost zone '%s', zone interfaces dropped.", zone)
-                del _zone_interfaces[zone]
+        if start_exception:
+            # add interfaces to zones again if startup failed
+            for zone in self.zone.get_zones():
+                if zone in _zone_interfaces:
+                    self.zone.set_settings(zone, { "interfaces":
+                                                   _zone_interfaces[zone] })
+                    del _zone_interfaces[zone]
+                else:
+                    log.info1("New zone '%s'.", zone)
+            if len(_zone_interfaces) > 0:
+                for zone in list(_zone_interfaces.keys()):
+                    log.info1("Lost zone '%s', zone interfaces dropped.", zone)
+                    del _zone_interfaces[zone]
         del _zone_interfaces
 
         # restore direct config


### PR DESCRIPTION
…failure

Commit 2796edc1691f ("fw: if startup fails on reload, reapply non-perm
config that survives reload") made the firewalld code more resilient to
startup failures by re-applying the runtime configuration if firewalld
startup method failed. However, this only must be done in case of
failures and not all the time since this means that permanent
configuration is not loaded properly as demonstrated below:

 firewall-cmd --zone=home --change-interface=eth0
 success
 firewall-cmd --zone=home --list-interfaces
 eth0
 firewall-cmd --permanent --zone=public --change-interface=eth0
 success
 firewall-cmd --list-interfaces --zone=home
 eth0
 firewall-cmd --reload
 firewall-cmd --list-interfaces --zone=public
 firewall-cmd --list-interfaces --zone=home
 eth0

As we can see, the runtime configuration of the 'public' zone is not
loaded properly and eth0 still remains assigned to the 'home' zone.

Fixes: suze bz #1109153
Fixes: 2796edc1691f ("fw: if startup fails on reload, reapply non-perm config that survives reload")