### PR TITLE
Use relative python shebangs

### DIFF
--- a/config/lockdown-whitelist.xml.in
+++ b/config/lockdown-whitelist.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <whitelist>
-  <command name="@PYTHON@ /usr/bin/firewall-config"/>
+  <command name="#!/usr/bin/env python@PYTHON_VERSION@ /usr/bin/firewall-config"/>
   <selinux context="system_u:system_r:NetworkManager_t:s0"/>
   <selinux context="system_u:system_r:virtd_t:s0-s0:c0.c1023"/>
   <user id="0"/>

--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -1,4 +1,4 @@
-#!@PYTHON@
+#!/usr/bin/env python@PYTHON_VERSION@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2015 Red Hat, Inc.

--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -1,4 +1,4 @@
-#!@PYTHON@
+#!/usr/bin/env python@PYTHON_VERSION@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009-2016 Red Hat, Inc.

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1,4 +1,4 @@
-#!@PYTHON@
+#!/usr/bin/env python@PYTHON_VERSION@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2015 Red Hat, Inc.

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -1,4 +1,4 @@
-#!@PYTHON@
+#!/usr/bin/env python@PYTHON_VERSION@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009-2016 Red Hat, Inc.

--- a/src/firewalld.in
+++ b/src/firewalld.in
@@ -1,4 +1,4 @@
-#!@PYTHON@
+#!/usr/bin/env python@PYTHON_VERSION@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.

--- a/src/tests/atlocal.in
+++ b/src/tests/atlocal.in
@@ -1,4 +1,4 @@
-export PYTHON="@PYTHON@"
+export PYTHON="/usr/bin/env python@PYTHON_VERSION@"
 
 export IPTABLES="@IPTABLES@"
 export IPTABLES_RESTORE="@IPTABLES_RESTORE@"


### PR DESCRIPTION
When cross-compiling, Python is built first and installed to a staging
directory and the target. When cross-compiling firewalld, the Python shebangs
end up with a full, hard-coded path to the specified python interpreter,
IE: #!/home/buildroot/output/host/bin/python.

The following files are affected by this:
config/lockdown-whitelist.xml.in
src/firewall-applet.in
src/firewall-cmd.in
src/firewall-config.in
src/firewall-offline-cmd.in
src/firewalld.in
src/tests/atlocal.in

This full path causes the above files not to run, as the full cross-compiled
path does not exist on the cross-compiled device.

Instead of using #!@PYTHON@ use #!/usr/bin/env python@PYTHON_VERSION@ instead.
This change allows for the python path to be relative but still work with the
AM_PATH_PYTHON macro.