### PR TITLE
Move D-Bus policy file to /usr/share/dbus-1/system.d/

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -22,7 +22,7 @@ polkit1_action_FILES = org.fedoraproject.FirewallD1.server.policy.in \
 polkit1_actiondir = $(datadir)/polkit-1/actions
 polkit1_action_DATA = $(polkit1_action_FILES:.in=)
 
-dbus_policydir = $(sysconfdir)/dbus-1/system.d
+dbus_policydir = $(datadir)/dbus-1/system.d
 dist_dbus_policy_DATA = FirewallD.conf
 
 gsettings_in_file = org.fedoraproject.FirewallConfig.gschema.xml.in


### PR DESCRIPTION
This is supported since dbus 1.9.18.
The old location in /etc/dbus-1/system.d/ has been deprecated.

https://lists.freedesktop.org/archives/dbus/2015-July/016746.html