### PR TITLE
config/services/matrix: use service include

### DIFF
--- a/config/services/matrix.xml
+++ b/config/services/matrix.xml
@@ -2,6 +2,6 @@
 <service>
   <short>Matrix</short>
   <description>Matrix is an ambitious new ecosystem for open federated Instant Messaging and VoIP. Port 443 is the 'client' port, whereas port 8448 is the Federation port. Federation is the process by which users on different servers can participate in the same room.</description>
-  <port port="443" protocol="tcp"/>
+  <include service="https"/>
   <port port="8448" protocol="tcp"/>
 </service>


### PR DESCRIPTION
For well known ports/services, use service includes instead of the
explicit port number.