### PR TITLE
Add firewall rules for FreeIPA 4.x

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -147,6 +147,7 @@ CONFIG_FILES = \
 	services/etcd-client.xml \
 	services/etcd-server.xml \
 	services/finger.xml \
+	services/freeipa-4.xml \
 	services/freeipa-ldaps.xml \
 	services/freeipa-ldap.xml \
 	services/freeipa-replication.xml \

--- a/config/services/freeipa-4.xml
+++ b/config/services/freeipa-4.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>FreeIPA 4 server</short>
+  <description>FreeIPA is an integrated identity and authentication solution with Kerberos, LDAP, PKI, and web UI. Enable this option if you plan to provide a FreeIPA server. Enable the 'dns' service if this FreeIPA server provides DNS services, 'ntp' service if this FreeIPA server provides NTP services, and 'freeipa-trust' for cross-forest trusts with Active Directory.</description>
+  <!-- CRL and OCSP -->
+  <port protocol="tcp" port="80"/>
+  <!-- API and web UI -->
+  <port protocol="tcp" port="443"/>
+  <!-- Kerberos and kpasswd -->
+  <port protocol="tcp" port="88"/>
+  <port protocol="udp" port="88"/>
+  <port protocol="tcp" port="464"/>
+  <port protocol="udp" port="464"/>
+  <!-- LDAP and LDAPS -->
+  <port protocol="tcp" port="389"/>
+  <port protocol="tcp" port="636"/>
+</service>

--- a/config/services/freeipa-ldap.xml
+++ b/config/services/freeipa-ldap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
-  <short>FreeIPA with LDAP</short>
-  <description>FreeIPA is an LDAP and Kerberos domain controller for Linux systems. Enable this option if you plan to provide a FreeIPA Domain Controller using the LDAP protocol. You can also enable the 'freeipa-ldaps' service if you want to provide the LDAPS protocol. Enable the 'dns' service if this FreeIPA server provides DNS services and 'freeipa-replication' service if this FreeIPA server is part of a multi-master replication setup.</description>
+  <short>FreeIPA with LDAP (deprecated)</short>
+  <description>This service is deprecated. Please use freeipa-4 service instead.</description>
   <port protocol="tcp" port="80"/>
   <port protocol="tcp" port="443"/>
   <port protocol="tcp" port="88"/>

--- a/config/services/freeipa-ldaps.xml
+++ b/config/services/freeipa-ldaps.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
-  <short>FreeIPA with LDAPS</short>
-  <description>FreeIPA is an LDAP and Kerberos domain controller for Linux systems. Enable this option if you plan to provide a FreeIPA Domain Controller using the LDAPS protocol. You can also enable the 'freeipa-ldap' service if you want to provide the LDAP protocol. Enable the 'dns' service if this FreeIPA server provides DNS services and 'freeipa-replication' service if this FreeIPA server is part of a multi-master replication setup.</description>
+  <short>FreeIPA with LDAPS (deprecated)</short>
+  <description>This service is deprecated. Please use freeipa-4 service instead.</description>
   <port protocol="tcp" port="80"/>
   <port protocol="tcp" port="443"/>
   <port protocol="tcp" port="88"/>

--- a/config/services/freeipa-replication.xml
+++ b/config/services/freeipa-replication.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
-  <short>FreeIPA replication</short>
-  <description>FreeIPA is an LDAP and Kerberos domain controller for Linux systems. Enable this option if you want to enable LDAP replication between FreeIPA servers.</description>
+  <short>FreeIPA replication (deprecated)</short>
+  <description>This service is deprecated. Please use freeipa-4 service instead.</description>
   <port protocol="tcp" port="7389"/>
 </service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -80,6 +80,7 @@ config/services/elasticsearch.xml
 config/services/etcd-client.xml
 config/services/etcd-server.xml
 config/services/finger.xml
+config/services/freeipa-4.xml
 config/services/freeipa-ldaps.xml
 config/services/freeipa-ldap.xml
 config/services/freeipa-replication.xml


### PR DESCRIPTION
The firewall services ``freeipa-ldap``, ``freeipa-ldaps``, and
``freeipa-replication`` are outdated. FreeIPA 4.x requires a different set
of rules.

* Port 7389 and service ``freeipa-replication`` are no longer needed since
  RHEL 7.0 and Fedora 18. Port 7389/TCP was used for Dogtag's LDAP server.
  FreeIPA 3.1 consolidated the 389-DS databases and now Dogtag and IPA
  share the same LDAP server instance.
* FreeIPA requires both LDAP and LDAPS to work properly. Iit doesn't make
  any sense to have separate services ``freeipa-ldap`` and
  ``freeipa-ldaps``. FreeIPA clients and master-master replication both
  require port 389/TCP (LDAP) to work. The LDAP protocol is not a security
  problem, because FreeIPA doesn't use plaintext LDAP but STARTTLS and/or
  GSSAPI to authenticate and protect. Dogtag PKI also uses LDAPS.
* FreeIPA 4.7 and newer no longer install a NTP instance on each master.

Fixes: https://github.com/firewalld/firewalld/issues/435
Signed-off-by: Christian Heimes <cheimes@redhat.com>