### PR TITLE
Add BitTorrent Local Peer Discovery service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -127,6 +127,7 @@ CONFIG_FILES = \
 	services/bitcoin-testnet-rpc.xml \
 	services/bitcoin-testnet.xml \
 	services/bitcoin.xml \
+	services/bittorrent-lsd.xml \
 	services/lightning-network.xml \
 	services/ceph-mon.xml \
 	services/ceph.xml \

--- a/config/services/bittorrent-lsd.xml
+++ b/config/services/bittorrent-lsd.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>BitTorrent Local Peer Discovery (LSD)</short>
+  <description>Local Peer Discovery is a protocol designed to support the discovery of BitTorrent peers on a local area network. Enable this service if you run a BitTorrent client.</description>
+  <port protocol="udp" port="6771"/>
+  <destination ipv4="239.192.152.143" ipv6="ff15::efc0:988f"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -61,6 +61,7 @@ config/services/bitcoin-rpc.xml
 config/services/bitcoin-testnet-rpc.xml
 config/services/bitcoin-testnet.xml
 config/services/bitcoin.xml
+config/services/bittorrent-lsd.xml
 config/services/ceph-mon.xml
 config/services/ceph.xml
 config/services/cfengine.xml


### PR DESCRIPTION
This adds a service for [Local Peer Discovery](https://en.wikipedia.org/wiki/Local_Peer_Discovery).

The acronym is LSD because the official name is [Local Service Discovery](http://bittorrent.org/beps/bep_0014.html), but AFAIK no BitTorrent client calls it that.