### PR TITLE
Fix permissions of the /etc/firewall directory

### DIFF
--- a/firewalld.spec
+++ b/firewalld.spec
@@ -289,10 +289,10 @@ fi
 %{_rpmconfigdir}/macros.d/macros.firewalld
 
 %files -n firewall-applet
+%attr(0755,root,root) %dir %{_sysconfdir}/firewall
 %{_bindir}/firewall-applet
 %defattr(0644,root,root)
 %{_sysconfdir}/xdg/autostart/firewall-applet.desktop
-%dir %{_sysconfdir}/firewall
 %{_sysconfdir}/firewall/applet.conf
 %{_datadir}/icons/hicolor/*/apps/firewall-applet*.*
 %{_mandir}/man1/firewall-applet*.1*


### PR DESCRIPTION
Permissions on /etc/firewall were set by defattr to 644, which made the
directory inaccessible to the owner.

This causes permission problems when trying to unpack a RHEL firewalld RPM, e.g.:

```shell
firewalld-rhel7 $ rpm2cpio firewall-applet-0.6.3-1.el7.noarch.rpm | cpio -idmv     
./etc/firewall
cpio: ./etc/firewall/applet.conf: Cannot open: Permission denied
./etc/firewall/applet.conf
./etc/xdg/autostart/firewall-applet.desktop
./usr/bin/firewall-applet
./usr/share/icons/hicolor/16x16/apps/firewall-applet-error.png
./usr/share/icons/hicolor/16x16/apps/firewall-applet-panic.png
./usr/share/icons/hicolor/16x16/apps/firewall-applet.png
./usr/share/icons/hicolor/22x22/apps/firewall-applet-error.png
./usr/share/icons/hicolor/22x22/apps/firewall-applet-panic.png
./usr/share/icons/hicolor/22x22/apps/firewall-applet.png
./usr/share/icons/hicolor/24x24/apps/firewall-applet-error.png
./usr/share/icons/hicolor/24x24/apps/firewall-applet-panic.png
./usr/share/icons/hicolor/24x24/apps/firewall-applet.png
./usr/share/icons/hicolor/32x32/apps/firewall-applet-error.png
./usr/share/icons/hicolor/32x32/apps/firewall-applet-panic.png
./usr/share/icons/hicolor/32x32/apps/firewall-applet.png
./usr/share/icons/hicolor/48x48/apps/firewall-applet-error.png
./usr/share/icons/hicolor/48x48/apps/firewall-applet-panic.png
./usr/share/icons/hicolor/48x48/apps/firewall-applet.png
./usr/share/icons/hicolor/scalable/apps/firewall-applet-error.svg
./usr/share/icons/hicolor/scalable/apps/firewall-applet-panic.svg
./usr/share/icons/hicolor/scalable/apps/firewall-applet.svg
./usr/share/man/man1/firewall-applet.1.gz
459 blocks
```