### PR TITLE
Fix several issues with special characters in rich rules

### DIFF
--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -901,7 +901,7 @@ class ip4tables(object):
         rule += self._rich_rule_priority_fragment(rich_rule)
         rule += rule_fragment + [ "-j", "LOG" ]
         if rich_rule.log.prefix:
-            rule += [ "--log-prefix", "'%s'" % rich_rule.log.prefix ]
+            rule += [ "--log-prefix", "%s" % rich_rule.log.prefix ]
         if rich_rule.log.level:
             rule += [ "--log-level", "%s" % rich_rule.log.level ]
         rule += self._rule_limit(rich_rule.log.limit)

--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -31,6 +31,7 @@ from firewall.core.ipset import check_ipset_name
 from firewall.core.base import REJECT_TYPES
 from firewall import errors
 from firewall.errors import FirewallError
+from firewall.functions import removeCharacters, CONTROL_CHARS
 
 class Rich_Source(object):
     def __init__(self, addr, mac, ipset, invert=False):
@@ -307,6 +308,7 @@ class Rich_Rule(object):
         if not rule_str:
             raise FirewallError(errors.INVALID_RULE, 'empty rule')
 
+        rule_str = removeCharacters(rule_str, CONTROL_CHARS)
         self.priority = 0
         self.family = None
         self.source = None

--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -141,7 +141,7 @@ class Rich_ForwardPort(object):
 class Rich_Log(object):
     def __init__(self, prefix=None, level=None, limit=None):
         #TODO check default level in iptables
-        self.prefix = prefix
+        self.prefix = removeCharacters(prefix, '\'"')
         self.level = level
         self.limit = limit
 
@@ -465,7 +465,7 @@ class Rich_Rule(object):
                     index = index -1 # return token to input
             elif in_element == 'log':
                 if attr_name in ['prefix', 'level']:
-                    attrs[attr_name] = attr_value
+                    attrs[attr_name] = removeCharacters(attr_value, '\'"')
                 elif element == 'limit':
                     in_elements.append('limit')
                 else:

--- a/src/firewall/functions.py
+++ b/src/firewall/functions.py
@@ -28,8 +28,8 @@ __all__ = [ "PY2", "getPortID", "getPortRange", "portStr", "getServiceName",
             "get_nf_nat_helpers", "check_port", "check_address",
             "check_single_address", "check_mac", "uniqify", "ppid_of_pid",
             "max_zone_name_len", "checkUser", "checkUid", "checkCommand",
-            "checkContext", "joinArgs", "splitArgs",
-            "b2u", "u2b", "u2b_if_py2" ]
+            "checkContext", "removeCharacters", "joinArgs", "splitArgs",
+            "b2u", "u2b", "u2b_if_py2", "CONTROL_CHARS" ]
 
 import socket
 import os
@@ -40,6 +40,7 @@ import re
 import string
 import sys
 import tempfile
+from itertools import chain
 from firewall.core.logger import log
 from firewall.core.prog import runProg
 from firewall.config import FIREWALLD_TEMPDIR, FIREWALLD_PIDFILE, COMMANDS
@@ -541,6 +542,11 @@ def checkContext(context):
     if len(splits[3]) < 1:
         return False
     return True
+
+CONTROL_CHARS = set(map(chr, chain(range(0, 32), range(127, 160))))
+
+def removeCharacters(string, chars):
+    return ''.join(c for c in string if c not in chars)
 
 def joinArgs(args):
     if "quote" in dir(shlex):


### PR DESCRIPTION
This PR fixes several issues with special characters in rich rules:

* Remove nonprintable characters when parsing a rich rule from a string

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596304

* Remove single and double quotes from log prefixes.

That way we don't allow invalid nftables rules with broken syntax.

Also, since prefixes don't have quotes anymore, there's no need to
quote them in _rich_rule_log (since it will be quoted correctly anyway
later with shlex) so this fixes the double quoting issue with the
iptables backend that always added single quotes around log prefixes.

* Add removeCharacters function and CONTROL_CHARS set

Used by the fixes above.

Fixes #480
