### PR TITLE
Add common services - AFP and WS-Discovery

### DIFF
--- a/config/services/afp.xml
+++ b/config/services/afp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Apple Filing Protocol</short>
+  <description>The Apple Filing Protocol (AFP), formerly AppleTalk Filing Protocol, is a proprietary network protocol, and part of the Apple File Service (AFS), that offers file services for macOS and the classic Mac OS.</description>
+  <port protocol="tcp" port="548"/>
+</service>

--- a/config/services/ws-discovery.xml
+++ b/config/services/ws-discovery.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Web Services Dynamic Discovery</short>
+  <description>Web Services Dynamic Discovery (WS-Discovery) is a technical specification that defines a multicast discovery protocol to locate services on a local network.</description>
+  <port protocol="tcp" port="3702"/>
+  <port protocol="udp" port="3702"/>
+</service>


### PR DESCRIPTION
In a mixed Linux/Windows/Mac OS X environment traffic from AFP and WS-Discovery is often seen.  It would be good to add service definitions for these to firewalld.