### PR TITLE
improvement(service): IPsec: Update description and add TCP port 4500

### DIFF
--- a/config/services/ipsec.xml
+++ b/config/services/ipsec.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>IPsec</short>
-  <description>Internet Protocol Security (IPsec) incorporates security for network transmissions directly into the Internet Protocol (IP). IPsec provides methods for both encrypting data and authentication for the host or network it sends to. If you plan to use a vpnc server or FreeS/WAN, do not disable this option.</description>
+  <description>Internet Protocol Security (IPsec) is the standarized IETF VPN architecture defined in RFC 4301. IPsec is negotiated using the IKEv1 (RFC 2409) or IKEv2 (RFC 7296) protocol, which in itself uses encryption and authentication. IPsec provides Internet Protocol (IP) packet encryption and authentication. Both IKE and IPsec can be encapsulated in UDP (RFC 3948) or TCP (RFC 8229 to make it easier to traverse NAT. Enabling this service will enable IKE, IPsec and their encapsulation protocols and ports. Note that IKE and IPsec can also be configured to use non-default ports, but this is not common practise.</description>
   <port protocol="ah" port=""/>
   <port protocol="esp" port=""/>
   <port protocol="udp" port="500"/>
   <port protocol="udp" port="4500"/>
+  <port protocol="tcp" port="4500"/>
 </service>


### PR DESCRIPTION
IKE and IPsec over TCP is defined in RFC 8229. It specifically mentions
no ports to allow administrators to configure any port to prevent being
blocked by networks.

However, most IKE/IPsec blocking seems to come from unwanted accidental
UDP blocks, so any TCP would usually ensures IPsec can still work on
such networks. The default is therefor to pick the same TCP port as IKE
and IPsec over UDP uses, port 4500.