### PR TITLE
Fix Rich_Mark logic

### DIFF
--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1012,7 +1012,7 @@ class ip4tables(object):
         if rich_rule:
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
-        if not rich_rule or rich_rule.action != Rich_Mark:
+        if not rich_rule or type(rich_rule.action) != Rich_Mark:
             rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW,UNTRACKED" ]
 
         rules = []
@@ -1037,7 +1037,7 @@ class ip4tables(object):
         if rich_rule:
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
-        if not rich_rule or rich_rule.action != Rich_Mark:
+        if not rich_rule or type(rich_rule.action) != Rich_Mark:
             rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW,UNTRACKED" ]
 
         rules = []
@@ -1065,7 +1065,7 @@ class ip4tables(object):
         if rich_rule:
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
-        if not rich_rule or rich_rule.action != Rich_Mark:
+        if not rich_rule or type(rich_rule.action) != Rich_Mark:
             rule_fragment += [ "-m", "conntrack", "--ctstate", "NEW,UNTRACKED" ]
 
         rules = []


### PR DESCRIPTION
We are looking to compare the type, not the object.
Without this fix ipXtables will only mark the very first packet of a connection.

Signed-off-by: Felix Kaechele <heffer@fedoraproject.org>