### PR TITLE
ipXtables/nftables: Fix "object has no attribute '_log_denied'"

### DIFF
--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -492,8 +492,7 @@ class ip4tables(object):
             if log_denied == "off":
                 return ""
             if log_denied in [ "unicast", "broadcast", "multicast" ]:
-                rule[i:i+1] = [ "-m", "pkttype", "--pkt-type",
-                                self._log_denied ]
+                rule[i:i+1] = [ "-m", "pkttype", "--pkt-type", log_denied ]
             else:
                 rule.pop(i)
 

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -290,7 +290,7 @@ class nftables(object):
             if log_denied == "off":
                 return ""
             if log_denied in ["unicast", "broadcast", "multicast"]:
-                rule[i:i+1] = ["pkttype", self._log_denied]
+                rule[i:i+1] = ["pkttype", log_denied]
             else:
                 rule.pop(i)
 


### PR DESCRIPTION
This fixes nftables and ipXtables (when IndividualCalls=yes),
as _log_denied is not an attribute of the class but a param.