### PR TITLE
feat(service): Add WireGuard service definition

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -287,6 +287,7 @@ CONFIG_FILES = \
 	services/vnc-server.xml \
 	services/wbem-http.xml \
 	services/wbem-https.xml \
+	services/wireguard.xml \
 	services/wsman.xml \
 	services/wsmans.xml \
 	services/xdmcp.xml \

--- a/config/services/wireguard.xml
+++ b/config/services/wireguard.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>WireGuard</short>
+  <description>WireGuard is the simple, fast and modern VPN. The port needs to be open if a peer has this host explicitly configured as endpoint.</description>
+  <port protocol="udp" port="51820"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -220,6 +220,7 @@ config/services/vdsm.xml
 config/services/vnc-server.xml
 config/services/wbem-https.xml
 config/services/wbem-http.xml
+config/services/wireguard.xml
 config/services/wsmans.xml
 config/services/wsman.xml
 config/services/xdmcp.xml


### PR DESCRIPTION
Of course, one can set up wireguard to listen on any other port.
However, 51820 is a good default that is used in many places.