### PR TITLE
Typo in firewall-config(1)

### DIFF
--- a/doc/xml/firewall-config.xml
+++ b/doc/xml/firewall-config.xml
@@ -73,7 +73,7 @@
         <term><option>--help</option></term>
         <listitem>
 	  <para>
-	    Prints a short help text and exists.
+	    Prints a short help text and exits.
 	  </para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
Very minor typo in `firewall-config(1)`