### PR TITLE
fix(cli): unify indentation for forward-ports and rich rules

### DIFF
--- a/src/firewall/command.py
+++ b/src/firewall/command.py
@@ -430,7 +430,7 @@ class FirewallCommand(object):
         self.print_msg("  protocols: " + " ".join(sorted(protocols)))
         self.print_msg("  forward: %s" % ("yes" if forward else "no"))
         self.print_msg("  masquerade: %s" % ("yes" if masquerade else "no"))
-        self.print_msg("  forward-ports: " +
+        self.print_msg("  forward-ports: " + ("\n\t" if forward_ports else "") +
                        "\n\t".join(["port=%s:proto=%s:toport=%s:toaddr=%s" % \
                                     (port, proto, toport, toaddr)
                                     for (port, proto, toport, toaddr) in \
@@ -439,8 +439,8 @@ class FirewallCommand(object):
                        " ".join(["%s/%s" % (port[0], port[1])
                                  for port in source_ports]))
         self.print_msg("  icmp-blocks: " + " ".join(icmp_blocks))
-        self.print_msg("  rich rules: \n\t" + "\n\t".join(
-                            sorted(rules, key=rich_rule_sorted_key)))
+        self.print_msg("  rich rules: " + ("\n\t" if rules else "") +
+                            "\n\t".join(sorted(rules, key=rich_rule_sorted_key)))
 
     def print_service_info(self, service, settings):
         ports = settings.getPorts()


### PR DESCRIPTION
Unify indentation for forward-ports and rich rules in the CLI zone listing.
Do not insert redundant newlines and tabulation if there are no forward-ports or rich rules.

Actual results (currently):
```
$ sudo firewall-cmd --list-all-zones
...

external (active)
  target: default
  icmp-block-inversion: no
  interfaces: 
  sources: 
  services: ssh
  ports: 
  protocols: 
  masquerade: yes
  forward-ports: port=22:proto=tcp:toport=:toaddr=192.168.2.3
	port=80:proto=tcp:toport=:toaddr=192.168.2.3
  source-ports: 
  icmp-blocks: 
  rich rules: 
	rule protocol value="ipv6-icmp" accept
	rule priority="32767" reject

...
```

Expected results (after the patch):
```
$ sudo firewall-cmd --list-all-zones
...

external (active)
  target: ACCEPT
  icmp-block-inversion: no
  interfaces: 
  sources: 
  services: ssh
  ports: 
  protocols: 
  masquerade: yes
  forward-ports: 
	port=22:proto=tcp:toport=:toaddr=192.168.2.3
	port=80:proto=tcp:toport=:toaddr=192.168.2.3
  source-ports: 
  icmp-blocks: 
  rich rules: 
	rule protocol value="ipv6-icmp" accept
	rule priority="32767" reject

...
```