### PR TITLE
freeipa-trust: update dynamic DCE RPC ports

### DIFF
--- a/config/services/freeipa-trust.xml
+++ b/config/services/freeipa-trust.xml
@@ -9,6 +9,6 @@
   <port protocol="udp" port="389"/>
   <port protocol="tcp" port="445"/>
   <port protocol="udp" port="445"/>
-  <port protocol="tcp" port="1024-1300"/>
+  <port protocol="tcp" port="49152-65535"/><!-- Dynamic RPC Ports -->
   <port protocol="tcp" port="3268"/>
 </service>


### PR DESCRIPTION
Samba did change DCE RPC dynamic port range to 49152-65535 with version 4.7.

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>