### PR TITLE
Fixes for when a firewalld.conf doesn't exist

### DIFF
--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -124,6 +124,7 @@ class Firewall(object):
         self._automatic_helpers = config.FALLBACK_AUTOMATIC_HELPERS
         self._firewall_backend = config.FALLBACK_FIREWALL_BACKEND
         self._flush_all_on_reload = config.FALLBACK_FLUSH_ALL_ON_RELOAD
+        self._rfc3964_ipv4 = config.FALLBACK_RFC3964_IPV4
         self.nf_conntrack_helper_setting = 0
         self.nf_conntrack_helpers = { }
         self.nf_nat_helpers = { }

--- a/src/firewall/core/io/firewalld_conf.py
+++ b/src/firewall/core/io/firewalld_conf.py
@@ -84,29 +84,29 @@ class firewalld_conf(object):
             self.set("FlushAllOnReload", "yes" if config.FALLBACK_FLUSH_ALL_ON_RELOAD else "no")
             self.set("RFC3964_IPv4", "yes" if config.FALLBACK_RFC3964_IPV4 else "no")
             raise
-
-        for line in f:
-            if not line:
-                break
-            line = line.strip()
-            if len(line) < 1 or line[0] in ['#', ';']:
-                continue
-            # get key/value pair
-            pair = [ x.strip() for x in line.split("=") ]
-            if len(pair) != 2:
-                log.error("Invalid option definition: '%s'", line.strip())
-                continue
-            elif pair[0] not in valid_keys:
-                log.error("Invalid option: '%s'", line.strip())
-                continue
-            elif pair[1] == '':
-                log.error("Missing value: '%s'", line.strip())
-                continue
-            elif self._config.get(pair[0]) is not None:
-                log.error("Duplicate option definition: '%s'", line.strip())
-                continue
-            self._config[pair[0]] = pair[1]
-        f.close()
+        else:
+            for line in f:
+                if not line:
+                    break
+                line = line.strip()
+                if len(line) < 1 or line[0] in ['#', ';']:
+                    continue
+                # get key/value pair
+                pair = [ x.strip() for x in line.split("=") ]
+                if len(pair) != 2:
+                    log.error("Invalid option definition: '%s'", line.strip())
+                    continue
+                elif pair[0] not in valid_keys:
+                    log.error("Invalid option: '%s'", line.strip())
+                    continue
+                elif pair[1] == '':
+                    log.error("Missing value: '%s'", line.strip())
+                    continue
+                elif self._config.get(pair[0]) is not None:
+                    log.error("Duplicate option definition: '%s'", line.strip())
+                    continue
+                self._config[pair[0]] = pair[1]
+            f.close()
 
         # check default zone
         if not self.get("DefaultZone"):


### PR DESCRIPTION
This PR fixes issues when a `firewalld.conf` file does not exist:

- warning caused by trying to parse the file even if the read failed.
- crash caused by not initializing RFC3964_IPV4 with the fallback value.