### PR TITLE
renable travis-ci tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,46 @@ dist: bionic
 
 language: python
 python:
-  - "2.7"
   - "3.7"
+
+# Use keywords to split the tests into smaller groups and therefore decrease
+# the time CI takes to run.
+env:
+# flake8, etc
+  - MAKE_ARGS="-C src check-local"
+  - MAKE_ARGS="-C config check-local"
+# offline tests
+  - MAKE_ARGS="-C src/tests check-local" TESTSUITEFLAGS="-k offline -j$(nproc)"
+    NEED_NFTABLES=1 RETEST=1
+# nftables backend
+  - MAKE_ARGS="-C src/tests check-local" TESTSUITEFLAGS="-k nftables -j$(nproc)"
+    NEED_NFTABLES=1 RETEST=1
+# iptables backend
+  - MAKE_ARGS="-C src/tests check-local" TESTSUITEFLAGS="-k iptables -j$(nproc)"
+    NEED_NFTABLES=1 RETEST=1
+  - MAKE_ARGS="-C src/tests check-local" TESTSUITEFLAGS="-k iptables -j$(nproc)"
+    IP6TABLES="/bin/false" IP6TABLES_RESTORE="/bin/false"
+    NEED_NFTABLES=1 RETEST=1
 
 addons:
   apt:
     packages:
     - autoconf
     - automake
-    - pkg-config
-    - intltool
-    - libglib2.0-dev
-    - xsltproc
-    - docbook-xsl
     - docbook-xml
-    - iptables
-    - ipset
+    - docbook-xsl
     - ebtables
-    - libxml2-utils
+    - intltool
+    - ipset
+    - iptables
     - libdbus-1-dev
     - libgirepository1.0-dev
+    - libglib2.0-dev
+    - libjansson-dev
+    - libxml2-utils
+    - network-manager
+    - pkg-config
+    - xsltproc
 
 install:
   - pip install flake8 decorator dbus-python PyGObject
@@ -31,10 +51,32 @@ install:
     && make
     && pip install .
     && popd
+  - test x"$NEED_NFTABLES" = x
+    || { sudo apt-get -qq -y install libmnl-dev libgmp-dev libreadline-dev
+    && pushd /tmp
+    && wget https://netfilter.org/projects/libnftnl/files/libnftnl-1.1.6.tar.bz2
+    && wget https://netfilter.org/projects/nftables/files/nftables-0.9.4.tar.bz2
+    && tar xf libnftnl-1.1.6.tar.bz2
+    && tar xf nftables-0.9.4.tar.bz2
+    && cd libnftnl-1.1.6
+    && ./configure --prefix=/usr
+    && make
+    && sudo make install
+    && sudo ldconfig
+    && cd /tmp
+    && cd nftables-0.9.4
+    && ./configure --prefix=/usr --disable-man-doc --with-json --enable-python
+    && make
+    && sudo make install
+    && cd py
+    && pip install .
+    && popd
+    && sudo ldconfig
+    ; }
 
 script:
   - ./autogen.sh
-    && ./configure --sysconfdir=/etc
-    && make -j32
-  - make -C src check-local
-  - make -C config check-local
+    && ./configure
+    && make -j$(nproc)
+  - sudo env PATH="$PATH" make ${MAKE_ARGS} ||
+    { test x"$RETEST" != x && sudo env PATH="$PATH" make ${MAKE_ARGS} TESTSUITEFLAGS="--recheck --errexit -v -d"; }

--- a/src/firewall/core/fw_ipset.py
+++ b/src/firewall/core/fw_ipset.py
@@ -117,6 +117,11 @@ class FirewallIPSet(object):
                         # no entries visible for ipsets with timeout
                         continue
 
+                try:
+                    backend.set_flush(obj.name)
+                except Exception as msg:
+                    raise FirewallError(errors.COMMAND_FAILED, msg)
+
                 for entry in obj.entries:
                     try:
                         backend.set_add(obj.name, entry)

--- a/src/tests/cli/firewall-cmd.at
+++ b/src/tests/cli/firewall-cmd.at
@@ -625,7 +625,10 @@ FWD_START_TEST([forward])
     ])
 
     dnl zone source
-    FWD_CHECK([--zone=internal --add-source=10.10.10.0/24 --add-source=1234::/64], 0, ignore)
+    FWD_CHECK([--zone=internal --add-source=10.10.10.0/24], 0, ignore)
+    IF_HOST_SUPPORTS_IPV6_RULES([
+    FWD_CHECK([--zone=internal --add-source=1234::/64], 0, ignore)
+    ])
     FWD_CHECK([--zone=internal --add-forward], 0, ignore)
     NFT_LIST_RULES([inet], [filter_FWDI_internal_allow], 0, [dnl
         table inet firewalld {
@@ -641,7 +644,9 @@ FWD_START_TEST([forward])
     IP6TABLES_LIST_RULES([filter], [FWDI_internal_allow], 0, [dnl
         ACCEPT all ::/0 1234::/64
     ])
+    IF_HOST_SUPPORTS_IPV6_RULES([
     FWD_CHECK([--zone=internal --remove-source=1234::/64], 0, ignore)
+    ])
     NFT_LIST_RULES([inet], [filter_FWDI_internal_allow], 0, [dnl
         table inet firewalld {
             chain filter_FWDI_internal_allow {
@@ -654,7 +659,10 @@ FWD_START_TEST([forward])
     ])
     IP6TABLES_LIST_RULES([filter], [FWDI_internal_allow], 0, [dnl
     ])
-    FWD_CHECK([--zone=internal --add-source=10.20.20.0/24 --add-source=4321::/64], 0, ignore)
+    FWD_CHECK([--zone=internal --add-source=10.20.20.0/24], 0, ignore)
+    IF_HOST_SUPPORTS_IPV6_RULES([
+    FWD_CHECK([--zone=internal --add-source=4321::/64], 0, ignore)
+    ])
     NFT_LIST_RULES([inet], [filter_FWDI_internal_allow], 0, [dnl
         table inet firewalld {
             chain filter_FWDI_internal_allow {

--- a/src/tests/dbus/firewalld.conf.at
+++ b/src/tests/dbus/firewalld.conf.at
@@ -7,6 +7,12 @@ IF_HOST_SUPPORTS_NFT_FIB([
    EXPECTED_IPV6_RPFILTER_VALUE=no
 ])
 
+IF_HOST_SUPPORTS_NFT_RULE_INDEX([
+    EXPECTED_INDIVIDUAL_CALLS_VALUE=no
+], [
+    EXPECTED_INDIVIDUAL_CALLS_VALUE=yes
+])
+
 dnl Verify defaults over dbus. Should be inline with default firewalld.conf.
 DBUS_GETALL([config], [config], 0, [dnl
 string "AllowZoneDrifting" : variant string "no"
@@ -16,7 +22,7 @@ string "DefaultZone" : variant string "public"
 string "FirewallBackend" : variant string "nftables"
 string "FlushAllOnReload" : variant string "yes"
 string "IPv6_rpfilter" : variant string m4_escape(["${EXPECTED_IPV6_RPFILTER_VALUE}"])
-string "IndividualCalls" : variant string "no"
+string "IndividualCalls" : variant string m4_escape(["${EXPECTED_INDIVIDUAL_CALLS_VALUE}"])
 string "Lockdown" : variant string "no"
 string "LogDenied" : variant string "off"
 string "MinimalMark" : variant int32 100

--- a/src/tests/dbus/firewalld.conf.at
+++ b/src/tests/dbus/firewalld.conf.at
@@ -1,36 +1,26 @@
 FWD_START_TEST([firewalld.conf])
 AT_KEYWORDS(dbus)
 
-dnl Verify defaults over dbus. Should be inline with default firewalld.conf.
 IF_HOST_SUPPORTS_NFT_FIB([
-DBUS_GETALL([config], [config], 0, [dnl
-string "AllowZoneDrifting" : variant string "no"
-string "AutomaticHelpers" : variant string "no"
-string "CleanupOnExit" : variant string "no"
-string "DefaultZone" : variant string "public"
-string "FirewallBackend" : variant string "nftables"
-string "FlushAllOnReload" : variant string "yes"
-string "IPv6_rpfilter" : variant string "yes"
-string "IndividualCalls" : variant string "no"
-string "Lockdown" : variant string "no"
-string "LogDenied" : variant string "off"
-string "MinimalMark" : variant int32 100
-string "RFC3964_IPv4" : variant string "yes"
-])], [
-DBUS_GETALL([config], [config], 0, [dnl
-string "AllowZoneDrifting" : variant string "no"
-string "AutomaticHelpers" : variant string "no"
-string "CleanupOnExit" : variant string "no"
-string "DefaultZone" : variant string "public"
-string "FirewallBackend" : variant string "nftables"
-string "FlushAllOnReload" : variant string "yes"
-string "IPv6_rpfilter" : variant string "no"
-string "IndividualCalls" : variant string "no"
-string "Lockdown" : variant string "no"
-string "LogDenied" : variant string "off"
-string "MinimalMark" : variant int32 100
-string "RFC3964_IPv4" : variant string "yes"
+   EXPECTED_IPV6_RPFILTER_VALUE=yes
+], [
+   EXPECTED_IPV6_RPFILTER_VALUE=no
 ])
+
+dnl Verify defaults over dbus. Should be inline with default firewalld.conf.
+DBUS_GETALL([config], [config], 0, [dnl
+string "AllowZoneDrifting" : variant string "no"
+string "AutomaticHelpers" : variant string "no"
+string "CleanupOnExit" : variant string "no"
+string "DefaultZone" : variant string "public"
+string "FirewallBackend" : variant string "nftables"
+string "FlushAllOnReload" : variant string "yes"
+string "IPv6_rpfilter" : variant string m4_escape(["${EXPECTED_IPV6_RPFILTER_VALUE}"])
+string "IndividualCalls" : variant string "no"
+string "Lockdown" : variant string "no"
+string "LogDenied" : variant string "off"
+string "MinimalMark" : variant int32 100
+string "RFC3964_IPv4" : variant string "yes"
 ])
 
 m4_define([_helper], [

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -597,3 +597,27 @@ m4_define([NMCLI_CHECK], [
     NS_CHECK([PIPESTATUS0([nmcli $1], [TRIM_WHITESPACE])],
              [$2], [m4_strip([$3])], [m4_strip([$4])], [$5], [$6])
 ])
+
+m4_define([IF_HOST_SUPPORTS_NFT_RULE_INDEX], [
+    m4_if(nftables, FIREWALL_BACKEND, [
+        AT_DATA([./nft_rule_index.nft], [
+            add table inet firewalld_check_rule_index
+            add chain inet firewalld_check_rule_index foobar { type filter hook input priority 0 ; }
+            add rule inet firewalld_check_rule_index foobar tcp dport 1234 accept
+            add rule inet firewalld_check_rule_index foobar accept
+            insert rule inet firewalld_check_rule_index foobar index 1 udp dport 4321 accept
+])
+        NS_CHECK([nft -f ./nft_rule_index.nft])
+
+        if test "$( NS_CMD([nft list chain inet firewalld_check_rule_index foobar | head -n 5 |tail -n 1 | TRIM_WHITESPACE]) )" = "udp dport 4321 accept"; then
+            :
+            $1
+        else
+            :
+            $2
+        fi
+
+        NS_CHECK([rm ./nft_rule_index.nft])
+        NS_CHECK([nft delete table inet firewalld_check_rule_index])
+    ], [$1])
+])

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -221,6 +221,10 @@ m4_define([FWD_START_TEST], [
         fi
         echo "kill $DBUS_PID" >> ./cleanup_late
 
+        IF_HOST_SUPPORTS_NFT_RULE_INDEX([], [
+            AT_CHECK([sed -i 's/^IndividualCalls.*/IndividualCalls=yes/' ./firewalld.conf])
+        ])
+
         FWD_START_FIREWALLD
     ])
 ])

--- a/src/tests/regression/gh509.at
+++ b/src/tests/regression/gh509.at
@@ -1,3 +1,4 @@
+m4_if(nftables, FIREWALL_BACKEND, [
 FWD_START_TEST([missing firewalld.conf file])
 AT_KEYWORDS(gh509)
 
@@ -12,3 +13,4 @@ FWD_RESTART
 FWD_END_TEST([-e '/ERROR: Failed to load/d' dnl
               -e '/WARNING:.*No such file or directory:.*/d' dnl
               -e '/WARNING: Using fallback firewalld configuration settings/d'])
+])

--- a/src/tests/regression/rhbz1779835.at
+++ b/src/tests/regression/rhbz1779835.at
@@ -1,6 +1,8 @@
 FWD_START_TEST([ipv6 address with brackets])
 AT_KEYWORDS(rhbz1779835 ipset zone forward_port rich)
 
+IF_HOST_SUPPORTS_IPV6_RULES([], [AT_SKIP_IF([:])])
+
 dnl ipset
 FWD_CHECK([-q --permanent --new-ipset=foobar --type=hash:ip --family=inet6])
 FWD_CHECK([[-q --permanent --ipset foobar --add-entry='[1234::4321]']])


### PR DESCRIPTION
Re-enables running the testsuite in travis-ci. Because Bionic has too old a kernel the nftables tests must run with IndividualCalls=yes. This is due to the kernel missing support for NFTA_RULE_POSITION_ID which was added in kernel 5.1.

@todoleza, you may find this PR interesting. It required a few test fix ups.