### PR TITLE
Fix doc typo about sequence options

### DIFF
--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -67,7 +67,7 @@
   <refsect1 id="options">
     <title>Options</title>
     <para>
-      For sequence options, this are the options that can be specified multiple times, the exit code is 0 if there is at least one item that succeded. The <literal>ALREADY_ENABLED</literal> (11), <literal>NOT_ENABLED</literal> (12) and also <literal>ZONE_ALREADY_SET</literal> (16) errors are treated as succeeded.
+      Sequence options are the options that can be specified multiple times, the exit code is 0 if there is at least one item that succeeded. The <literal>ALREADY_ENABLED</literal> (11), <literal>NOT_ENABLED</literal> (12) and also <literal>ZONE_ALREADY_SET</literal> (16) errors are treated as succeeded.
       If there are issues while parsing the items, then these are treated as warnings and will not change the result as long as there is a succeeded one.
       Without any succeeded item, the exit code will depend on the error codes. If there is exactly one error code, then this is used. If there are more than one then <literal>UNKNOWN_ERROR</literal> (254) will be used.
     </para>

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -71,7 +71,7 @@
     </para>
 
     <para>
-      For sequence options, this are the options that can be specified multiple times, the exit code is 0 if there is at least one item that succeded. The <literal>ALREADY_ENABLED</literal> (11), <literal>NOT_ENABLED</literal> (12) and also <literal>ZONE_ALREADY_SET</literal> (16) errors are treated as succeeded.
+      Sequence options are the options that can be specified multiple times, the exit code is 0 if there is at least one item that succeeded. The <literal>ALREADY_ENABLED</literal> (11), <literal>NOT_ENABLED</literal> (12) and also <literal>ZONE_ALREADY_SET</literal> (16) errors are treated as succeeded.
       If there are issues while parsing the items, then these are treated as warnings and will not change the result as long as there is a succeeded one.
       Without any succeeded item, the exit code will depend on the error codes. If there is exactly one error code, then this is used. If there are more than one then <literal>UNKNOWN_ERROR</literal> (254) will be used.
     </para>


### PR DESCRIPTION
Remove "this are" and fixed "succeded"