### PR TITLE
fix(rich): use correct error code for invalid priority

### DIFF
--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -382,7 +382,7 @@ class Rich_Rule(object):
                     try:
                         self.priority = int(attr_value)
                     except ValueError:
-                        raise FirewallError(errors.INVALID_RULE, "invalid 'priority' attribute value '%s'." % attr_value)
+                        raise FirewallError(errors.INVALID_PRIORITY, "invalid 'priority' attribute value '%s'." % attr_value)
                 elif attr_name:
                     if attr_name == 'protocol':
                         err_msg = "wrong 'protocol' usage. Use either 'rule protocol value=...' or  'rule [forward-]port protocol=...'."

--- a/src/tests/regression/rhbz1689429.at
+++ b/src/tests/regression/rhbz1689429.at
@@ -1,11 +1,11 @@
 FWD_START_TEST([rich rule invalid priority])
 AT_KEYWORDS(rich rhbz1689429)
 
-FWD_CHECK([--add-rich-rule='rule priority=foo accept'], 122, [],
-	  [Error: INVALID_RULE: invalid 'priority' attribute value 'foo'.
+FWD_CHECK([--add-rich-rule='rule priority=foo accept'], 139, [],
+	  [Error: INVALID_PRIORITY: invalid 'priority' attribute value 'foo'.
 ])
-FWD_CHECK([--permanent --add-rich-rule='rule priority=foo accept'], 122, [],
-	  [Error: INVALID_RULE: invalid 'priority' attribute value 'foo'.
+FWD_CHECK([--permanent --add-rich-rule='rule priority=foo accept'], 139, [],
+	  [Error: INVALID_PRIORITY: invalid 'priority' attribute value 'foo'.
 ])
 FWD_RELOAD
 


### PR DESCRIPTION
Fixes: 3a0e79b1cfe4 ("fix: core: rich: Catch ValueError on non-numeric priority values")