### PR TITLE
fix(applet): Show a basic tooltip instead of HTML in system tray

### DIFF
--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -854,17 +854,13 @@ class TrayApplet(QtWidgets.QSystemTrayIcon):
 
     def update_tooltip(self):
         if self.get_mode() == "error":
-            self.setToolTip("<big><b>" + \
-                            _("No connection to firewall daemon") + \
-                            "</b></big>")
+            self.setToolTip(_("No connection to firewall daemon"))
             return
 
         messages = [ ]
 
         if self.panicAction.isChecked():
-            messages.append("<big><b>" + \
-                            _("All network traffic is blocked.") + \
-                            "</b></big>")
+            messages.append(_("All network traffic is blocked."))
 
         if self.default_zone:
             messages.append(_("Default Zone: '%s'") % self.default_zone)
@@ -903,8 +899,8 @@ class TrayApplet(QtWidgets.QSystemTrayIcon):
             messages.append(_("No Active Zones."))
         messages.extend(self.tooltip_messages)
 
-        tooltip = "<nobr>"+"</nobr><br><nobr>".join(messages)+"</nobr>"
-        self.setToolTip("<font size=\"3\">"+tooltip+"</font>")
+        tooltip = "\n".join(messages)
+        self.setToolTip(tooltip)
         self.set_icon()
 
     def show(self):


### PR DESCRIPTION
Removes the HTML markup tags in the Qt applet tooltip, as they cannot be rendered in KDE now and will produce garbled output.

Seems that other projects are also resolving this problem similarly by removing the HTML tags. 
See https://github.com/clementine-player/Clementine/pull/6745 and https://github.com/qbittorrent/qBittorrent/commit/89277a2f52b2bcade3798f85f262dc4e9724667c

Related discussions in KDE community can be found at: https://bugs.kde.org/show_bug.cgi?id=422616

Resolves #668 
Resolves #701