### PR TITLE
fix(policy): generic accept of established connections in OUTPUT

### DIFF
--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -757,6 +757,7 @@ class ip4tables(object):
         default_rules["filter"] += [
             "-N OUTPUT_direct",
 
+            "-A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT",
             "-A OUTPUT -o lo -j ACCEPT",
             "-A OUTPUT -j OUTPUT_direct",
         ]
@@ -1515,7 +1516,7 @@ class ip6tables(ip4tables):
                               "--log-prefix", "\"RFC3964_IPv4_REJECT: \""])
 
         # Inject into FORWARD and OUTPUT chains
-        rules.append(["-t", "filter", "-I", "OUTPUT", "3",
+        rules.append(["-t", "filter", "-I", "OUTPUT", "4",
                       "-j", chain_name])
         rules.append(["-t", "filter", "-I", "FORWARD", "4",
                       "-j", chain_name])

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -689,6 +689,13 @@ class nftables(object):
         # filter, OUTPUT
         default_rules.append({"add": {"rule":  {"family": "inet",
                                                 "table": TABLE_NAME,
+                                                "chain": "filter_%s" % "OUTPUT",
+                                                "expr": [{"match": {"left": {"ct": {"key": "state"}},
+                                                                    "op": "in",
+                                                                    "right": {"set": ["established", "related"]}}},
+                                                         {"accept": None}]}}})
+        default_rules.append({"add": {"rule":  {"family": "inet",
+                                                "table": TABLE_NAME,
                                                 "chain": "filter_OUTPUT",
                                                 "expr": [{"match": {"left": {"meta": {"key": "oifname"}},
                                                           "op": "==",
@@ -1733,7 +1740,7 @@ class nftables(object):
         rules.append({"add": {"rule": {"family": "inet",
                                        "table": TABLE_NAME,
                                        "chain": "filter_OUTPUT",
-                                       "index": 0,
+                                       "index": 1,
                                        "expr": expr_fragments}}})
         rules.append({"add": {"rule": {"family": "inet",
                                        "table": TABLE_NAME,

--- a/src/tests/features/rfc3964_ipv4.at
+++ b/src/tests/features/rfc3964_ipv4.at
@@ -26,6 +26,7 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
 NFT_LIST_RULES([inet], [filter_OUTPUT], 0, [dnl
     table inet firewalld {
     chain filter_OUTPUT {
+    ct state established,related accept
     oifname "lo" accept
     ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 type addr-unreachable
     jump filter_OUTPUT_POLICIES_pre
@@ -68,6 +69,7 @@ IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
 IP6TABLES_LIST_RULES([filter], [OUTPUT], 0, [dnl
+    ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED
     ACCEPT all ::/0 ::/0
     OUTPUT_direct all ::/0 ::/0
     RFC3964_IPv4 all ::/0 ::/0
@@ -98,6 +100,7 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
 NFT_LIST_RULES([inet], [filter_OUTPUT], 0, [dnl
     table inet firewalld {
     chain filter_OUTPUT {
+    ct state established,related accept
     oifname "lo" accept
     jump filter_OUTPUT_POLICIES_pre
     jump filter_OUTPUT_POLICIES_post
@@ -120,6 +123,7 @@ IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
 IP6TABLES_LIST_RULES([filter], [OUTPUT], 0, [dnl
+    ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED
     ACCEPT all ::/0 ::/0
     OUTPUT_direct all ::/0 ::/0
     OUTPUT_POLICIES_pre all ::/0 ::/0


### PR DESCRIPTION
Now that policies allow filtering on the OUTPUT we must also generically
accept established connections in OUTPUT. Otherwise a policy that blocks
all OUTPUT will cause even selectively allowed traffic to drop. This is
because "allows" match on "ct state new", which only matches on the
_first_ packet.

Fixes: #705