### PR TITLE
ci(github): cleanup no longer needed dependencies

### DIFF
--- a/.github/workflows/source-checks.yml
+++ b/.github/workflows/source-checks.yml
@@ -9,7 +9,7 @@ jobs:
         iptables libdbus-1-dev libgirepository1.0-dev libglib2.0-dev \
         libxml2-utils nftables pkg-config python3-nftables xsltproc
       pip-dependencies: |
-        decorator dbus-python PyGObject flake8
+        dbus-python PyGObject flake8
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -9,7 +9,7 @@ jobs:
         libgirepository1.0-dev libglib2.0-dev libxml2-utils network-manager \
         pkg-config 
       pip-dependencies: |
-        decorator dbus-python PyGObject six
+        dbus-python PyGObject six
 
     name: testsuite ${{ join(matrix.*, ' ') }}
     runs-on: ubuntu-20.04


### PR DESCRIPTION
six hasn't been needed since dropping python2 support in 74dd57ed3df2
("chore(README): drop python2 support") and following commits.

decorator hasn't been needed since it was dropped in e7fbb41ae113
("chore: drop dependency on python-decorator").