### PR TITLE
fix(rich): limit table to strip non-printables to C0 and C1

### DIFF
--- a/src/firewall/functions.py
+++ b/src/firewall/functions.py
@@ -30,7 +30,6 @@ __all__ = [ "getPortID", "getPortRange", "portStr", "getServiceName",
             "max_policy_name_len", "checkTcpMssClamp", 
             "stripNonPrintableCharacters"]
 
-import sys
 import socket
 import os
 import os.path
@@ -42,7 +41,12 @@ from firewall.core.logger import log
 from firewall.config import FIREWALLD_TEMPDIR, FIREWALLD_PIDFILE
 
 NOPRINT_TRANS_TABLE = {
-    i: None for i in range(0, sys.maxunicode + 1) if not chr(i).isprintable()
+    # Limit to C0 and C1 code points. Building entries for all unicode code
+    # points requires too much memory.
+    # C0 = [0, 31]
+    # C1 = [127, 159]
+    #
+    i: None for i in range(0, 160) if not (i > 31 and i < 127)
 }
 
 def getPortID(port):


### PR DESCRIPTION
Generating the table was taking an unreasonable amount of memory.
Stripping C0 and C1 should cover most scenarios while limiting memory
usage.

Fixes: ac5960856991 ("fix(rich): non-printable characters removed from rich rules")