### PR TITLE
fix issue #457

### DIFF
--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -394,7 +394,7 @@ class Rich_Rule(object):
                 elif element in ['not', 'NOT']:
                     attrs['invert'] = True
                 else:
-                    self.source = Rich_Source(attrs.get('address'), attrs.get('mac'), attrs.get('ipset'), attrs.get('invert'))
+                    self.source = Rich_Source(attrs.get('address'), attrs.get('mac'), attrs.get('ipset'), attrs.get('invert', False))
                     in_elements.pop() # source
                     attrs.clear()
                     index = index -1 # return token to input


### PR DESCRIPTION
I found out I did not set a value for invert when adding the rich rule via firewall-cmd. Then I got the error as mentioned in issue #457 because the invert attribute was given a default value None. I corrected it here so that it gets the default value False. This fixed the issue for me.