### PR TITLE
firewall-applet: Fix out-of-sync Shields Up checkbox.

### DIFF
--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -809,6 +809,8 @@ class TrayApplet(QtWidgets.QSystemTrayIcon):
         else:
             zone = str(self.shields_down)
 
+        # let default_zone_changed update the checked state
+        self.shieldsupAction.setChecked(not self.shieldsupAction.isChecked())
         if self.fw.connected and self.default_zone != zone:
             try:
                 self.fw.setDefaultZone(zone)


### PR DESCRIPTION
Previously, when the Shields Up menu action was clicked and a firewall
exception occurred (for example, NotAuthorizedException), the state of
this checkbox became out of sync.

To reproduce the issue:
* right-click on the applet
* select Shields Up
* when (hopefully) prompted for authentication click cancel.

An "Authorization failed" message should appear. The default zone was not changed, however, the "Shields Up" option in the menu is (incorrectly) checked.