### PR TITLE
fix/cleanup: relax auth for property getters to PK_ACTION_CONFIG_INFO

### DIFF
--- a/src/firewall/server/config.py
+++ b/src/firewall/server/config.py
@@ -65,7 +65,7 @@ class FirewallDConfig(slip.dbus.service.Object):
     persistent = True
     """ Make FirewallD persistent. """
     default_polkit_auth_required = config.dbus.PK_ACTION_CONFIG
-    """ Use config.dbus.PK_ACTION_INFO as a default """
+    """ Use config.dbus.PK_ACTION_CONFIG as a default """
 
     @handle_exceptions
     def __init__(self, conf, *args, **kwargs):

--- a/src/firewall/server/config.py
+++ b/src/firewall/server/config.py
@@ -570,6 +570,7 @@ class FirewallDConfig(slip.dbus.service.Object):
                 "org.freedesktop.DBus.Error.InvalidArgs: "
                 "Property '%s' does not exist" % prop)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ss',
                          out_signature='v')
     @dbus_handle_exceptions
@@ -593,6 +594,7 @@ class FirewallDConfig(slip.dbus.service.Object):
 
         return self._get_dbus_property(property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='s',
                          out_signature='a{sv}')
     @dbus_handle_exceptions

--- a/src/firewall/server/config_helper.py
+++ b/src/firewall/server/config_helper.py
@@ -95,6 +95,7 @@ class FirewallDConfigHelper(slip.dbus.service.Object):
                 "org.freedesktop.DBus.Error.InvalidArgs: "
                 "Property '%s' does not exist" % property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ss',
                          out_signature='v')
     @dbus_handle_exceptions
@@ -112,6 +113,7 @@ class FirewallDConfigHelper(slip.dbus.service.Object):
 
         return self._get_property(property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='s',
                          out_signature='a{sv}')
     @dbus_handle_exceptions

--- a/src/firewall/server/config_helper.py
+++ b/src/firewall/server/config_helper.py
@@ -51,7 +51,7 @@ class FirewallDConfigHelper(slip.dbus.service.Object):
     persistent = True
     """ Make FirewallD persistent. """
     default_polkit_auth_required = config.dbus.PK_ACTION_CONFIG
-    """ Use PK_ACTION_INFO as a default """
+    """ Use PK_ACTION_CONFIG as a default """
 
     @handle_exceptions
     def __init__(self, parent, conf, helper, item_id, *args, **kwargs):

--- a/src/firewall/server/config_icmptype.py
+++ b/src/firewall/server/config_icmptype.py
@@ -51,7 +51,7 @@ class FirewallDConfigIcmpType(slip.dbus.service.Object):
     persistent = True
     """ Make FirewallD persistent. """
     default_polkit_auth_required = config.dbus.PK_ACTION_CONFIG
-    """ Use PK_ACTION_INFO as a default """
+    """ Use PK_ACTION_CONFIG as a default """
 
     @handle_exceptions
     def __init__(self, parent, conf, icmptype, item_id, *args, **kwargs):

--- a/src/firewall/server/config_icmptype.py
+++ b/src/firewall/server/config_icmptype.py
@@ -95,6 +95,7 @@ class FirewallDConfigIcmpType(slip.dbus.service.Object):
                 "org.freedesktop.DBus.Error.InvalidArgs: "
                 "Property '%s' does not exist" % property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ss',
                          out_signature='v')
     @dbus_handle_exceptions
@@ -112,6 +113,7 @@ class FirewallDConfigIcmpType(slip.dbus.service.Object):
 
         return self._get_property(property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='s',
                          out_signature='a{sv}')
     @dbus_handle_exceptions

--- a/src/firewall/server/config_ipset.py
+++ b/src/firewall/server/config_ipset.py
@@ -52,7 +52,7 @@ class FirewallDConfigIPSet(slip.dbus.service.Object):
     persistent = True
     """ Make FirewallD persistent. """
     default_polkit_auth_required = config.dbus.PK_ACTION_CONFIG
-    """ Use PK_ACTION_INFO as a default """
+    """ Use PK_ACTION_CONFIG as a default """
 
     @handle_exceptions
     def __init__(self, parent, conf, ipset, item_id, *args, **kwargs):

--- a/src/firewall/server/config_ipset.py
+++ b/src/firewall/server/config_ipset.py
@@ -96,6 +96,7 @@ class FirewallDConfigIPSet(slip.dbus.service.Object):
                 "org.freedesktop.DBus.Error.InvalidArgs: "
                 "Property '%s' does not exist" % property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ss',
                          out_signature='v')
     @dbus_handle_exceptions
@@ -113,6 +114,7 @@ class FirewallDConfigIPSet(slip.dbus.service.Object):
 
         return self._get_property(property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='s',
                          out_signature='a{sv}')
     @dbus_handle_exceptions

--- a/src/firewall/server/config_service.py
+++ b/src/firewall/server/config_service.py
@@ -50,7 +50,7 @@ class FirewallDConfigService(slip.dbus.service.Object):
     persistent = True
     """ Make FirewallD persistent. """
     default_polkit_auth_required = config.dbus.PK_ACTION_CONFIG
-    """ Use PK_ACTION_INFO as a default """
+    """ Use PK_ACTION_CONFIG as a default """
 
     @handle_exceptions
     def __init__(self, parent, conf, service, item_id, *args, **kwargs):

--- a/src/firewall/server/config_service.py
+++ b/src/firewall/server/config_service.py
@@ -94,6 +94,7 @@ class FirewallDConfigService(slip.dbus.service.Object):
                 "org.freedesktop.DBus.Error.InvalidArgs: "
                 "Property '%s' does not exist" % property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ss',
                          out_signature='v')
     @dbus_handle_exceptions
@@ -111,6 +112,7 @@ class FirewallDConfigService(slip.dbus.service.Object):
 
         return self._get_property(property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='s',
                          out_signature='a{sv}')
     @dbus_handle_exceptions

--- a/src/firewall/server/config_zone.py
+++ b/src/firewall/server/config_zone.py
@@ -55,7 +55,7 @@ class FirewallDConfigZone(slip.dbus.service.Object):
     persistent = True
     """ Make FirewallD persistent. """
     default_polkit_auth_required = config.dbus.PK_ACTION_CONFIG
-    """ Use PK_ACTION_INFO as a default """
+    """ Use PK_ACTION_CONFIG as a default """
 
     @handle_exceptions
     def __init__(self, parent, conf, zone, item_id, *args, **kwargs):

--- a/src/firewall/server/config_zone.py
+++ b/src/firewall/server/config_zone.py
@@ -99,6 +99,7 @@ class FirewallDConfigZone(slip.dbus.service.Object):
                 "org.freedesktop.DBus.Error.InvalidArgs: "
                 "Property '%s' does not exist" % property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ss',
                          out_signature='v')
     @dbus_handle_exceptions
@@ -116,6 +117,7 @@ class FirewallDConfigZone(slip.dbus.service.Object):
 
         return self._get_property(property_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='s',
                          out_signature='a{sv}')
     @dbus_handle_exceptions

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -196,6 +196,7 @@ class FirewallD(slip.dbus.service.Object):
                 "org.freedesktop.DBus.Error.InvalidArgs: "
                 "Property '%s' does not exist" % prop)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ss',
                          out_signature='v')
     @dbus_handle_exceptions
@@ -219,6 +220,7 @@ class FirewallD(slip.dbus.service.Object):
                 "org.freedesktop.DBus.Error.UnknownInterface: "
                 "Interface '%s' does not exist" % interface_name)
 
+    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='s',
                          out_signature='a{sv}')
     @dbus_handle_exceptions


### PR DESCRIPTION
[copy-pasted from the main commit message]

On FirewallD, the getters were missing an explicit annotation.  The default
is PK_ACTION_CONFIG.  All other methods on FirewallD are annotated with
an explicit auth requirement.  So lets be explicit about the auth
requirement for the FirewallD getters.

And lets change the requirement (for the getters) to PK_ACTION_CONFIG_INFO.
This was the old default, before CVE-2016-5410[1].

[1] https://www.openwall.com/lists/oss-security/2016/08/16/3

It should be _CONFIG_INFO not just _INFO, because it discloses
"nf_conntrack_helper_setting".  Also, the setter is marked as _CONFIG.

Apply the same change to the config object and all the config sub-objects.
They also have setters which require PK_ACTION_CONFIG.