### PR TITLE
chore: drop dependency on python-decorator

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,6 @@ These are the runtime dependencies:
   iptables (optional)
   linux >= 5.3
   python3-dbus
-  python3-decorator
   python3-gobject
   python3-nftables >= 0.9.4
   python3-slip-dbus

--- a/firewalld.spec
+++ b/firewalld.spec
@@ -33,7 +33,6 @@ firewall with a D-Bus interface.
 Summary: Python3 bindings for firewalld
 Requires: python3-dbus
 Requires: python3-slip-dbus
-Requires: python3-decorator
 Requires: python3-nftables
 %if (0%{?fedora} >= 23 || 0%{?rhel} >= 8)
 Requires: python3-gobject-base


### PR DESCRIPTION
Modern python has functools.wraps() which is sufficient. One less
dependency.

Fixes: rhbz 1944206