### PR TITLE
feat(service): Add CrateDB ports

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -139,6 +139,7 @@ CONFIG_FILES = \
 	services/cockpit.xml \
 	services/collectd.xml \
 	services/condor-collector.xml \
+	services/cratedb.xml \
 	services/ctdb.xml \
 	services/dhcpv6-client.xml \
 	services/dhcpv6.xml \

--- a/config/services/cratedb.xml
+++ b/config/services/cratedb.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>CrateDB</short>
+  <description>CrateDB is a distributed SQL database management system that integrates a fully searchable document oriented data store.</description>
+  <port protocol="tcp" port="4200"/>
+  <port protocol="tcp" port="4300"/>
+  <include service="postgresql"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -71,6 +71,7 @@ config/services/checkmk-agent.xml
 config/services/cockpit.xml
 config/services/condor-collector.xml
 config/services/collectd.xml
+config/services/cratedb.xml
 config/services/ctdb.xml
 config/services/dhcpv6-client.xml
 config/services/dhcpv6.xml


### PR DESCRIPTION
Open tcp ports 4200, 4300 and 5432 for CrateDB service.