### PR TITLE
fix(dbus): handle all zone settings in setZoneSettings2 method

### DIFF
--- a/src/firewall/client.py
+++ b/src/firewall/client.py
@@ -114,6 +114,8 @@ class FirewallClientZoneSettings(object):
     def getSettingsDict(self):
         settings = {}
         for key,value in zip(self.settings_name, self.settings):
+            if key == 'UNUSED':
+                continue
             settings[key] = value
         return settings
     @handle_exceptions
@@ -124,12 +126,33 @@ class FirewallClientZoneSettings(object):
     def getSettingsDbusDict(self):
         settings = {}
         for key,value,sig in zip(self.settings_name, self.settings, self.settings_dbus_type):
+            if key == 'UNUSED':
+                continue
             if type(value) is list:
                 settings[key] = dbus.Array(value, signature=sig)
             elif type(value) is dict:
                 settings[key] = dbus.Dictionary(value, signature=sig)
             else:
                 settings[key] = value
+        return settings
+
+    @handle_exceptions
+    def getRuntimeSettingsDict(self):
+        settings = self.getSettingsDict()
+        # These are not configurable at runtime:
+        del settings['version']
+        del settings['short']
+        del settings['description']
+        del settings['target']
+        return settings
+    @handle_exceptions
+    def getRuntimeSettingsDbusDict(self):
+        settings = self.getSettingsDbusDict()
+        # These are not configurable at runtime:
+        del settings['version']
+        del settings['short']
+        del settings['description']
+        del settings['target']
         return settings
 
     @handle_exceptions
@@ -3114,7 +3137,7 @@ class FirewallClient(object):
     @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setZoneSettings(self, zone, settings):
-        self.fw_zone.setZoneSettings2(zone, settings.getSettingsDbusDict())
+        self.fw_zone.setZoneSettings2(zone, settings.getRuntimeSettingsDbusDict())
 
     @slip.dbus.polkit.enable_proxy
     @handle_exceptions

--- a/src/tests/python/firewalld_config.py
+++ b/src/tests/python/firewalld_config.py
@@ -119,6 +119,9 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         self.assertEquals(self.fw.queryMasquerade(zone_name), zone_masquerade)
         self.assertEquals(self.fw.getForwardPorts(zone_name).sort(), zone_forward_ports.sort())
 
+        print ("Checking that settings can be roundtripped through setZoneSettings")
+        self.fw.setZoneSettings(zone_name, zone_settings)
+
         print ("Renaming zone to name that already exists")
         config_zone = self.fw.config().getZoneByName(zone_name)
         self.assertRaisesRegexp(Exception, 'NAME_CONFLICT', config_zone.rename, "home")


### PR DESCRIPTION
The new setZoneSettings2 D-Bus method was not handling a few zone
attributes which are plain attributes and do not have add/remove
methods: version, short, description, and target.

The problem was most evident with the client setZoneSettings method,
which was feeding back the complete zone settings, which was failing
like this:

    Traceback (most recent call last):
      File "src/firewall/server/decorators.py", line 67, in dbus_handle_exceptions
        return func(*args, **kwargs)
      File "src/firewall/server/firewalld.py", line 917, in setZoneSettings2
        self.fw.zone.set_config_with_settings_dict(zone, settings, sender)
      File "src/firewall/core/fw_zone.py", line 398, in set_config_with_settings_dict
        raise FirewallError(errors.INVALID_SETTING, "Unhandled setting type {} key {}".format(type(settings[key]), key))
    firewall.errors.FirewallError: INVALID_SETTING: Unhandled setting type <class 'dbus.String'> key description

This patch makes setZoneSettings2 handle the attributes that it was
previously ignoring, and adds test coverage for setZoneSettings in the
client API as well as a direct test case for the setZoneSettings2 D-Bus
method.

Fixes: 67d057508f81 ("improvement(dbus): new dict based APIs for zones")