### PR TITLE
Add libxslt to README for doc generation

### DIFF
--- a/README
+++ b/README
@@ -58,7 +58,7 @@ For use with Python 2:
 To be able to create man pages and documentation from docbook files:
 
   docbook-style-xsl
-
+  libxslt
 
 Use the usual autoconf/automake incantation to generate makefiles
 


### PR DESCRIPTION
Adds a missing dependency for doc generation to README.