### PR TITLE
allow forwarding between interfaces in a zone

### DIFF
--- a/shell-completion/bash/firewall-cmd
+++ b/shell-completion/bash/firewall-cmd
@@ -53,6 +53,7 @@ OPTIONS_ZONE_ACTION_ACTION="--add-service= --remove-service= --query-service= \
 OPTIONS_ZONE_ADAPT_QUERY="--add-rich-rule= --remove-rich-rule= --query-rich-rule= \
                     --add-icmp-block-inversion --remove-icmp-block-inversion \
                     --query-icmp-block-inversion \
+                    --add-forward --remove-forward --query-forward \
                     --add-masquerade --remove-masquerade --query-masquerade \
                     --list-services --list-ports --list-protocols \
                     --list-source-ports --list-icmp-blocks \
@@ -183,6 +184,7 @@ _firewall_cmd()
     --list-forward-ports|--add-forward-port=*|--remove-forward-port=*|--query-forward-port=*|\
     --list-interfaces|--add-interface=*|--remove-interface=*|--query-interface=*|\
     --list-sources|--add-source=*|--remove-source=*|--query-source=*|\
+    --add-forward|--remove-forward|--query-forward|\
     --add-masquerade|--remove-masquerade|--query-masquerade|--list-all|\
     --get-description|--get-short|--set-description=*|--set-short=*)
         opts=""

--- a/shell-completion/zsh/_firewalld
+++ b/shell-completion/zsh/_firewalld
@@ -182,6 +182,9 @@ _arguments -C -s $args $direct \
   '*--add-forward-port=[add the IPv4 forward port for a zone]: :->port-forwards' \
   '*--remove-forward-port=[remove the IPv4 forward port from a zone]: :->port-forwards' \
   '*--query-forward-port=[return whether the IPv4 forward port has been added for a zone]: :->port-forwards' \
+  '--add-forward[enable IP forwarding between interfaces in a zone]' \
+  '--remove-forward[disable IP forwarding between interfaces in a zone]' \
+  '--query-forward[return whether IP forwarding has been enabled for a zone]' \
   '--add-masquerade[enable IPv4 masquerade for a zone]' \
   '--remove-masquerade[disable IPv4 masquerade for a zone]' \
   '--query-masquerade[return whether IPv4 masquerading has been enabled for a zone]' \

--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -293,6 +293,12 @@ Options to Adapt and Query Zones
   --query-forward-port=port=<portid>[-<portid>]:proto=<protocol>[:toport=<portid>[-<portid>]][:toaddr=<address>[/<mask>]]
                        Return whether the IPv4 forward port has been added for
                        a zone [P] [Z]
+  --add-forward        Enable forwarding of IP packets between interfaces in
+                       a zone [P] [Z] [T]
+  --remove-forward     Disable forwarding of IP packets between interfaces in
+                       a zone [P] [Z]
+  --query-forward      Return whether forwarding of IP packets between
+                       interfaces has been enabled for a zone [P] [Z]
   --add-masquerade     Enable IPv4 masquerade for a zone [P] [Z] [T]
   --remove-masquerade  Disable IPv4 masquerade for a zone [P] [Z]
   --query-masquerade   Return whether IPv4 masquerading has been enabled for a
@@ -617,6 +623,9 @@ parser_group_zone.add_argument("--query-protocol", metavar="<protocol>", action=
 parser_group_zone.add_argument("--add-source-port", metavar="<port>", action='append')
 parser_group_zone.add_argument("--remove-source-port", metavar="<port>", action='append')
 parser_group_zone.add_argument("--query-source-port", metavar="<port>", action='append')
+parser_group_zone.add_argument("--add-forward", action="store_true")
+parser_group_zone.add_argument("--remove-forward", action="store_true")
+parser_group_zone.add_argument("--query-forward", action="store_true")
 parser_group_zone.add_argument("--add-masquerade", action="store_true")
 parser_group_zone.add_argument("--remove-masquerade", action="store_true")
 parser_group_zone.add_argument("--query-masquerade", action="store_true")
@@ -825,6 +834,7 @@ options_zone_interfaces_sources = \
 
 options_zone_adapt_query = \
     a.add_rich_rule or a.remove_rich_rule or a.query_rich_rule or \
+    a.add_forward or a.remove_forward or a.query_forward or \
     a.add_masquerade or a.remove_masquerade or a.query_masquerade or \
     a.list_services or a.list_ports or a.list_protocols or \
     a.list_source_ports or \
@@ -1012,7 +1022,8 @@ else:
 
 if a.timeout and not (a.add_service or a.add_port or a.add_protocol or \
                       a.add_icmp_block or a.add_forward_port or \
-                      a.add_source_port or a.add_masquerade or a.add_rich_rule):
+                      a.add_source_port or a.add_forward or \
+                      a.add_masquerade or a.add_rich_rule):
     cmd.fail(parser.format_usage() + "Wrong --timeout usage")
 
 if a.permanent:
@@ -1999,6 +2010,14 @@ if a.permanent:
             cmd.query_sequence(a.query_source_port, fw_zone.querySourcePort,
                                cmd.parse_port, "%s/%s")
 
+        # forward
+        elif a.add_forward:
+            fw_zone.addForward()
+        elif a.remove_forward:
+            fw_zone.removeForward()
+        elif a.query_forward:
+            cmd.print_query_result(fw_zone.queryForward())
+
         # masquerade
         elif a.add_masquerade:
             fw_zone.addMasquerade()
@@ -2552,6 +2571,14 @@ elif a.remove_source_port:
 elif a.query_source_port:
     cmd.x_query_sequence(zone, a.query_source_port, fw.querySourcePort,
                          cmd.parse_port, "'%s/%s'")
+
+# forward
+elif a.add_forward:
+    fw.addForward(zone, a.timeout)
+elif a.remove_forward:
+    fw.removeForward(zone)
+elif a.query_forward:
+    cmd.print_query_result(fw.queryForward(zone))
 
 # masquerade
 elif a.add_masquerade:

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -327,6 +327,12 @@ Options to Adapt and Query Zones
   --query-forward-port=port=<portid>[-<portid>]:proto=<protocol>[:toport=<portid>[-<portid>]][:toaddr=<address>[/<mask>]]
                        Return whether the IPv4 forward port has been added for
                        a zone [Z]
+  --add-forward        Enable forwarding of IP packets between interfaces in
+                       a zone [Z]
+  --remove-forward     Disable forwarding of IP packets between interfaces in
+                       a zone [Z]
+  --query-forward      Return whether forwarding of IP packets between
+                       interfaces has been enabled for a zone [Z]
   --add-masquerade     Enable IPv4 masquerade for a zone [Z]
   --remove-masquerade  Disable IPv4 masquerade for a zone [Z]
   --query-masquerade   Return whether IPv4 masquerading has been enabled for a
@@ -653,6 +659,9 @@ parser_group_zone.add_argument("--query-protocol", metavar="<protocol>", action=
 parser_group_zone.add_argument("--add-source-port", metavar="<port>", action='append')
 parser_group_zone.add_argument("--remove-source-port", metavar="<port>", action='append')
 parser_group_zone.add_argument("--query-source-port", metavar="<port>", action='append')
+parser_group_zone.add_argument("--add-forward", action="store_true")
+parser_group_zone.add_argument("--remove-forward", action="store_true")
+parser_group_zone.add_argument("--query-forward", action="store_true")
 parser_group_zone.add_argument("--add-masquerade", action="store_true")
 parser_group_zone.add_argument("--remove-masquerade", action="store_true")
 parser_group_zone.add_argument("--query-masquerade", action="store_true")
@@ -898,6 +907,7 @@ options_zone_interfaces_sources = \
 
 options_zone_adapt_query = \
     a.add_rich_rule or a.remove_rich_rule or a.query_rich_rule or \
+    a.add_forward or a.remove_forward or a.query_forward or \
     a.add_masquerade or a.remove_masquerade or a.query_masquerade or \
     a.list_services or a.list_ports or a.list_protocols or \
     a.list_source_ports or \
@@ -2216,6 +2226,14 @@ try:
         elif a.query_source_port:
             cmd.query_sequence(a.query_source_port, fw_settings.querySourcePort,
                                cmd.parse_port, "%s/%s")
+
+        # forward
+        elif a.add_forward:
+            fw_settings.setForward(True)
+        elif a.remove_forward:
+            fw_settings.setForward(False)
+        elif a.query_forward:
+            cmd.print_query_result(fw_settings.getForward())
 
         # masquerade
         elif a.add_masquerade:

--- a/src/firewall/client.py
+++ b/src/firewall/client.py
@@ -89,7 +89,7 @@ class FirewallClientZoneSettings(object):
             self.settings = settings
         else:
             self.settings = ["", "", "", False, DEFAULT_ZONE_TARGET, [], [],
-                             [], False, [], [], [], [], [], [], False]
+                             [], False, [], [], [], [], [], [], False, False]
 
     @handle_exceptions
     def __repr__(self):
@@ -263,6 +263,31 @@ class FirewallClientZoneSettings(object):
     @handle_exceptions
     def queryIcmpBlockInversion(self):
         return self.settings[15]
+
+    @handle_exceptions
+    def getForward(self):
+        return self.settings[16]
+    @handle_exceptions
+    def setForward(self, forward):
+        self.settings[16] = forward
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def addForward(self):
+        if not self.settings[16]:
+            self.settings[16] = True
+        else:
+            FirewallError(errors.ALREADY_ENABLED, "forward")
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def removeForward(self):
+        if self.settings[16]:
+            self.settings[16] = False
+        else:
+            FirewallError(errors.NOT_ENABLED, "forward")
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def queryForward(self):
+        return self.settings[16]
 
     @handle_exceptions
     def getMasquerade(self):
@@ -664,6 +689,33 @@ class FirewallClientConfigZone(object):
     @handle_exceptions
     def queryIcmpBlockInversion(self):
         return self.fw_zone.queryIcmpBlockInversion()
+
+    # forward
+
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def getForward(self):
+        return self.fw_zone.getForward()
+
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def setForward(self, forward):
+        self.fw_zone.setForward(forward)
+
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def addForward(self):
+        self.fw_zone.addForward()
+
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def removeForward(self):
+        self.fw_zone.removeForward()
+
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def queryForward(self):
+        return self.fw_zone.queryForward()
 
     # masquerade
 
@@ -2632,6 +2684,8 @@ class FirewallClient(object):
             "source-port-removed": "SourcePortRemoved",
             "protocol-added": "ProtocolAdded",
             "protocol-removed": "ProtocolRemoved",
+            "forward-added": "ForwardAdded",
+            "forward-removed": "ForwardRemoved",
             "masquerade-added": "MasqueradeAdded",
             "masquerade-removed": "MasqueradeRemoved",
             "forward-port-added": "ForwardPortAdded",
@@ -3189,6 +3243,23 @@ class FirewallClient(object):
     @handle_exceptions
     def removeProtocol(self, zone, protocol):
         return dbus_to_python(self.fw_zone.removeProtocol(zone, protocol))
+
+    # forward
+
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def addForward(self, zone, timeout=0):
+        return dbus_to_python(self.fw_zone.addForward(zone, timeout))
+
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def queryForward(self, zone):
+        return dbus_to_python(self.fw_zone.queryForward(zone))
+
+    @slip.dbus.polkit.enable_proxy
+    @handle_exceptions
+    def removeForward(self, zone):
+        return dbus_to_python(self.fw_zone.removeForward(zone))
 
     # masquerade
 

--- a/src/firewall/command.py
+++ b/src/firewall/command.py
@@ -385,6 +385,7 @@ class FirewallCommand(object):
         services = settings.getServices()
         ports = settings.getPorts()
         protocols = settings.getProtocols()
+        forward = settings.getForward()
         masquerade = settings.getMasquerade()
         forward_ports = settings.getForwardPorts()
         source_ports = settings.getSourcePorts()
@@ -427,6 +428,7 @@ class FirewallCommand(object):
         self.print_msg("  ports: " + " ".join(["%s/%s" % (port[0], port[1])
                                                for port in ports]))
         self.print_msg("  protocols: " + " ".join(sorted(protocols)))
+        self.print_msg("  forward: %s" % ("yes" if forward else "no"))
         self.print_msg("  masquerade: %s" % ("yes" if masquerade else "no"))
         self.print_msg("  forward-ports: " +
                        "\n\t".join(["port=%s:proto=%s:toport=%s:toaddr=%s" % \

--- a/src/firewall/core/io/zone.py
+++ b/src/firewall/core/io/zone.py
@@ -57,8 +57,9 @@ class Zone(IO_Object):
         ( "protocols", [ "", ], ),                     # as
         ( "source_ports", [ ( "", "" ), ], ),          # a(ss)
         ( "icmp_block_inversion", False ),             # b
+        ( "forward", False ),                          # b
         )
-    DBUS_SIGNATURE = '(sssbsasa(ss)asba(ssss)asasasasa(ss)b)'
+    DBUS_SIGNATURE = '(sssbsasa(ss)asba(ssss)asasasasa(ss)bb)'
     ADDITIONAL_ALNUM_CHARS = [ "_", "-", "/" ]
     PARSER_REQUIRED_ELEMENT_ATTRS = {
         "short": None,
@@ -68,6 +69,7 @@ class Zone(IO_Object):
         "port": [ "port", "protocol" ],
         "icmp-block": [ "name" ],
         "icmp-type": [ "name" ],
+        "forward": None,
         "forward-port": [ "port", "protocol" ],
         "interface": [ "name" ],
         "rule": None,
@@ -113,6 +115,7 @@ class Zone(IO_Object):
         self.ports = [ ]
         self.protocols = [ ]
         self.icmp_blocks = [ ]
+        self.forward = False
         self.masquerade = False
         self.forward_ports = [ ]
         self.source_ports = [ ]
@@ -134,6 +137,7 @@ class Zone(IO_Object):
         del self.ports[:]
         del self.protocols[:]
         del self.icmp_blocks[:]
+        self.forward = False
         self.masquerade = False
         del self.forward_ports[:]
         del self.source_ports[:]
@@ -282,6 +286,8 @@ class Zone(IO_Object):
         for icmp in zone.icmp_blocks:
             if icmp not in self.icmp_blocks:
                 self.icmp_blocks.append(icmp)
+        if zone.forward:
+            self.forward = True
         if zone.masquerade:
             self.masquerade = True
         for forward in zone.forward_ports:
@@ -407,6 +413,12 @@ class zone_ContentHandler(IO_Object_ContentHandler):
             else:
                 log.warning("Invalid rule: icmp-block '%s' outside of rule",
                             attrs["name"])
+
+        elif name == "forward":
+            if self.item.forward:
+                log.warning("Forward already set, ignoring.")
+            else:
+                self.item.forward = True
 
         elif name == "masquerade":
             if "enabled" in attrs and \
@@ -806,6 +818,12 @@ def zone_writer(zone, path=None):
     for icmp in uniqify(zone.icmp_blocks):
         handler.ignorableWhitespace("  ")
         handler.simpleElement("icmp-block", { "name": icmp })
+        handler.ignorableWhitespace("\n")
+
+    # forward
+    if zone.forward:
+        handler.ignorableWhitespace("  ")
+        handler.simpleElement("forward", { })
         handler.ignorableWhitespace("\n")
 
     # masquerade

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1159,6 +1159,16 @@ class ip4tables(object):
 
         return [rule]
 
+    def build_zone_forward_rules(self, enable, zone, interfaces):
+        add_del = { True: "-A", False: "-D" }[enable]
+        target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["FORWARD_IN"],
+                                            zone=zone)
+        rules = []
+        for interface in interfaces:
+            rules.append(["-t", "filter", add_del, "%s_allow" % target,
+                          "-o", interface, "-j", "ACCEPT"])
+        return rules
+
     def build_zone_masquerade_rules(self, enable, zone, rich_rule=None):
         add_del = { True: "-A", False: "-D" }[enable]
         target = DEFAULT_ZONE_TARGET.format(chain=SHORTCUTS["POSTROUTING"],

--- a/src/firewall/server/config_zone.py
+++ b/src/firewall/server/config_zone.py
@@ -722,6 +722,55 @@ class FirewallDConfigZone(slip.dbus.service.Object):
         log.debug1("%s.queryIcmpBlockInversion()", self._log_prefix)
         return self.getSettings()[15]
 
+    # forward
+
+    @dbus_service_method(config.dbus.DBUS_INTERFACE_CONFIG_ZONE,
+                         out_signature='b')
+    @dbus_handle_exceptions
+    def getForward(self, sender=None): # pylint: disable=W0613
+        log.debug1("%s.getForward()", self._log_prefix)
+        return self.getSettings()[16]
+
+    @dbus_service_method(config.dbus.DBUS_INTERFACE_CONFIG_ZONE,
+                         in_signature='b')
+    @dbus_handle_exceptions
+    def setForward(self, forward, sender=None):
+        forward = dbus_to_python(forward, bool)
+        log.debug1("%s.setForward('%s')", self._log_prefix, forward)
+        self.parent.accessCheck(sender)
+        settings = list(self.getSettings())
+        settings[16] = forward
+        self.update(settings)
+
+    @dbus_service_method(config.dbus.DBUS_INTERFACE_CONFIG_ZONE)
+    @dbus_handle_exceptions
+    def addForward(self, sender=None):
+        log.debug1("%s.addForward()", self._log_prefix)
+        self.parent.accessCheck(sender)
+        settings = list(self.getSettings())
+        if settings[16]:
+            raise FirewallError(errors.ALREADY_ENABLED, "forward")
+        settings[16] = True
+        self.update(settings)
+
+    @dbus_service_method(config.dbus.DBUS_INTERFACE_CONFIG_ZONE)
+    @dbus_handle_exceptions
+    def removeForward(self, sender=None):
+        log.debug1("%s.removeForward()", self._log_prefix)
+        self.parent.accessCheck(sender)
+        settings = list(self.getSettings())
+        if not settings[16]:
+            raise FirewallError(errors.NOT_ENABLED, "forward")
+        settings[16] = False
+        self.update(settings)
+
+    @dbus_service_method(config.dbus.DBUS_INTERFACE_CONFIG_ZONE,
+                         out_signature='b')
+    @dbus_handle_exceptions
+    def queryForward(self, sender=None): # pylint: disable=W0613
+        log.debug1("%s.queryForward()", self._log_prefix)
+        return self.getSettings()[16]
+
     # masquerade
 
     @dbus_service_method(config.dbus.DBUS_INTERFACE_CONFIG_ZONE,

--- a/src/tests/cli/firewall-cmd.at
+++ b/src/tests/cli/firewall-cmd.at
@@ -499,6 +499,75 @@ FWD_START_TEST([masquerade])
     FWD_CHECK([--permanent --query-masquerade], 1, ignore)
 FWD_END_TEST
 
+FWD_START_TEST([forward])
+    AT_KEYWORDS(forward)
+
+    FWD_CHECK([--zone=home --add-interface=dummy --add-interface=dummy2], 0, ignore)
+    FWD_CHECK([--zone=home --add-forward], 0, ignore)
+    NFT_LIST_RULES([inet], [filter_FWDI_home_allow], 0, [dnl
+        table inet firewalld {
+        chain filter_FWDI_home_allow {
+        oifname "dummy" accept
+        oifname "dummy2" accept
+        }
+        }
+    ])
+    dnl These two ipXtables rules correspond to:
+    dnl   -A FWDI_home_allow -o dummy -j ACCEPT
+    dnl   -A FWDI_home_allow -o dummy2 -j ACCEPT
+    dnl although we can't assert the interface names because they don't
+    dnl appear in these rule listings, unfortunately...
+    IPTABLES_LIST_RULES([filter], [FWDI_home_allow], 0, [dnl
+        ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
+        ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
+    ])
+    IP6TABLES_LIST_RULES([filter], [FWDI_home_allow], 0, [dnl
+        ACCEPT all ::/0 ::/0
+        ACCEPT all ::/0 ::/0
+    ])
+    dnl Forward rules should be updated when the interfaces change
+    FWD_CHECK([--zone=home --remove-interface=dummy2], 0, ignore)
+    NFT_LIST_RULES([inet], [filter_FWDI_home_allow], 0, [dnl
+        table inet firewalld {
+        chain filter_FWDI_home_allow {
+        oifname "dummy" accept
+        }
+        }
+    ])
+    IPTABLES_LIST_RULES([filter], [FWDI_home_allow], 0, [dnl
+        ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
+    ])
+    IP6TABLES_LIST_RULES([filter], [FWDI_home_allow], 0, [dnl
+        ACCEPT all ::/0 ::/0
+    ])
+    FWD_CHECK([--zone=home --add-interface=dummy3], 0, ignore)
+    NFT_LIST_RULES([inet], [filter_FWDI_home_allow], 0, [dnl
+        table inet firewalld {
+        chain filter_FWDI_home_allow {
+        oifname "dummy" accept
+        oifname "dummy3" accept
+        }
+        }
+    ])
+    IPTABLES_LIST_RULES([filter], [FWDI_home_allow], 0, [dnl
+        ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
+        ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
+    ])
+    IP6TABLES_LIST_RULES([filter], [FWDI_home_allow], 0, [dnl
+        ACCEPT all ::/0 ::/0
+        ACCEPT all ::/0 ::/0
+    ])
+    FWD_CHECK([--zone=home --query-forward], 0, ignore)
+    FWD_CHECK([--zone=home --remove-forward], 0, ignore)
+    FWD_CHECK([--zone=home --query-forward], 1, ignore)
+    FWD_CHECK([--zone=home --remove-interface=dummy --remove-interface=dummy3], 0, ignore)
+
+    FWD_CHECK([--permanent --zone=home --add-forward], 0, ignore)
+    FWD_CHECK([--permanent --zone=home --query-forward], 0, ignore)
+    FWD_CHECK([--permanent --zone=home --remove-forward], 0, ignore)
+    FWD_CHECK([--permanent --zone=home --query-forward], 1, ignore)
+FWD_END_TEST
+
 FWD_START_TEST([forward ports])
     AT_KEYWORDS(port forward_port)
 
@@ -1698,6 +1767,7 @@ FWD_START_TEST([rich rules priority])
         services: dhcpv6-client ssh
         ports:
         protocols:
+        forward: no
         masquerade: no
         forward-ports:
         source-ports:


### PR DESCRIPTION
This introduces a new boolean flag called "forward" on zones, similar to
the existing "masquerade" setting.

When the "forward" setting is enabled for a zone, the firewall rules
will allow packets to be forwarded between interfaces within that zone,
but not to other zones. Unlike the "masquerade" setting, no other NAT
rules are applied.

This gives a rudimentary kind of configurable forwarding. You can
control whether packets will be forwarded by arranging your interfaces
into zones and turning on this flag.