### PR TITLE
Added application name for cleaner tray presentation

### DIFF
--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -1136,6 +1136,7 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 app = QtWidgets.QApplication(sys.argv)
 app.setQuitOnLastWindowClosed(False)
+app.setApplicationName(_("Firewall Applet"))
 
 applet = TrayApplet()
 applet.show()


### PR DESCRIPTION
This PR changing applet tray in KDE when it shown in dropdown list. 
Currently KDE renders file name `firewall-applet`. Just small esthetic change.