### PR TITLE
chore: config/services/RH-Satellite-6: use service includes

### DIFF
--- a/config/services/RH-Satellite-6.xml
+++ b/config/services/RH-Satellite-6.xml
@@ -2,11 +2,12 @@
 <service>
   <short>Red Hat Satellite 6</short>
   <description>Red Hat Satellite 6 is a systems management server that can be used to configure new systems, subscribe to updates, and maintain installations in distributed environments.</description>
-  <port protocol="tcp" port="53"/>
-  <port protocol="udp" port="53"/>
-  <port protocol="udp" port="67-69"/>
-  <port protocol="tcp" port="80"/>
-  <port protocol="tcp" port="443"/>
+  <include service="dns"/>
+  <include service="http"/>
+  <include service="https"/>
+  <include service="dhcp"/>
+  <include service="tftp"/>
+  <port protocol="udp" port="68"/>
   <port protocol="tcp" port="5000"/>
   <port protocol="tcp" port="5646-5647"/>
   <port protocol="tcp" port="5671"/>


### PR DESCRIPTION
For well known ports/services, use service includes instead of the
explicit port number.