### PR TITLE
firewall/core/fw_nm: nm_get_zone_of_connection should return None or …

### DIFF
--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -84,12 +84,12 @@ def nm_get_zone_of_connection(connection):
     try:
         if con.get_flags() & (NM.SettingsConnectionFlags.NM_GENERATED
                               | NM.SettingsConnectionFlags.NM_VOLATILE):
-            return False
+            return ""
     except AttributeError:
         # Prior to NetworkManager 1.12, we can only guess
         # that a connection was generated/volatile.
         if con.get_unsaved():
-            return False
+            return ""
 
     zone = setting_con.get_zone()
     if zone is None:


### PR DESCRIPTION
…empty string instead of False

(cherry picked from commit 5a59a90f449a8bf836e62e2d9ad486301b1aa2bb)