### PR TITLE
add ps2link service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -221,6 +221,7 @@ CONFIG_FILES = \
 	services/privoxy.xml \
 	services/prometheus.xml \
 	services/proxy-dhcp.xml \
+	services/ps2link.xml \
 	services/ptp.xml \
 	services/pulseaudio.xml \
 	services/puppetmaster.xml \

--- a/config/services/ps2link.xml
+++ b/config/services/ps2link.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>ps2link</short>
+  <description>ps2link and ps2netfs are protocols used for interacting with a PlayStation 2 system.</description>
+  <port protocol="udp" port="18194"/>
+  <port protocol="tcp" port="18193"/>
+  <port protocol="tcp" port="18195"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -155,6 +155,7 @@ config/services/postgresql.xml
 config/services/privoxy.xml
 config/services/prometheus.xml
 config/services/proxy-dhcp.xml
+config/services/ps2link.xml
 config/services/ptp.xml
 config/services/pulseaudio.xml
 config/services/puppetmaster.xml


### PR DESCRIPTION
[ps2link](https://github.com/ps2dev/ps2client/blob/master/doc/ps2link-protocol.txt) uses UDP 18194 and TCP 18193.
[ps2netfs](https://github.com/ps2dev/ps2client/blob/master/doc/ps2netfs-protocol.txt) uses TCP 18195.