### PR TITLE
fix(config): Fix RPM macros to test if firewall-cmd is executable

### DIFF
--- a/config/macros.firewalld
+++ b/config/macros.firewalld
@@ -2,5 +2,5 @@
 
 # put this into %post otherwise firewalld won't load new service/zone file
 %firewalld_reload() \
-test -f %{_bindir}/firewall-cmd && firewall-cmd --reload --quiet || : \
+test -x %{_bindir}/firewall-cmd && firewall-cmd --reload --quiet || : \
 %{nil}


### PR DESCRIPTION
While unlikely, we cannot exactly predict how a running system has its
permissions set, but we can guard against it to prevent weird failures.

This should have no appreciable impact, but ensures that we do not try
to run `firewall-cmd` if it is not actually executable.