### PR TITLE
improvement: Select target chain in rich rules

### DIFF
--- a/doc/xml/firewalld.richlanguage.xml
+++ b/doc/xml/firewalld.richlanguage.xml
@@ -99,7 +99,7 @@ rule
       <title>Rule</title>
       <para>
 	  <programlisting>
-rule [family="ipv4|ipv6"] [priority="priority"]
+rule [family="ipv4|ipv6"] [priority="priority"] [chain="INPUT|FORWARD_IN|FOWARD_OUT"]
 	  </programlisting>
       </para>
       <para>
@@ -107,6 +107,9 @@ rule [family="ipv4|ipv6"] [priority="priority"]
       </para>
       <para>
       If the rule priority is provided, it can be in the range of -32768 to 32767 where lower values have higher precendence. Rich rules are sorted by priority. Ordering for rules with the same priority value is undefined. A negative priority value will be executed before other firewalld primitives. A positive priority value will be executed after other firewalld primitives. A priority value of 0 will place the rule in a chain based on the action as per the "Information about logging and actions" below.
+      </para>
+      <para>
+      If the rule chain is provided, it can be either "INPUT", "FORWARD_IN", or "FORWARD_OUT", which adds the rule into the specified chain. If the rule chain is not provided, the rule will be added to the INPUT chain. The rule chain can be safely omitted if the previous behavior where rules were only added to the INPUT chain is desired.
       </para>
     </refsect2>
 

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1044,6 +1044,10 @@ class ip4tables(object):
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["INPUT"],
                                             zone=zone)
 
+        if rich_rule and rich_rule.chain:
+            target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[rich_rule.chain],
+                                                zone=zone)
+
         rule_fragment = [ "-p", proto ]
         if port:
             rule_fragment += [ "--dport", "%s" % portStr(port) ]
@@ -1071,6 +1075,10 @@ class ip4tables(object):
         table = "filter"
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["INPUT"], zone=zone)
 
+        if rich_rule and rich_rule.chain:
+            target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[rich_rule.chain],
+                                                zone=zone)
+
         rule_fragment = [ "-p", protocol ]
         if destination:
             rule_fragment += [ "-d", destination ]
@@ -1096,6 +1104,10 @@ class ip4tables(object):
         add_del = { True: "-A", False: "-D" }[enable]
         table = "filter"
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["INPUT"], zone=zone)
+
+        if rich_rule and rich_rule.chain:
+            target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[rich_rule.chain],
+                                                zone=zone)
 
         rule_fragment = [ "-p", proto ]
         if port:
@@ -1293,6 +1305,10 @@ class ip4tables(object):
         table = "filter"
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["INPUT"],
                                             zone=zone)
+
+        if rich_rule and rich_rule.chain:
+            target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[rich_rule.chain],
+                                                zone=zone)
 
         rule_fragment = []
         rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -1109,6 +1109,10 @@ class nftables(object):
         table = "filter"
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["INPUT"], zone=zone)
 
+        if rich_rule and rich_rule.chain:
+            target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[rich_rule.chain],
+                                                zone=zone)
+
         expr_fragments = []
         if rich_rule:
             expr_fragments.append(self._rich_rule_family_fragment(rich_rule.family))
@@ -1145,6 +1149,10 @@ class nftables(object):
         table = "filter"
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["INPUT"], zone=zone)
 
+        if rich_rule and rich_rule.chain:
+            target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[rich_rule.chain],
+                                                zone=zone)
+
         expr_fragments = []
         if rich_rule:
             expr_fragments.append(self._rich_rule_family_fragment(rich_rule.family))
@@ -1180,6 +1188,10 @@ class nftables(object):
         add_del = { True: "add", False: "delete" }[enable]
         table = "filter"
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["INPUT"], zone=zone)
+
+        if rich_rule and rich_rule.chain:
+            target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[rich_rule.chain],
+                                                zone=zone)
 
         expr_fragments = []
         if rich_rule:
@@ -1528,6 +1540,10 @@ class nftables(object):
         table = "filter"
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["INPUT"],
                                             zone=zone)
+
+        if rich_rule and rich_rule.chain:
+            target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS[rich_rule.chain],
+                                                zone=zone)
 
         expr_fragments = []
         expr_fragments.append(self._rich_rule_family_fragment(rich_rule.family))

--- a/src/tests/firewall-cmd.at
+++ b/src/tests/firewall-cmd.at
@@ -1040,6 +1040,9 @@ FWD_START_TEST([rich rules good])
     rich_rule_test([rule forward-port port="99" to-port="10999" to-addr="1::2:3:4:7" protocol="dccp" family="ipv6" source address="1:2:3:4:6::"])
     ])
     rich_rule_test([rule family="ipv4" port port="222" protocol="tcp" mark set="0xff"])
+    rich_rule_test([rule family="ipv4" chain="INPUT" port port="222" protocol="tcp" mark set="0xff"])
+    rich_rule_test([rule family="ipv4" chain="FORWARD_IN" port port="222" protocol="tcp" mark set="0xff"])
+    rich_rule_test([rule family="ipv4" chain="FORWARD_OUT" port port="222" protocol="tcp" mark set="0xff"])
 FWD_END_TEST([-e '/ERROR: Failed to write to file .*\/proc\/sys\/net\/ipv6\/conf\/all\/forwarding.*/d'])
 FWD_START_TEST([rich rules audit])
     AT_KEYWORDS(rich)
@@ -1694,6 +1697,7 @@ FWD_START_TEST([rich rules bad])
     rich_rule_test([rule family="ipv4" masquerade drop], 122) dnl masquerade & action
     rich_rule_test([rule family="ipv4" icmp-block name="redirect" accept], 122) dnl icmp-block & action
     rich_rule_test([rule forward-port port="2222" to-port="22" protocol="tcp" family="ipv4" accept], 122) dnl forward-port & action
+    rich_rule_test([rule chain="BAD" accept], 122) dnl bad chain
     m4_undefine([rich_rule_test])
 FWD_END_TEST([-e '/ERROR: INVALID_RULE:/d' dnl
               -e '/ERROR: INVALID_LOG_LEVEL: eror/d' dnl

--- a/src/tests/python/firewalld_rich.py
+++ b/src/tests/python/firewalld_rich.py
@@ -85,3 +85,11 @@ zone = FirewallClientZoneSettings()
 zone.setRichRules(rule)
 nz = fw_config.addZone("zone9", zone.settings)
 nz.remove()
+
+rule = ['rule chain=INPUT accept',
+        'rule chain=FORWARD_IN accept',
+        'rule chain=FORWARD_OUT accept']
+zone = FirewallClientZoneSettings()
+zone.setRichRules(rule)
+nz = fw_config.addZone("zone10", zone.settings)
+nz.remove()


### PR DESCRIPTION
Adds needed syntax, implementation in ipXtables and nftables,
documentation, and tests to extend the rich rule syntax to allow
rules to be added to chains other than INPUT. Currently limited
to INPUT, FORWARD_IN, and FORWARD_OUT. OUTPUT could be added easily as
soon as firewalld creates the needed per-zone OUTPUT chains.

Currently, firewalld lacks the ability to be effectively used on a
router due to rules only getting added to the INPUT chain. This commit
seeks to resolve this.

Fixes: #2 