### PR TITLE
Change-interface can accept permanent option

### DIFF
--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -925,7 +925,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
 	</varlistentry>
 
 	<varlistentry>
-	  <term><optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <option>--change-interface</option>=<replaceable>interface</replaceable></term>
+	  <term><optional><option>--permanent</option></optional> <optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <option>--change-interface</option>=<replaceable>interface</replaceable></term>
 	  <listitem>
 	    <para>
 	      If the interface is under control of NetworkManager, it is at first connected to change the zone for the connection that is using the interface. If this fails, the zone binding is created in firewalld and the limitations below apply.

--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -317,7 +317,7 @@ Options to Handle Bindings of Interfaces
   --add-interface=<interface>
                        Bind the <interface> to a zone [P] [Z]
   --change-interface=<interface>
-                       Change zone the <interface> is bound to [Z]
+                       Change zone the <interface> is bound to [P] [Z]
   --query-interface=<interface>
                        Query whether <interface> is bound to a zone [P] [Z]
   --remove-interface=<interface>


### PR DESCRIPTION
This is a documentation change to reflect that `--change-interface` option can indeed be used together with  `--permanent` option.

Fixes #479 