### PR TITLE
docs(dbus): fix invalid method names.

### DIFF
--- a/doc/xml/firewalld.dbus.xml
+++ b/doc/xml/firewalld.dbus.xml
@@ -556,7 +556,7 @@
             </listitem>
           </varlistentry>
           <varlistentry id="FirewallD1.ipset.Methods.queryEntry">
-            <term><methodname>queryService</methodname>(s: ipset, s: entry) &rarr; b</term>
+            <term><methodname>queryEntry</methodname>(s: ipset, s: entry) &rarr; b</term>
             <listitem>
               <para>
 		Return whether <replaceable>entry</replaceable> has been added to <replaceable>ipset</replaceable>.
@@ -568,7 +568,7 @@
             </listitem>
           </varlistentry>
           <varlistentry id="FirewallD1.ipset.Methods.queryIPSet">
-            <term><methodname>queryService</methodname>(s: ipset) &rarr; b</term>
+            <term><methodname>queryIPSet</methodname>(s: ipset) &rarr; b</term>
             <listitem>
               <para>
 		Return whether <replaceable>ipset</replaceable> is defined in runtime configuration.


### PR DESCRIPTION
Replace invalid method names for both 'queryEntry' and 'queryIPSet'.

fixes #693 