### PR TITLE
docs: Add issue templates for bug fixes and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report
+about: Report a bug encountered while using Firewalld
+---
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Firewalld Version (if Fedora based `dnf info firewalld` or commit hash if developing from git `git log -n1 --format=format:"%H"`):
+- Firewalld Backend (`cat /etc/firewalld/firewalld.conf | grep FirewallBackend`): 
+- OS (e.g: `cat /etc/os-release`):
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,8 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to Firewalld
+---
+
+**What would you like to be added**:
+
+**Why is this needed**:


### PR DESCRIPTION
These issue templates will be useful for people wanting to make bug reports and feature requests, so they know how much information is needed, and it's helpful for developers to more easily replicate bugs.