### PR TITLE
autoconf: Check for Docbook XML stylesheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 /doxygen.conf
 /firewalld-*.tar.bz2
 /install-sh
+/m4/intltool.m4
 /missing
 /po/*
 /src/firewall/config/__init__.py

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ m4_define([PKG_RELEASE], m4_bpatsubst(m4_esyscmd([grep "Release:" firewalld.spec
 m4_define([PKG_TAG], m4_format(v%s, PKG_VERSION))
 
 AC_INIT(PKG_NAME,PKG_VERSION)
+AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/firewalld.in])
 AC_PREFIX_DEFAULT([/usr])
 
@@ -38,6 +39,10 @@ AC_PATH_PROG([SYSCTL], [sysctl], [/sbin/sysctl])
 AC_CONFIG_TESTDIR([src/tests])
 
 GLIB_GSETTINGS
+
+#############################################################
+
+JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl], [DocBook XSL Stylesheets])
 
 #############################################################
 

--- a/m4/jh_path_xml_catalog.m4
+++ b/m4/jh_path_xml_catalog.m4
@@ -1,0 +1,54 @@
+# Checks the location of the XML Catalog
+# Usage:
+#   JH_PATH_XML_CATALOG([ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# Defines XMLCATALOG and XML_CATALOG_FILE substitutions
+AC_DEFUN([JH_PATH_XML_CATALOG],
+[
+  # check for the presence of the XML catalog
+  AC_ARG_WITH([xml-catalog],
+              AC_HELP_STRING([--with-xml-catalog=CATALOG],
+                             [path to xml catalog to use]),,
+              [with_xml_catalog=/etc/xml/catalog])
+  jh_found_xmlcatalog=true
+  XML_CATALOG_FILE="$with_xml_catalog"
+  AC_SUBST([XML_CATALOG_FILE])
+  AC_MSG_CHECKING([for XML catalog ($XML_CATALOG_FILE)])
+  if test -f "$XML_CATALOG_FILE"; then
+    AC_MSG_RESULT([found])
+  else
+    jh_found_xmlcatalog=false
+    AC_MSG_RESULT([not found])
+  fi
+
+  # check for the xmlcatalog program
+  AC_PATH_PROG(XMLCATALOG, xmlcatalog, no)
+  if test "x$XMLCATALOG" = xno; then
+    jh_found_xmlcatalog=false
+  fi
+
+  if $jh_found_xmlcatalog; then
+    ifelse([$1],,[:],[$1])
+  else
+    ifelse([$2],,[AC_MSG_ERROR([could not find XML catalog])],[$2])
+  fi
+])
+
+# Checks if the particular URI appears in the XML catalog
+# Usage:
+#   JH_CHECK_XML_CATALOG(URI, [FRIENDLY-NAME], [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+AC_DEFUN([JH_CHECK_XML_CATALOG],
+[
+  AC_REQUIRE([JH_PATH_XML_CATALOG],[JH_PATH_XML_CATALOG(,[:])])
+  AC_MSG_CHECKING([for ifelse([$2],,[$1],[$2]) in XML catalog])
+  if $jh_found_xmlcatalog && \
+     AC_RUN_LOG([$XMLCATALOG --noout "$XML_CATALOG_FILE" "$1" >&2]); then
+    AC_MSG_RESULT([found])
+    ifelse([$3],,,[$3
+])
+  else
+    AC_MSG_RESULT([not found])
+    ifelse([$4],,
+       [AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],
+       [$4])
+  fi
+])


### PR DESCRIPTION
m4 macro and configure check for Docbook XML stylesheets, which are
required to build firewalld.

Fixes #436

Signed-off-by: Michal Rostecki <mrostecki@suse.de>