### PR TITLE
feat(service): Allow QUIC connections for syncthing

### DIFF
--- a/config/services/syncthing.xml
+++ b/config/services/syncthing.xml
@@ -3,5 +3,6 @@
   <short>Syncthing</short>
   <description>Syncthing is a Peer-to-Peer file synchronization service. Enable this option, if you plan to run the Synthing service.</description>
   <port protocol="tcp" port="22000"/>
+  <port protocol="udp" port="22000"/>
   <port protocol="udp" port="21027"/>
 </service>


### PR DESCRIPTION
Syncthing also accepts UDP based QUIC connections by default.