### PR TITLE
fix building in a separate directory outside the source tree

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -382,11 +382,11 @@ install-config:
 	$(MKDIR_P) $(DESTDIR)$(sconfdir)/zones
 	$(MKDIR_P) $(DESTDIR)$(sconfdir)/helpers
 	$(MKDIR_P) $(DESTDIR)$(prefixlibdir)
-	cp -r icmptypes $(DESTDIR)$(prefixlibdir)
-	cp -r ipsets $(DESTDIR)$(prefixlibdir)
-	cp -r services $(DESTDIR)$(prefixlibdir)
-	cp -r zones $(DESTDIR)$(prefixlibdir)
-	cp -r helpers $(DESTDIR)$(prefixlibdir)
+	cp -r $(srcdir)/icmptypes $(DESTDIR)$(prefixlibdir)
+	cp -r $(srcdir)/ipsets $(DESTDIR)$(prefixlibdir)
+	cp -r $(srcdir)/services $(DESTDIR)$(prefixlibdir)
+	cp -r $(srcdir)/zones $(DESTDIR)$(prefixlibdir)
+	cp -r $(srcdir)/helpers $(DESTDIR)$(prefixlibdir)
 
 uninstall-config:
 	rmdir $(DESTDIR)$(sconfdir)/icmptypes

--- a/doc/xml/Makefile.am
+++ b/doc/xml/Makefile.am
@@ -69,7 +69,8 @@ edit = sed \
 	-e 's|\@PREFIX\@|$(prefix)|' \
 	-e 's|\@SYSCONFDIR\@|$(sysconfdir)|' \
 	-e 's|\@PACKAGE_STRING\@|$(PACKAGE_STRING)|' \
-	-e 's|\@IFCFGDIR\@|$(IFCFGDIR)|'
+	-e 's|\@IFCFGDIR\@|$(IFCFGDIR)|' \
+	-e 's|@SRCDIR@|$(srcdir)|'
 
 transform-man.xsl: transform-man.xsl.in
 	$(edit) $< >$@

--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN" "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd"
 [
-<!ENTITY authors SYSTEM "authors.xml">
-<!ENTITY seealso SYSTEM "seealso.xml">
-<!ENTITY notes SYSTEM "notes.xml">
+<!ENTITY authors SYSTEM "@SRCDIR@/authors.xml">
+<!ENTITY seealso SYSTEM "@SRCDIR@/seealso.xml">
+<!ENTITY notes SYSTEM "@SRCDIR@/notes.xml">
 <!ENTITY errorcodes SYSTEM "errorcodes.xml">
 ]>
 

--- a/doc/xml/firewalld.xml.in
+++ b/doc/xml/firewalld.xml.in
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN" "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd"
 [
-<!ENTITY authors SYSTEM "authors.xml">
-<!ENTITY seealso SYSTEM "seealso.xml">
-<!ENTITY notes SYSTEM "notes.xml">
+<!ENTITY authors SYSTEM "@SRCDIR@/authors.xml">
+<!ENTITY seealso SYSTEM "@SRCDIR@/seealso.xml">
+<!ENTITY notes SYSTEM "@SRCDIR@/notes.xml">
 ]>
 
 <!--


### PR DESCRIPTION
This patch fixes two problems when you try to build outside the source
tree, as in:

    mkdir build
    cd build
    ../configure