### PR TITLE
Add an option to disable building documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,9 @@
-SUBDIRS = config doc po shell-completion src
+SUBDIRS = config po shell-completion src
+
+if ENABLE_DOCS
+SUBDIRS += doc
+endif
+
 DIST_TARGETS = dist-gzip
 
 EXTRA_DIST = \
@@ -43,7 +48,9 @@ tag:
 	git push
 	git push --tags
 
+if ENABLE_DOCS
 dist: clean-docs update-docs
+endif
 
 dist-check:
 	@rm -f _dist_check_failed
@@ -83,8 +90,10 @@ check-container check-integration installcheck-integration:
 
 .PHONY: check-container check-integration installcheck-integration
 
+if ENABLE_DOCS
 update-docs:
 	$(MAKE) -C doc/xml
+endif
 
 clean-docs:
 	$(MAKE) -C doc/xml clean

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,14 @@ GLIB_GSETTINGS
 
 #############################################################
 
-JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl], [DocBook XSL Stylesheets])
+AC_ARG_ENABLE([docs],
+    [AS_HELP_STRING([--enable-docs], [Enable building documentation])],
+    [ENABLE_DOCS="${enableval}"], [ENABLE_DOCS='yes'])
+AM_CONDITIONAL(ENABLE_DOCS, [test x$ENABLE_DOCS = xyes])
+if test "x$ENABLE_DOCS" = "xyes"; then
+    JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl], [DocBook XSL Stylesheets])
+fi
+AC_SUBST(ENABLE_DOCS)
 
 #############################################################
 
@@ -165,17 +172,10 @@ AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE], ["$GETTEXT_PACKAGE"],)
 IT_PROG_INTLTOOL([0.35.0], [no-xml])
 AM_PO_SUBDIRS
 
-AC_CONFIG_COMMANDS([xsl-cleanup],,[rm -f doc/xml/transform-*.xsl])
-
 AC_CONFIG_FILES([Makefile
 		 doxygen.conf
 		 config/lockdown-whitelist.xml
 		 config/Makefile
-		 doc/Makefile
-		 doc/man/Makefile
-		 doc/man/man1/Makefile
-		 doc/man/man5/Makefile
-		 doc/xml/Makefile
 		 po/Makefile.in
 		 shell-completion/Makefile
 		 src/firewall/config/__init__.py
@@ -183,6 +183,15 @@ AC_CONFIG_FILES([Makefile
 		 src/tests/Makefile
 		 src/tests/atlocal
 		 src/icons/Makefile])
+
+if test "x$ENABLE_DOCS" = "xyes"; then
+AC_CONFIG_COMMANDS([xsl-cleanup],,[rm -f doc/xml/transform-*.xsl])
+AC_CONFIG_FILES([doc/Makefile
+		 doc/man/Makefile
+		 doc/man/man1/Makefile
+		 doc/man/man5/Makefile
+		 doc/xml/Makefile])
+fi
 
 m4_foreach([FILE], [[src/firewall-applet],
                    [src/firewall-cmd],


### PR DESCRIPTION
For embedded applications such as Buildroot or Yocto, the man pages may not be
desired or even capable of being built.

On line 45 of configure.ac there is the line:
JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl], [DocBook XSL Stylesheets])

There are three issues with this:
  - It requires building the xml-catalog package.
  - It automatically defaults to the host systems xml-catalog
    instead of the cross environments.
  - It isn't necessary to have a functioning firewalld.

Create a new option: --disable-docs. By default, build the documentation, but
if a user passes --disable-docs documentation will no longer be built as
desired.