### PR TITLE
docs(zone): fix remaining usage of --list={services,icpmtypes}

### DIFF
--- a/doc/xml/policy_zone_descriptions.xml
+++ b/doc/xml/policy_zone_descriptions.xml
@@ -50,7 +50,7 @@
                 <para>
                     The name of the service to be enabled. To get a list of
                     valid service names <command>firewall-cmd
-                    --list=services</command> can be used.
+                    --get-services</command> can be used.
                 </para>
             </listitem>
         </varlistentry>
@@ -122,7 +122,7 @@
                 <para>
                     The name of the Internet Control Message Protocol (ICMP)
                     type to be blocked. To get a list of valid ICMP types
-                    <command>firewall-cmd --list=icmptypes</command> can be
+                    <command>firewall-cmd --get-icmptypes</command> can be
                     used.
                 </para>
             </listitem>


### PR DESCRIPTION
Fixes: 4095551e2679 ("Fixed usage: direct options are not related to zones, addes missing direct options, fixed ports in forward-port entry.")