### PR TITLE
Add redis-sentinel service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -221,6 +221,7 @@ CONFIG_FILES = \
 	services/quassel.xml \
 	services/radius.xml \
 	services/redis.xml \
+	services/redis-sentinel.xml \
 	services/RH-Satellite-6.xml \
 	services/rpc-bind.xml \
 	services/rsh.xml \

--- a/config/services/redis-sentinel.xml
+++ b/config/services/redis-sentinel.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>redis-sentinel</short>
+  <description>Redis Sentinel provides high availability for Redis.</description>
+  <port protocol="tcp" port="26379"/>
+</service> 


### PR DESCRIPTION
Open tcp port 26379 for Redis Sentinel service.