### PR TITLE
Fix handling of <forward/> tag in zone definitions

### DIFF
--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -259,7 +259,7 @@ class FirewallZone(object):
                 elif key == "icmp_block_inversion":
                     continue
                 elif key == "forward":
-                    self._forward(enable, zone, args, transaction)
+                    self._forward(enable, zone, transaction)
                 else:
                     log.warning("Zone '%s': Unknown setting '%s:%s', "
                                 "unable to apply", zone, key, args)


### PR DESCRIPTION
Currently its broken:
```
Traceback (most recent call last):
    File "/usr/lib/python3.8/site-packages/firewall/server/decorators.py", line 53, in handle_exceptions
      return func(*args, **kwargs)
    File "/usr/lib/python3.8/site-packages/firewall/server/firewalld.py", line 93, in start
      return self.fw.start()
    File "/usr/lib/python3.8/site-packages/firewall/core/fw.py", line 478, in start
      self._start()
    File "/usr/lib/python3.8/site-packages/firewall/core/fw.py", line 443, in _start
      self.zone.apply_zones(use_transaction=transaction)
    File "/usr/lib/python3.8/site-packages/firewall/core/fw_zone.py", line 169, in apply_zones
      self.apply_zone_settings(zone, use_transaction=use_transaction)
    File "/usr/lib/python3.8/site-packages/firewall/core/fw_zone.py", line 286, in apply_zone_settings
      self._zone_settings(True, _zone, transaction)
    File "/usr/lib/python3.8/site-packages/firewall/core/fw_zone.py", line 262, in _zone_settings
      self._forward(enable, zone, args, transaction)
  TypeError: _forward() takes 4 positional arguments but 5 were given
```

Ref: https://github.com/firewalld/firewalld/pull/613#issuecomment-622672202