### PR TITLE
Update rhbz1871298 to fix a timeout on slow arm architectures (See: #691)

### DIFF
--- a/src/tests/regression/rhbz1871298.at
+++ b/src/tests/regression/rhbz1871298.at
@@ -13,6 +13,6 @@ NS_CHECK([echo "</zone>" >> ./zones/foobar.xml])
 if test "x${FIREWALLD_DEFAULT_CONFIG}" != x ; then
     FIREWALL_OFFLINE_CMD_ARGS+=" --default-config ${FIREWALLD_DEFAULT_CONFIG}"
 fi
-NS_CHECK([timeout 45 firewall-offline-cmd --system-config ./ $FIREWALL_OFFLINE_CMD_ARGS --check-config], 0, [ignore])
+NS_CHECK([timeout 75 firewall-offline-cmd --system-config ./ $FIREWALL_OFFLINE_CMD_ARGS --check-config], 0, [ignore])
 
 FWD_END_TEST


### PR DESCRIPTION
Some architectures, such as arm64, cannot finish the test in time, relaxing a little bit the timeout helps them in figuring out the test result

Closes: #691 
Look e.g. https://autopkgtest.ubuntu.com/packages/f/firewalld/groovy/arm64
https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-groovy/groovy/arm64/f/firewalld/20201005_090931_e08a1@/log.gz