### PR TITLE
Add Kubernetes definitions

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -185,7 +185,12 @@ CONFIG_FILES = \
 	services/kpasswd.xml \
 	services/kprop.xml \
 	services/kshell.xml \
+	services/kube-api.xml \
 	services/kube-apiserver.xml \
+	services/kube-control-plane.xml \
+	services/kube-controller-manager.xml \
+	services/kube-scheduler.xml \
+	services/kubelet-worker.xml \
 	services/ldaps.xml \
 	services/ldap.xml \
 	services/libvirt-tls.xml \

--- a/config/services/kube-api.xml
+++ b/config/services/kube-api.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kubernetes Kubelet API</short>
+  <description>The kubelet API is used to communicate between kube-scheduler and the node.</description>
+  <port protocol="tcp" port="10250"/>
+</service>

--- a/config/services/kube-control-plane.xml
+++ b/config/services/kube-control-plane.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kubernetes Control-plane Node</short>
+  <description>The Kubernetes Control-plane Node runs all the services of the Kubernetes Control Plane.  This includes kube-apiserver, etcd, kube-schedule, kube-controller-manager, cloud-controller-manager, and others</description>
+  <include service="etcd-client" />
+  <include service="etcd-server" />
+  <include service="kube-apiserver" />
+  <include service="kube-controller-manager" />
+  <include service="kube-scheduler" />
+  <include service="kube-api" />
+</service>

--- a/config/services/kube-controller-manager.xml
+++ b/config/services/kube-controller-manager.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kubernetes Controller Manager</short>
+  <description>The Kubernetes controller manager is a daemon that embeds the core control loops shipped with Kubernetes.</description>
+  <port protocol="tcp" port="10252"/>
+</service>

--- a/config/services/kube-scheduler.xml
+++ b/config/services/kube-scheduler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kubernetes Scheduler</short>
+  <description>The Kubernetes scheduler is a policy-rich, topology-aware, workload-specific function that significantly impacts availability, performance, and capacity.</description>
+  <port protocol="tcp" port="10251"/>
+</service>

--- a/config/services/kubelet-worker.xml
+++ b/config/services/kubelet-worker.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kubernetes Kubelet</short>
+  <description>The kubelet is the primary “node agent” that runs on each Kubernetes node.</description>
+  <include service="kube-api" />
+  <port protocol="tcp" port="30000-32767"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -117,7 +117,12 @@ config/services/klogin.xml
 config/services/kpasswd.xml
 config/services/kprop.xml
 config/services/kshell.xml
+config/services/kube-api.xml
 config/services/kube-apiserver.xml
+config/services/kube-control-plane.xml
+config/services/kube-controller-manager.xml
+config/services/kube-scheduler.xml
+config/services/kubelet-worker.xml
 config/services/ldaps.xml
 config/services/ldap.xml
 config/services/libvirt-tls.xml


### PR DESCRIPTION
Based on the ports list from: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/

This adds some static services for the individual components and two "meta services".

Someone following the guide there can open the required ports on the master/control plane with `kube-master` and on the worker/nodes with `kubelet-worker`.

I'm not 100% happy with the names for the "meta services" but master and worker seemed to fit along with the possibility that workers may add more services than just `kubelet` down the road.