### PR TITLE
drop dependency python-slip

### DIFF
--- a/.github/workflows/source-checks.yml
+++ b/.github/workflows/source-checks.yml
@@ -9,7 +9,7 @@ jobs:
         iptables libdbus-1-dev libgirepository1.0-dev libglib2.0-dev \
         libxml2-utils nftables pkg-config python3-nftables xsltproc
       pip-dependencies: |
-        decorator dbus-python PyGObject flake8
+        dbus-python PyGObject flake8
 
     runs-on: ubuntu-20.04
 
@@ -36,15 +36,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ${{ env.pip-dependencies }}
-
-      - name: install python-slip-dbus
-        run: |
-          cd /tmp
-          wget --retry-connrefused https://github.com/nphilipp/python-slip/releases/download/python-slip-0.6.5/python-slip-0.6.5.tar.bz2
-          tar xf python-slip-0.6.5.tar.bz2
-          cd python-slip-0.6.5
-          make
-          python ./setup.py install
 
       - name: build firewalld
         run: |

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -9,7 +9,7 @@ jobs:
         libgirepository1.0-dev libglib2.0-dev libxml2-utils network-manager \
         pkg-config 
       pip-dependencies: |
-        decorator dbus-python PyGObject six
+        dbus-python PyGObject
 
     name: testsuite ${{ join(matrix.*, ' ') }}
     runs-on: ubuntu-20.04
@@ -57,15 +57,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ${{ env.pip-dependencies }}
-
-      - name: install python-slip-dbus
-        run: |
-          cd /tmp
-          wget --retry-connrefused https://github.com/nphilipp/python-slip/releases/download/python-slip-0.6.5/python-slip-0.6.5.tar.bz2
-          tar xf python-slip-0.6.5.tar.bz2
-          cd python-slip-0.6.5
-          make
-          python ./setup.py install
 
       - name: install nftables build dependencies
         run: |

--- a/README
+++ b/README
@@ -36,7 +36,6 @@ These are the runtime dependencies:
   python3-dbus
   python3-gobject
   python3-nftables >= 0.9.4
-  python3-slip-dbus
 
 Note: python2 is _not_ supported.
 

--- a/firewalld.spec
+++ b/firewalld.spec
@@ -32,7 +32,6 @@ firewall with a D-Bus interface.
 %package -n python3-firewall
 Summary: Python3 bindings for firewalld
 Requires: python3-dbus
-Requires: python3-slip-dbus
 Requires: python3-nftables
 %if (0%{?fedora} >= 23 || 0%{?rhel} >= 8)
 Requires: python3-gobject-base

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -299,6 +299,7 @@ src/firewall/server/config.py
 src/firewall/server/config_service.py
 src/firewall/server/config_zone.py
 src/firewall/server/config_policy.py
+src/firewall/server/dbus.py
 src/firewall/server/decorators.py
 src/firewall/server/firewalld.py
 src/firewall/server/__init__.py

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -68,6 +68,7 @@ nobase_dist_python_DATA = \
 	firewall/server/config_service.py \
 	firewall/server/config_zone.py \
 	firewall/server/config_policy.py \
+	firewall/server/dbus.py \
 	firewall/server/decorators.py \
 	firewall/server/firewalld.py \
 	firewall/server/__init__.py \

--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -38,7 +38,6 @@ from firewall.core.fw_nm import nm_is_imported, nm_get_zone_of_connection, \
                                 nm_get_connections
 from firewall.core.watcher import Watcher
 from firewall.client import FirewallClient
-import slip.dbus
 import dbus
 import signal
 
@@ -542,12 +541,7 @@ class TrayApplet(QtWidgets.QSystemTrayIcon):
         # connect to firewalld
 
         DBusQtMainLoop(set_as_default=True)
-        try:
-            self.bus = slip.dbus.SystemBus()
-            self.bus.default_timeout = None
-        except Exception as msg:
-            print("Not using slip", msg)
-            self.bus = dbus.SystemBus()
+        self.bus = dbus.SystemBus()
 
         if nm_is_imported():
             self.bus.add_signal_receiver(

--- a/src/firewall/client.py
+++ b/src/firewall/client.py
@@ -19,14 +19,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from gi.repository import GLib, GObject
-
-# force use of pygobject3 in python-slip
-import sys
-sys.modules['gobject'] = GObject
+from gi.repository import GLib
 
 import dbus.mainloop.glib
-import slip.dbus
 import functools
 
 from firewall import config
@@ -307,21 +302,18 @@ class FirewallClientZoneSettings(object):
     @handle_exceptions
     def setIcmpBlockInversion(self, flag):
         self.settings[15] = flag
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addIcmpBlockInversion(self):
         if not self.settings[15]:
             self.settings[15] = True
         else:
             FirewallError(errors.ALREADY_ENABLED, "icmp-block-inversion")
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeIcmpBlockInversion(self):
         if self.settings[15]:
             self.settings[15] = False
         else:
             FirewallError(errors.NOT_ENABLED, "icmp-block-inversion")
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryIcmpBlockInversion(self):
         return self.settings[15]
@@ -332,21 +324,18 @@ class FirewallClientZoneSettings(object):
     @handle_exceptions
     def setForward(self, forward):
         self.settings[16] = forward
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addForward(self):
         if not self.settings[16]:
             self.settings[16] = True
         else:
             FirewallError(errors.ALREADY_ENABLED, "forward")
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeForward(self):
         if self.settings[16]:
             self.settings[16] = False
         else:
             FirewallError(errors.NOT_ENABLED, "forward")
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryForward(self):
         return self.settings[16]
@@ -357,21 +346,18 @@ class FirewallClientZoneSettings(object):
     @handle_exceptions
     def setMasquerade(self, masquerade):
         self.settings[8] = masquerade
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addMasquerade(self):
         if not self.settings[8]:
             self.settings[8] = True
         else:
             FirewallError(errors.ALREADY_ENABLED, "masquerade")
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeMasquerade(self):
         if self.settings[8]:
             self.settings[8] = False
         else:
             FirewallError(errors.NOT_ENABLED, "masquerade")
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryMasquerade(self):
         return self.settings[8]
@@ -498,326 +484,267 @@ class FirewallClientConfigZone(object):
         #TODO: check interface version and revision (need to match client 
         # version)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_property(self, prop):
         return dbus_to_python(self.fw_properties.Get(
             config.dbus.DBUS_INTERFACE_CONFIG_ZONE, prop))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_properties(self):
         return dbus_to_python(self.fw_properties.GetAll(
             config.dbus.DBUS_INTERFACE_CONFIG_ZONE))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def set_property(self, prop, value):
         self.fw_properties.Set(config.dbus.DBUS_INTERFACE_CONFIG_ZONE,
                                prop, value)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSettings(self):
         return FirewallClientZoneSettings(dbus_to_python(self.fw_zone.getSettings2()))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def update(self, settings):
         self.fw_zone.update2(settings.getSettingsDbusDict())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def loadDefaults(self):
         self.fw_zone.loadDefaults()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def remove(self):
         self.fw_zone.remove()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def rename(self, name):
         self.fw_zone.rename(name)
 
     # version
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getVersion(self):
         return self.fw_zone.getVersion()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setVersion(self, version):
         self.fw_zone.setVersion(version)
 
     # short
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getShort(self):
         return self.fw_zone.getShort()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setShort(self, short):
         self.fw_zone.setShort(short)
 
     # description
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDescription(self):
         return self.fw_zone.getDescription()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDescription(self, description):
         self.fw_zone.setDescription(description)
 
     # target
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getTarget(self):
         return self.fw_zone.getTarget()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setTarget(self, target):
         self.fw_zone.setTarget(target)
 
     # service
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getServices(self):
         return self.fw_zone.getServices()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setServices(self, services):
         self.fw_zone.setServices(services)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addService(self, service):
         self.fw_zone.addService(service)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeService(self, service):
         self.fw_zone.removeService(service)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryService(self, service):
         return self.fw_zone.queryService(service)
 
     # port
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPorts(self):
         return self.fw_zone.getPorts()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setPorts(self, ports):
         self.fw_zone.setPorts(ports)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addPort(self, port, protocol):
         self.fw_zone.addPort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removePort(self, port, protocol):
         self.fw_zone.removePort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryPort(self, port, protocol):
         return self.fw_zone.queryPort(port, protocol)
 
     # protocol
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getProtocols(self):
         return self.fw_zone.getProtocols()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setProtocols(self, protocols):
         self.fw_zone.setProtocols(protocols)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addProtocol(self, protocol):
         self.fw_zone.addProtocol(protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeProtocol(self, protocol):
         self.fw_zone.removeProtocol(protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryProtocol(self, protocol):
         return self.fw_zone.queryProtocol(protocol)
 
     # source-port
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSourcePorts(self):
         return self.fw_zone.getSourcePorts()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setSourcePorts(self, ports):
         self.fw_zone.setSourcePorts(ports)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addSourcePort(self, port, protocol):
         self.fw_zone.addSourcePort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeSourcePort(self, port, protocol):
         self.fw_zone.removeSourcePort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def querySourcePort(self, port, protocol):
         return self.fw_zone.querySourcePort(port, protocol)
 
     # icmp block
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIcmpBlocks(self):
         return self.fw_zone.getIcmpBlocks()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setIcmpBlocks(self, icmptypes):
         self.fw_zone.setIcmpBlocks(icmptypes)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addIcmpBlock(self, icmptype):
         self.fw_zone.addIcmpBlock(icmptype)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeIcmpBlock(self, icmptype):
         self.fw_zone.removeIcmpBlock(icmptype)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryIcmpBlock(self, icmptype):
         return self.fw_zone.queryIcmpBlock(icmptype)
 
     # icmp-block-inversion
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIcmpBlockInversion(self):
         return self.fw_zone.getIcmpBlockInversion()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setIcmpBlockInversion(self, inversion):
         self.fw_zone.setIcmpBlockInversion(inversion)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addIcmpBlockInversion(self):
         self.fw_zone.addIcmpBlockInversion()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeIcmpBlockInversion(self):
         self.fw_zone.removeIcmpBlockInversion()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryIcmpBlockInversion(self):
         return self.fw_zone.queryIcmpBlockInversion()
 
     # forward
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getForward(self):
         return self.fw_zone.getSettings2()["forward"]
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setForward(self, forward):
         self.fw_zone.update2({"forward": forward})
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addForward(self):
         self.fw_zone.update2({"forward": True})
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeForward(self):
         self.fw_zone.update2({"forward": False})
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryForward(self):
         return self.fw_zone.getSettings2()["forward"]
 
     # masquerade
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getMasquerade(self):
         return self.fw_zone.getMasquerade()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setMasquerade(self, masquerade):
         self.fw_zone.setMasquerade(masquerade)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addMasquerade(self):
         self.fw_zone.addMasquerade()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeMasquerade(self):
         self.fw_zone.removeMasquerade()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryMasquerade(self):
         return self.fw_zone.queryMasquerade()
 
     # forward port
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getForwardPorts(self):
         return self.fw_zone.getForwardPorts()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setForwardPorts(self, ports):
         self.fw_zone.setForwardPorts(ports)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addForwardPort(self, port, protocol, toport, toaddr):
         if toport is None:
@@ -826,7 +753,6 @@ class FirewallClientConfigZone(object):
             toaddr = ''
         self.fw_zone.addForwardPort(port, protocol, toport, toaddr)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeForwardPort(self, port, protocol, toport, toaddr):
         if toport is None:
@@ -835,7 +761,6 @@ class FirewallClientConfigZone(object):
             toaddr = ''
         self.fw_zone.removeForwardPort(port, protocol, toport, toaddr)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryForwardPort(self, port, protocol, toport, toaddr):
         if toport is None:
@@ -846,81 +771,66 @@ class FirewallClientConfigZone(object):
 
     # interface
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getInterfaces(self):
         return self.fw_zone.getInterfaces()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setInterfaces(self, interfaces):
         self.fw_zone.setInterfaces(interfaces)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addInterface(self, interface):
         self.fw_zone.addInterface(interface)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeInterface(self, interface):
         self.fw_zone.removeInterface(interface)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryInterface(self, interface):
         return self.fw_zone.queryInterface(interface)
 
     # source
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSources(self):
         return self.fw_zone.getSources()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setSources(self, sources):
         self.fw_zone.setSources(sources)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addSource(self, source):
         self.fw_zone.addSource(source)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeSource(self, source):
         self.fw_zone.removeSource(source)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def querySource(self, source):
         return self.fw_zone.querySource(source)
 
     # rich rule
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getRichRules(self):
         return self.fw_zone.getRichRules()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setRichRules(self, rules):
         self.fw_zone.setRichRules(rules)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addRichRule(self, rule):
         self.fw_zone.addRichRule(rule)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeRichRule(self, rule):
         self.fw_zone.removeRichRule(rule)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryRichRule(self, rule):
         return self.fw_zone.queryRichRule(rule)
@@ -1129,21 +1039,18 @@ class FirewallClientPolicySettings(object):
     @handle_exceptions
     def setMasquerade(self, masquerade):
         self.settings["masquerade"] = masquerade
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addMasquerade(self):
         if not self.settings["masquerade"]:
             self.settings["masquerade"] = True
         else:
             FirewallError(errors.ALREADY_ENABLED, "masquerade")
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeMasquerade(self):
         if self.settings["masquerade"]:
             self.settings["masquerade"] = False
         else:
             FirewallError(errors.NOT_ENABLED, "masquerade")
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryMasquerade(self):
         return self.settings["masquerade"]
@@ -1272,45 +1179,37 @@ class FirewallClientConfigPolicy(object):
         self.fw_properties = dbus.Interface(
             self.dbus_obj, dbus_interface='org.freedesktop.DBus.Properties')
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_property(self, prop):
         return dbus_to_python(self.fw_properties.Get(
             config.dbus.DBUS_INTERFACE_CONFIG_POLICY, prop))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_properties(self):
         return dbus_to_python(self.fw_properties.GetAll(
             config.dbus.DBUS_INTERFACE_CONFIG_POLICY))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def set_property(self, prop, value):
         self.fw_properties.Set(config.dbus.DBUS_INTERFACE_CONFIG_POLICY,
                                prop, value)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSettings(self):
         return FirewallClientPolicySettings(dbus_to_python(self.fw_policy.getSettings()))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def update(self, settings):
         self.fw_policy.update(settings.getSettingsDbusDict())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def loadDefaults(self):
         self.fw_policy.loadDefaults()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def remove(self):
         self.fw_policy.remove()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def rename(self, name):
         self.fw_policy.rename(name)
@@ -1666,109 +1565,90 @@ class FirewallClientConfigIPSet(object):
         self.fw_properties = dbus.Interface(
             self.dbus_obj, dbus_interface='org.freedesktop.DBus.Properties')
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_property(self, prop):
         return dbus_to_python(self.fw_properties.Get(
             config.dbus.DBUS_INTERFACE_CONFIG_IPSET, prop))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_properties(self):
         return dbus_to_python(self.fw_properties.GetAll(
             config.dbus.DBUS_INTERFACE_CONFIG_IPSET))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def set_property(self, prop, value):
         self.fw_properties.Set(config.dbus.DBUS_INTERFACE_CONFIG_IPSET,
                                prop, value)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSettings(self):
         return FirewallClientIPSetSettings(list(dbus_to_python(\
                     self.fw_ipset.getSettings())))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def update(self, settings):
         self.fw_ipset.update(tuple(settings.settings))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def loadDefaults(self):
         self.fw_ipset.loadDefaults()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def remove(self):
         self.fw_ipset.remove()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def rename(self, name):
         self.fw_ipset.rename(name)
 
     # version
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getVersion(self):
         return self.fw_ipset.getVersion()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setVersion(self, version):
         self.fw_ipset.setVersion(version)
 
     # short
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getShort(self):
         return self.fw_ipset.getShort()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setShort(self, short):
         self.fw_ipset.setShort(short)
 
     # description
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDescription(self):
         return self.fw_ipset.getDescription()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDescription(self, description):
         self.fw_ipset.setDescription(description)
 
     # entry
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getEntries(self):
         return self.fw_ipset.getEntries()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setEntries(self, entries):
         self.fw_ipset.setEntries(entries)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addEntry(self, entry):
         self.fw_ipset.addEntry(entry)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeEntry(self, entry):
         self.fw_ipset.removeEntry(entry)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryEntry(self, entry):
         return self.fw_ipset.queryEntry(entry)
@@ -1862,121 +1742,100 @@ class FirewallClientConfigHelper(object):
         self.fw_properties = dbus.Interface(
             self.dbus_obj, dbus_interface='org.freedesktop.DBus.Properties')
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_property(self, prop):
         return dbus_to_python(self.fw_properties.Get(
             config.dbus.DBUS_INTERFACE_CONFIG_HELPER, prop))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_properties(self):
         return dbus_to_python(self.fw_properties.GetAll(
             config.dbus.DBUS_INTERFACE_CONFIG_HELPER))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def set_property(self, prop, value):
         self.fw_properties.Set(config.dbus.DBUS_INTERFACE_CONFIG_HELPER,
                                prop, value)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSettings(self):
         return FirewallClientHelperSettings(list(dbus_to_python(\
                     self.fw_helper.getSettings())))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def update(self, settings):
         self.fw_helper.update(tuple(settings.settings))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def loadDefaults(self):
         self.fw_helper.loadDefaults()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def remove(self):
         self.fw_helper.remove()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def rename(self, name):
         self.fw_helper.rename(name)
 
     # version
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getVersion(self):
         return self.fw_helper.getVersion()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setVersion(self, version):
         self.fw_helper.setVersion(version)
 
     # short
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getShort(self):
         return self.fw_helper.getShort()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setShort(self, short):
         self.fw_helper.setShort(short)
 
     # description
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDescription(self):
         return self.fw_helper.getDescription()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDescription(self, description):
         self.fw_helper.setDescription(description)
 
     # port
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPorts(self):
         return self.fw_helper.getPorts()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setPorts(self, ports):
         self.fw_helper.setPorts(ports)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addPort(self, port, protocol):
         self.fw_helper.addPort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removePort(self, port, protocol):
         self.fw_helper.removePort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryPort(self, port, protocol):
         return self.fw_helper.queryPort(port, protocol)
 
     # family
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getFamily(self):
         return self.fw_helper.getFamily()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setFamily(self, ipv):
         if ipv is None:
@@ -1985,12 +1844,10 @@ class FirewallClientConfigHelper(object):
 
     # module
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getModule(self):
         return self.fw_helper.getModule()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setModule(self, module):
         self.fw_helper.setModule(module)
@@ -2009,217 +1866,178 @@ class FirewallClientConfigService(object):
         self.fw_properties = dbus.Interface(
             self.dbus_obj, dbus_interface='org.freedesktop.DBus.Properties')
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_property(self, prop):
         return dbus_to_python(self.fw_properties.Get(
             config.dbus.DBUS_INTERFACE_CONFIG_SERVICE, prop))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_properties(self):
         return dbus_to_python(self.fw_properties.GetAll(
             config.dbus.DBUS_INTERFACE_CONFIG_SERVICE))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def set_property(self, prop, value):
         self.fw_properties.Set(config.dbus.DBUS_INTERFACE_CONFIG_SERVICE,
                                prop, value)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSettings(self):
         return FirewallClientServiceSettings(dbus_to_python(
                     self.fw_service.getSettings2()))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def update(self, settings):
         self.fw_service.update2(settings.getSettingsDbusDict())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def loadDefaults(self):
         self.fw_service.loadDefaults()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def remove(self):
         self.fw_service.remove()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def rename(self, name):
         self.fw_service.rename(name)
 
     # version
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getVersion(self):
         return self.fw_service.getVersion()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setVersion(self, version):
         self.fw_service.setVersion(version)
 
     # short
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getShort(self):
         return self.fw_service.getShort()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setShort(self, short):
         self.fw_service.setShort(short)
 
     # description
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDescription(self):
         return self.fw_service.getDescription()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDescription(self, description):
         self.fw_service.setDescription(description)
 
     # port
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPorts(self):
         return self.fw_service.getPorts()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setPorts(self, ports):
         self.fw_service.setPorts(ports)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addPort(self, port, protocol):
         self.fw_service.addPort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removePort(self, port, protocol):
         self.fw_service.removePort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryPort(self, port, protocol):
         return self.fw_service.queryPort(port, protocol)
 
     # protocol
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getProtocols(self):
         return self.fw_service.getProtocols()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setProtocols(self, protocols):
         self.fw_service.setProtocols(protocols)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addProtocol(self, protocol):
         self.fw_service.addProtocol(protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeProtocol(self, protocol):
         self.fw_service.removeProtocol(protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryProtocol(self, protocol):
         return self.fw_service.queryProtocol(protocol)
 
     # source-port
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSourcePorts(self):
         return self.fw_service.getSourcePorts()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setSourcePorts(self, ports):
         self.fw_service.setSourcePorts(ports)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addSourcePort(self, port, protocol):
         self.fw_service.addSourcePort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeSourcePort(self, port, protocol):
         self.fw_service.removeSourcePort(port, protocol)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def querySourcePort(self, port, protocol):
         return self.fw_service.querySourcePort(port, protocol)
 
     # module
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getModules(self):
         return self.fw_service.getModules()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setModules(self, modules):
         self.fw_service.setModules(modules)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addModule(self, module):
         self.fw_service.addModule(module)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeModule(self, module):
         self.fw_service.removeModule(module)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryModule(self, module):
         return self.fw_service.queryModule(module)
 
     # destination
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDestinations(self):
         return self.fw_service.getDestinations()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDestinations(self, destinations):
         self.fw_service.setDestinations(destinations)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDestination(self, destination):
         return self.fw_service.getDestination(destination)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDestination(self, destination, address):
         self.fw_service.setDestination(destination, address)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeDestination(self, destination, address=None):
         if address is not None and self.getDestination(destination) != address:
@@ -2227,34 +2045,28 @@ class FirewallClientConfigService(object):
                                 (destination, address))
         self.fw_service.removeDestination(destination)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryDestination(self, destination, address):
         return self.fw_service.queryDestination(destination, address)
 
     # include
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIncludes(self):
         return self.fw_service.getIncludes()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setIncludes(self, includes):
         self.fw_service.setIncludes(includes)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addInclude(self, include):
         self.fw_service.addInclude(include)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeInclude(self, include):
         self.fw_service.removeInclude(include)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryInclude(self, include):
         return self.fw_service.queryInclude(include)
@@ -2341,109 +2153,90 @@ class FirewallClientConfigIcmpType(object):
         self.fw_properties = dbus.Interface(
             self.dbus_obj, dbus_interface='org.freedesktop.DBus.Properties')
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_property(self, prop):
         return dbus_to_python(self.fw_properties.Get(
             config.dbus.DBUS_INTERFACE_CONFIG_ICMPTYPE, prop))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_properties(self):
         return dbus_to_python(self.fw_properties.GetAll(
             config.dbus.DBUS_INTERFACE_CONFIG_ICMPTYPE))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def set_property(self, prop, value):
         self.fw_properties.Set(config.dbus.DBUS_INTERFACE_CONFIG_ICMPTYPE,
                                prop, value)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSettings(self):
         return FirewallClientIcmpTypeSettings(list(dbus_to_python(\
                     self.fw_icmptype.getSettings())))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def update(self, settings):
         self.fw_icmptype.update(tuple(settings.settings))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def loadDefaults(self):
         self.fw_icmptype.loadDefaults()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def remove(self):
         self.fw_icmptype.remove()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def rename(self, name):
         self.fw_icmptype.rename(name)
 
     # version
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getVersion(self):
         return self.fw_icmptype.getVersion()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setVersion(self, version):
         self.fw_icmptype.setVersion(version)
 
     # short
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getShort(self):
         return self.fw_icmptype.getShort()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setShort(self, short):
         self.fw_icmptype.setShort(short)
 
     # description
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDescription(self):
         return self.fw_icmptype.getDescription()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDescription(self, description):
         self.fw_icmptype.setDescription(description)
 
     # destination
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDestinations(self):
         return self.fw_icmptype.getDestinations()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDestinations(self, destinations):
         self.fw_icmptype.setDestinations(destinations)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addDestination(self, destination):
         self.fw_icmptype.addDestination(destination)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeDestination(self, destination):
         self.fw_icmptype.removeDestination(destination)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryDestination(self, destination):
         return self.fw_icmptype.queryDestination(destination)
@@ -2547,106 +2340,87 @@ class FirewallClientConfigPolicies(object):
             self.dbus_obj,
             dbus_interface=config.dbus.DBUS_INTERFACE_CONFIG_POLICIES)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelist(self):
         return FirewallClientPoliciesLockdownWhitelist( \
             list(dbus_to_python(self.fw_policies.getLockdownWhitelist())))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setLockdownWhitelist(self, settings):
         self.fw_policies.setLockdownWhitelist(tuple(settings.settings))
 
     # command
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addLockdownWhitelistCommand(self, command):
         self.fw_policies.addLockdownWhitelistCommand(command)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeLockdownWhitelistCommand(self, command):
         self.fw_policies.removeLockdownWhitelistCommand(command)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdownWhitelistCommand(self, command):
         return dbus_to_python(self.fw_policies.queryLockdownWhitelistCommand(command))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelistCommands(self):
         return dbus_to_python(self.fw_policies.getLockdownWhitelistCommands())
 
     # context
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addLockdownWhitelistContext(self, context):
         self.fw_policies.addLockdownWhitelistContext(context)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeLockdownWhitelistContext(self, context):
         self.fw_policies.removeLockdownWhitelistContext(context)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdownWhitelistContext(self, context):
         return dbus_to_python(self.fw_policies.queryLockdownWhitelistContext(context))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelistContexts(self):
         return dbus_to_python(self.fw_policies.getLockdownWhitelistContexts())
 
     # user
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addLockdownWhitelistUser(self, user):
         self.fw_policies.addLockdownWhitelistUser(user)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeLockdownWhitelistUser(self, user):
         self.fw_policies.removeLockdownWhitelistUser(user)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdownWhitelistUser(self, user):
         return dbus_to_python(self.fw_policies.queryLockdownWhitelistUser(user))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelistUsers(self):
         return dbus_to_python(self.fw_policies.getLockdownWhitelistUsers())
 
     # uid
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelistUids(self):
         return dbus_to_python(self.fw_policies.getLockdownWhitelistUids())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setLockdownWhitelistUids(self, uids):
         self.fw_policies.setLockdownWhitelistUids(uids)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addLockdownWhitelistUid(self, uid):
         self.fw_policies.addLockdownWhitelistUid(uid)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeLockdownWhitelistUid(self, uid):
         self.fw_policies.removeLockdownWhitelistUid(uid)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdownWhitelistUid(self, uid):
         return dbus_to_python(self.fw_policies.queryLockdownWhitelistUid(uid))
@@ -2761,99 +2535,81 @@ class FirewallClientConfigDirect(object):
             self.dbus_obj,
             dbus_interface=config.dbus.DBUS_INTERFACE_CONFIG_DIRECT)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSettings(self):
         return FirewallClientDirect( \
             list(dbus_to_python(self.fw_direct.getSettings())))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def update(self, settings):
         self.fw_direct.update(tuple(settings.settings))
 
     # direct chain
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addChain(self, ipv, table, chain):
         self.fw_direct.addChain(ipv, table, chain)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeChain(self, ipv, table, chain):
         self.fw_direct.removeChain(ipv, table, chain)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryChain(self, ipv, table, chain):
         return dbus_to_python(self.fw_direct.queryChain(ipv, table, chain))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getChains(self, ipv, table):
         return dbus_to_python(self.fw_direct.getChains(ipv, table))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getAllChains(self):
         return dbus_to_python(self.fw_direct.getAllChains())
 
     # direct rule
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addRule(self, ipv, table, chain, priority, args):
         self.fw_direct.addRule(ipv, table, chain, priority, args)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeRule(self, ipv, table, chain, priority, args):
         self.fw_direct.removeRule(ipv, table, chain, priority, args)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeRules(self, ipv, table, chain):
         self.fw_direct.removeRules(ipv, table, chain)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryRule(self, ipv, table, chain, priority, args):
         return dbus_to_python(self.fw_direct.queryRule(ipv, table, chain, priority, args))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getRules(self, ipv, table, chain):
         return dbus_to_python(self.fw_direct.getRules(ipv, table, chain))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getAllRules(self):
         return dbus_to_python(self.fw_direct.getAllRules())
 
     # tracked passthrough
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addPassthrough(self, ipv, args):
         self.fw_direct.addPassthrough(ipv, args)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removePassthrough(self, ipv, args):
         self.fw_direct.removePassthrough(ipv, args)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryPassthrough(self, ipv, args):
         return dbus_to_python(self.fw_direct.queryPassthrough(ipv, args))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPassthroughs(self, ipv):
         return dbus_to_python(self.fw_direct.getPassthroughs(ipv))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getAllPassthroughs(self):
         return dbus_to_python(self.fw_direct.getAllPassthroughs())
@@ -2876,47 +2632,39 @@ class FirewallClientConfig(object):
 
     # properties
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_property(self, prop):
         return dbus_to_python(self.fw_properties.Get(
             config.dbus.DBUS_INTERFACE_CONFIG, prop))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_properties(self):
         return dbus_to_python(self.fw_properties.GetAll(
             config.dbus.DBUS_INTERFACE_CONFIG))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def set_property(self, prop, value):
         self.fw_properties.Set(config.dbus.DBUS_INTERFACE_CONFIG, prop, value)
 
     # ipset
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIPSetNames(self):
         return dbus_to_python(self.fw_config.getIPSetNames())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def listIPSets(self):
         return dbus_to_python(self.fw_config.listIPSets())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIPSet(self, path):
         return FirewallClientConfigIPSet(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIPSetByName(self, name):
         path = dbus_to_python(self.fw_config.getIPSetByName(name))
         return FirewallClientConfigIPSet(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addIPSet(self, name, settings):
         if isinstance(settings, FirewallClientIPSetSettings):
@@ -2927,38 +2675,31 @@ class FirewallClientConfig(object):
 
     # zone
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZoneNames(self):
         return dbus_to_python(self.fw_config.getZoneNames())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def listZones(self):
         return dbus_to_python(self.fw_config.listZones())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZone(self, path):
         return FirewallClientConfigZone(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZoneByName(self, name):
         path = dbus_to_python(self.fw_config.getZoneByName(name))
         return FirewallClientConfigZone(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZoneOfInterface(self, iface):
         return dbus_to_python(self.fw_config.getZoneOfInterface(iface))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZoneOfSource(self, source):
         return dbus_to_python(self.fw_config.getZoneOfSource(source))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addZone(self, name, settings):
         if isinstance(settings, FirewallClientZoneSettings):
@@ -2973,28 +2714,23 @@ class FirewallClientConfig(object):
 
     # policy
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPolicyNames(self):
         return dbus_to_python(self.fw_config.getPolicyNames())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def listPolicies(self):
         return dbus_to_python(self.fw_config.listPolicies())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPolicy(self, path):
         return FirewallClientConfigPolicy(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPolicyByName(self, name):
         path = dbus_to_python(self.fw_config.getPolicyByName(name))
         return FirewallClientConfigPolicy(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addPolicy(self, name, settings):
         if isinstance(settings, FirewallClientPolicySettings):
@@ -3005,28 +2741,23 @@ class FirewallClientConfig(object):
 
     # service
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getServiceNames(self):
         return dbus_to_python(self.fw_config.getServiceNames())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def listServices(self):
         return dbus_to_python(self.fw_config.listServices())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getService(self, path):
         return FirewallClientConfigService(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getServiceByName(self, name):
         path = dbus_to_python(self.fw_config.getServiceByName(name))
         return FirewallClientConfigService(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addService(self, name, settings):
         if isinstance(settings, FirewallClientServiceSettings):
@@ -3041,28 +2772,23 @@ class FirewallClientConfig(object):
 
     # icmptype
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIcmpTypeNames(self):
         return dbus_to_python(self.fw_config.getIcmpTypeNames())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def listIcmpTypes(self):
         return dbus_to_python(self.fw_config.listIcmpTypes())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIcmpType(self, path):
         return FirewallClientConfigIcmpType(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIcmpTypeByName(self, name):
         path = dbus_to_python(self.fw_config.getIcmpTypeByName(name))
         return FirewallClientConfigIcmpType(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addIcmpType(self, name, settings):
         if isinstance(settings, FirewallClientIcmpTypeSettings):
@@ -3071,40 +2797,33 @@ class FirewallClientConfig(object):
             path = self.fw_config.addIcmpType(name, tuple(settings))
         return FirewallClientConfigIcmpType(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def policies(self):
         return self._policies
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def direct(self):
         return self._direct
 
     # helper
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getHelperNames(self):
         return dbus_to_python(self.fw_config.getHelperNames())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def listHelpers(self):
         return dbus_to_python(self.fw_config.listHelpers())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getHelper(self, path):
         return FirewallClientConfigHelper(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getHelperByName(self, name):
         path = dbus_to_python(self.fw_config.getHelperByName(name))
         return FirewallClientConfigHelper(self.bus, path)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addHelper(self, name, settings):
         if isinstance(settings, FirewallClientHelperSettings):
@@ -3121,16 +2840,10 @@ class FirewallClient(object):
         if not bus:
             dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
             try:
-                self.bus = slip.dbus.SystemBus()
-                self.bus.default_timeout = None
-            except Exception:
-                try:
-                    self.bus = dbus.SystemBus()
-                except dbus.exceptions.DBusException as e:
-                    raise FirewallError(errors.DBUS_ERROR,
-                                        e.get_dbus_message())
-                else:
-                    print("Not using slip.dbus")
+                self.bus = dbus.SystemBus()
+            except dbus.exceptions.DBusException as e:
+                raise FirewallError(errors.DBUS_ERROR,
+                                    e.get_dbus_message())
         else:
             self.bus = bus
 
@@ -3405,136 +3118,111 @@ class FirewallClient(object):
         except Exception as msg:
             print(msg)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def config(self):
         return self._config
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def reload(self):
         self.fw.reload()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def complete_reload(self):
         self.fw.completeReload()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def runtimeToPermanent(self):
         self.fw.runtimeToPermanent()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def checkPermanentConfig(self):
         self.fw.checkPermanentConfig()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_property(self, prop):
         return dbus_to_python(self.fw_properties.Get(
             config.dbus.DBUS_INTERFACE, prop))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def get_properties(self):
         return dbus_to_python(self.fw_properties.GetAll(
             config.dbus.DBUS_INTERFACE))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def set_property(self, prop, value):
         self.fw_properties.Set(config.dbus.DBUS_INTERFACE, prop, value)
 
     # panic mode
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def enablePanicMode(self):
         self.fw.enablePanicMode()
     
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def disablePanicMode(self):
         self.fw.disablePanicMode()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryPanicMode(self):
         return dbus_to_python(self.fw.queryPanicMode())
 
     # list functions
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZoneSettings(self, zone):
         return FirewallClientZoneSettings(dbus_to_python(self.fw_zone.getZoneSettings2(zone)))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIPSets(self):
         return dbus_to_python(self.fw_ipset.getIPSets())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIPSetSettings(self, ipset):
         return FirewallClientIPSetSettings(list(dbus_to_python(\
                     self.fw_ipset.getIPSetSettings(ipset))))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addEntry(self, ipset, entry):
         self.fw_ipset.addEntry(ipset, entry)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getEntries(self, ipset):
         return self.fw_ipset.getEntries(ipset)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setEntries(self, ipset, entries):
         return self.fw_ipset.setEntries(ipset, entries)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeEntry(self, ipset, entry):
         self.fw_ipset.removeEntry(ipset, entry)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryEntry(self, ipset, entry):
         return dbus_to_python(self.fw_ipset.queryEntry(ipset, entry))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def listServices(self):
         return dbus_to_python(self.fw.listServices())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getServiceSettings(self, service):
         return FirewallClientServiceSettings(dbus_to_python(
                     self.fw.getServiceSettings2(service)))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def listIcmpTypes(self):
         return dbus_to_python(self.fw.listIcmpTypes())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIcmpTypeSettings(self, icmptype):
         return FirewallClientIcmpTypeSettings(list(dbus_to_python(\
                     self.fw.getIcmpTypeSettings(icmptype))))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getHelpers(self):
         return dbus_to_python(self.fw.getHelpers())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getHelperSettings(self, helper):
         return FirewallClientHelperSettings(list(dbus_to_python(\
@@ -3542,284 +3230,233 @@ class FirewallClient(object):
 
     # automatic helper setting
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getAutomaticHelpers(self):
         return dbus_to_python(self.fw.getAutomaticHelpers())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setAutomaticHelpers(self, value):
         self.fw.setAutomaticHelpers(value)
 
     # log denied
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLogDenied(self):
         return dbus_to_python(self.fw.getLogDenied())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setLogDenied(self, value):
         self.fw.setLogDenied(value)
 
     # default zone
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getDefaultZone(self):
         return dbus_to_python(self.fw.getDefaultZone())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setDefaultZone(self, zone):
         self.fw.setDefaultZone(zone)
 
     # zone
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setZoneSettings(self, zone, settings):
         self.fw_zone.setZoneSettings2(zone, settings.getRuntimeSettingsDbusDict())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZones(self):
         return dbus_to_python(self.fw_zone.getZones())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getActiveZones(self):
         return dbus_to_python(self.fw_zone.getActiveZones())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZoneOfInterface(self, interface):
         return dbus_to_python(self.fw_zone.getZoneOfInterface(interface))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getZoneOfSource(self, source):
         return dbus_to_python(self.fw_zone.getZoneOfSource(source))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def isImmutable(self, zone):
         return dbus_to_python(self.fw_zone.isImmutable(zone))
 
     # policy
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPolicySettings(self, policy):
         return FirewallClientPolicySettings(dbus_to_python(self.fw_policy.getPolicySettings(policy)))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def setPolicySettings(self, policy, settings):
         self.fw_policy.setPolicySettings(policy, settings.getRuntimeSettingsDbusDict())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPolicies(self):
         return dbus_to_python(self.fw_policy.getPolicies())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getActivePolicies(self):
         return dbus_to_python(self.fw_policy.getActivePolicies())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def isPolicyImmutable(self, policy):
         return dbus_to_python(self.fw_policy.isImmutable(policy))
 
     # interfaces
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addInterface(self, zone, interface):
         return dbus_to_python(self.fw_zone.addInterface(zone, interface))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def changeZone(self, zone, interface): # DEPRECATED
         return dbus_to_python(self.fw_zone.changeZone(zone, interface))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def changeZoneOfInterface(self, zone, interface):
         return dbus_to_python(self.fw_zone.changeZoneOfInterface(zone,
                                                                  interface))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getInterfaces(self, zone):
         return dbus_to_python(self.fw_zone.getInterfaces(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryInterface(self, zone, interface):
         return dbus_to_python(self.fw_zone.queryInterface(zone, interface))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeInterface(self, zone, interface):
         return dbus_to_python(self.fw_zone.removeInterface(zone, interface))
 
     # sources
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addSource(self, zone, source):
         return dbus_to_python(self.fw_zone.addSource(zone, source))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def changeZoneOfSource(self, zone, source):
         return dbus_to_python(self.fw_zone.changeZoneOfSource(zone, source))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSources(self, zone):
         return dbus_to_python(self.fw_zone.getSources(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def querySource(self, zone, source):
         return dbus_to_python(self.fw_zone.querySource(zone, source))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeSource(self, zone, source):
         return dbus_to_python(self.fw_zone.removeSource(zone, source))
 
     # rich rules
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addRichRule(self, zone, rule, timeout=0):
         return dbus_to_python(self.fw_zone.addRichRule(zone, rule, timeout))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getRichRules(self, zone):
         return dbus_to_python(self.fw_zone.getRichRules(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryRichRule(self, zone, rule):
         return dbus_to_python(self.fw_zone.queryRichRule(zone, rule))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeRichRule(self, zone, rule):
         return dbus_to_python(self.fw_zone.removeRichRule(zone, rule))
 
     # services
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addService(self, zone, service, timeout=0):
         return dbus_to_python(self.fw_zone.addService(zone, service, timeout))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getServices(self, zone):
         return dbus_to_python(self.fw_zone.getServices(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryService(self, zone, service):
         return dbus_to_python(self.fw_zone.queryService(zone, service))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeService(self, zone, service):
         return dbus_to_python(self.fw_zone.removeService(zone, service))
 
     # ports
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addPort(self, zone, port, protocol, timeout=0):
         return dbus_to_python(self.fw_zone.addPort(zone, port, protocol, timeout))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPorts(self, zone):
         return dbus_to_python(self.fw_zone.getPorts(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryPort(self, zone, port, protocol):
         return dbus_to_python(self.fw_zone.queryPort(zone, port, protocol))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removePort(self, zone, port, protocol):
         return dbus_to_python(self.fw_zone.removePort(zone, port, protocol))
 
     # protocols
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addProtocol(self, zone, protocol, timeout=0):
         return dbus_to_python(self.fw_zone.addProtocol(zone, protocol, timeout))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getProtocols(self, zone):
         return dbus_to_python(self.fw_zone.getProtocols(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryProtocol(self, zone, protocol):
         return dbus_to_python(self.fw_zone.queryProtocol(zone, protocol))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeProtocol(self, zone, protocol):
         return dbus_to_python(self.fw_zone.removeProtocol(zone, protocol))
 
     # forward
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addForward(self, zone):
         self.fw_zone.setZoneSettings2(zone, {"forward": True})
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryForward(self, zone):
         return dbus_to_python(self.fw_zone.getZoneSettings2(zone))["forward"]
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeForward(self, zone):
         self.fw_zone.setZoneSettings2(zone, {"forward": False})
 
     # masquerade
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addMasquerade(self, zone, timeout=0):
         return dbus_to_python(self.fw_zone.addMasquerade(zone, timeout))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryMasquerade(self, zone):
         return dbus_to_python(self.fw_zone.queryMasquerade(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeMasquerade(self, zone):
         return dbus_to_python(self.fw_zone.removeMasquerade(zone))
 
     # forward ports
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addForwardPort(self, zone, port, protocol, toport, toaddr,
                        timeout=0):
@@ -3831,12 +3468,10 @@ class FirewallClient(object):
                                                           toport, toaddr,
                                                           timeout))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getForwardPorts(self, zone):
         return dbus_to_python(self.fw_zone.getForwardPorts(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryForwardPort(self, zone, port, protocol, toport, toaddr):
         if toport is None:
@@ -3847,7 +3482,6 @@ class FirewallClient(object):
                                                             port, protocol,
                                                             toport, toaddr))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeForwardPort(self, zone, port, protocol, toport, toaddr):
         if toport is None:
@@ -3860,23 +3494,19 @@ class FirewallClient(object):
 
     # source ports
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addSourcePort(self, zone, port, protocol, timeout=0):
         return dbus_to_python(self.fw_zone.addSourcePort(zone, port, protocol,
                                                          timeout))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getSourcePorts(self, zone):
         return dbus_to_python(self.fw_zone.getSourcePorts(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def querySourcePort(self, zone, port, protocol):
         return dbus_to_python(self.fw_zone.querySourcePort(zone, port, protocol))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeSourcePort(self, zone, port, protocol):
         return dbus_to_python(self.fw_zone.removeSourcePort(zone, port,
@@ -3884,154 +3514,126 @@ class FirewallClient(object):
 
     # icmpblock
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addIcmpBlock(self, zone, icmp, timeout=0):
         return dbus_to_python(self.fw_zone.addIcmpBlock(zone, icmp, timeout))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getIcmpBlocks(self, zone):
         return dbus_to_python(self.fw_zone.getIcmpBlocks(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryIcmpBlock(self, zone, icmp):
         return dbus_to_python(self.fw_zone.queryIcmpBlock(zone, icmp))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeIcmpBlock(self, zone, icmp):
         return dbus_to_python(self.fw_zone.removeIcmpBlock(zone, icmp))
 
     # icmp block inversion
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addIcmpBlockInversion(self, zone):
         return dbus_to_python(self.fw_zone.addIcmpBlockInversion(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryIcmpBlockInversion(self, zone):
         return dbus_to_python(self.fw_zone.queryIcmpBlockInversion(zone))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeIcmpBlockInversion(self, zone):
         return dbus_to_python(self.fw_zone.removeIcmpBlockInversion(zone))
 
     # direct chain
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addChain(self, ipv, table, chain):
         self.fw_direct.addChain(ipv, table, chain)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeChain(self, ipv, table, chain):
         self.fw_direct.removeChain(ipv, table, chain)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryChain(self, ipv, table, chain):
         return dbus_to_python(self.fw_direct.queryChain(ipv, table, chain))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getChains(self, ipv, table):
         return dbus_to_python(self.fw_direct.getChains(ipv, table))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getAllChains(self):
         return dbus_to_python(self.fw_direct.getAllChains())
 
     # direct rule
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addRule(self, ipv, table, chain, priority, args):
         self.fw_direct.addRule(ipv, table, chain, priority, args)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeRule(self, ipv, table, chain, priority, args):
         self.fw_direct.removeRule(ipv, table, chain, priority, args)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeRules(self, ipv, table, chain):
         self.fw_direct.removeRules(ipv, table, chain)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryRule(self, ipv, table, chain, priority, args):
         return dbus_to_python(self.fw_direct.queryRule(ipv, table, chain, priority, args))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getRules(self, ipv, table, chain):
         return dbus_to_python(self.fw_direct.getRules(ipv, table, chain))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getAllRules(self):
         return dbus_to_python(self.fw_direct.getAllRules())
 
     # direct passthrough
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def passthrough(self, ipv, args):
         return dbus_to_python(self.fw_direct.passthrough(ipv, args))
 
     # tracked passthrough
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getAllPassthroughs(self):
         return dbus_to_python(self.fw_direct.getAllPassthroughs())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeAllPassthroughs(self):
         self.fw_direct.removeAllPassthroughs()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getPassthroughs(self, ipv):
         return dbus_to_python(self.fw_direct.getPassthroughs(ipv))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addPassthrough(self, ipv, args):
         self.fw_direct.addPassthrough(ipv, args)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removePassthrough(self, ipv, args):
         self.fw_direct.removePassthrough(ipv, args)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryPassthrough(self, ipv, args):
         return dbus_to_python(self.fw_direct.queryPassthrough(ipv, args))
 
     # lockdown
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def enableLockdown(self):
         self.fw_policies.enableLockdown()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def disableLockdown(self):
         self.fw_policies.disableLockdown()
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdown(self):
         return dbus_to_python(self.fw_policies.queryLockdown())
@@ -4040,93 +3642,76 @@ class FirewallClient(object):
 
     # lockdown white list commands
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addLockdownWhitelistCommand(self, command):
         self.fw_policies.addLockdownWhitelistCommand(command)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelistCommands(self):
         return dbus_to_python(self.fw_policies.getLockdownWhitelistCommands())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdownWhitelistCommand(self, command):
         return dbus_to_python(self.fw_policies.queryLockdownWhitelistCommand(command))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeLockdownWhitelistCommand(self, command):
         self.fw_policies.removeLockdownWhitelistCommand(command)
 
     # lockdown white list contexts
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addLockdownWhitelistContext(self, context):
         self.fw_policies.addLockdownWhitelistContext(context)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelistContexts(self):
         return dbus_to_python(self.fw_policies.getLockdownWhitelistContexts())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdownWhitelistContext(self, context):
         return dbus_to_python(self.fw_policies.queryLockdownWhitelistContext(context))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeLockdownWhitelistContext(self, context):
         self.fw_policies.removeLockdownWhitelistContext(context)
 
     # lockdown white list uids
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addLockdownWhitelistUid(self, uid):
         self.fw_policies.addLockdownWhitelistUid(uid)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelistUids(self):
         return dbus_to_python(self.fw_policies.getLockdownWhitelistUids())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdownWhitelistUid(self, uid):
         return dbus_to_python(self.fw_policies.queryLockdownWhitelistUid(uid))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeLockdownWhitelistUid(self, uid):
         self.fw_policies.removeLockdownWhitelistUid(uid)
 
     # lockdown white list users
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def addLockdownWhitelistUser(self, user):
         self.fw_policies.addLockdownWhitelistUser(user)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def getLockdownWhitelistUsers(self):
         return dbus_to_python(self.fw_policies.getLockdownWhitelistUsers())
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def queryLockdownWhitelistUser(self, user):
         return dbus_to_python(self.fw_policies.queryLockdownWhitelistUser(user))
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def removeLockdownWhitelistUser(self, user):
         self.fw_policies.removeLockdownWhitelistUser(user)
 
-    @slip.dbus.polkit.enable_proxy
     @handle_exceptions
     def authorizeAll(self):
         """ Authorize once for all polkit actions. """

--- a/src/firewall/server/config.py
+++ b/src/firewall/server/config.py
@@ -18,24 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# force use of pygobject3 in python-slip
-from gi.repository import GObject
-import sys
-sys.modules['gobject'] = GObject
 import os
 
 import dbus
 import dbus.service
-import slip.dbus
-import slip.dbus.service
 
 from firewall import config
 from firewall.core.base import DEFAULT_ZONE_TARGET
 from firewall.core.watcher import Watcher
 from firewall.core.logger import log
+from firewall.server.dbus import DbusServiceObject
 from firewall.server.decorators import handle_exceptions, \
     dbus_handle_exceptions, dbus_service_method, \
-    dbus_service_method_deprecated, dbus_service_signal_deprecated
+    dbus_service_method_deprecated, dbus_service_signal_deprecated, \
+    dbus_polkit_require_auth
 from firewall.server.config_icmptype import FirewallDConfigIcmpType
 from firewall.server.config_service import FirewallDConfigService
 from firewall.server.config_zone import FirewallDConfigZone
@@ -61,7 +57,7 @@ from firewall.errors import FirewallError
 #
 ############################################################################
 
-class FirewallDConfig(slip.dbus.service.Object):
+class FirewallDConfig(DbusServiceObject):
     """FirewallD main class"""
 
     persistent = True
@@ -701,7 +697,7 @@ class FirewallDConfig(slip.dbus.service.Object):
 
         return dbus.Dictionary(ret, signature="sv")
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ssv')
     @dbus_handle_exceptions
     def Set(self, interface_name, property_name, new_value, sender=None):
@@ -773,7 +769,7 @@ class FirewallDConfig(slip.dbus.service.Object):
         log.debug1("config.PropertiesChanged('%s', '%s', '%s')",
                    interface_name, changed_properties, invalidated_properties)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(dbus.INTROSPECTABLE_IFACE, out_signature='s')
     @dbus_handle_exceptions
     def Introspect(self, sender=None): # pylint: disable=W0613

--- a/src/firewall/server/config_icmptype.py
+++ b/src/firewall/server/config_icmptype.py
@@ -18,15 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# force use of pygobject3 in python-slip
-from gi.repository import GObject
-import sys
-sys.modules['gobject'] = GObject
-
 import dbus
 import dbus.service
-import slip.dbus
-import slip.dbus.service
 
 from firewall import config
 from firewall.dbus_utils import dbus_to_python, \
@@ -34,8 +27,10 @@ from firewall.dbus_utils import dbus_to_python, \
     dbus_introspection_add_properties
 from firewall.core.io.icmptype import IcmpType
 from firewall.core.logger import log
+from firewall.server.dbus import DbusServiceObject
 from firewall.server.decorators import handle_exceptions, \
-    dbus_handle_exceptions, dbus_service_method
+    dbus_handle_exceptions, dbus_service_method, \
+    dbus_polkit_require_auth
 from firewall import errors
 from firewall.errors import FirewallError
 
@@ -45,7 +40,7 @@ from firewall.errors import FirewallError
 #
 ############################################################################
 
-class FirewallDConfigIcmpType(slip.dbus.service.Object):
+class FirewallDConfigIcmpType(DbusServiceObject):
     """FirewallD main class"""
 
     persistent = True
@@ -129,7 +124,7 @@ class FirewallDConfigIcmpType(slip.dbus.service.Object):
             ret[x] = self._get_property(x)
         return dbus.Dictionary(ret, signature="sv")
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ssv')
     @dbus_handle_exceptions
     def Set(self, interface_name, property_name, new_value, sender=None):
@@ -158,7 +153,7 @@ class FirewallDConfigIcmpType(slip.dbus.service.Object):
         log.debug1("%s.PropertiesChanged('%s', '%s', '%s')", self._log_prefix,
                    interface_name, changed_properties, invalidated_properties)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(dbus.INTROSPECTABLE_IFACE, out_signature='s')
     @dbus_handle_exceptions
     def Introspect(self, sender=None): # pylint: disable=W0613

--- a/src/firewall/server/config_ipset.py
+++ b/src/firewall/server/config_ipset.py
@@ -18,15 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# force use of pygobject3 in python-slip
-from gi.repository import GObject
-import sys
-sys.modules['gobject'] = GObject
-
 import dbus
 import dbus.service
-import slip.dbus
-import slip.dbus.service
 
 from firewall import config
 from firewall.dbus_utils import dbus_to_python, \
@@ -36,8 +29,10 @@ from firewall.core.io.ipset import IPSet
 from firewall.core.ipset import IPSET_TYPES, normalize_ipset_entry, \
                                 check_entry_overlaps_existing
 from firewall.core.logger import log
+from firewall.server.dbus import DbusServiceObject
 from firewall.server.decorators import handle_exceptions, \
-    dbus_handle_exceptions, dbus_service_method
+    dbus_handle_exceptions, dbus_service_method, \
+    dbus_polkit_require_auth
 from firewall import errors
 from firewall.errors import FirewallError
 
@@ -47,7 +42,7 @@ from firewall.errors import FirewallError
 #
 ############################################################################
 
-class FirewallDConfigIPSet(slip.dbus.service.Object):
+class FirewallDConfigIPSet(DbusServiceObject):
     """FirewallD main class"""
 
     persistent = True
@@ -131,7 +126,7 @@ class FirewallDConfigIPSet(slip.dbus.service.Object):
             ret[x] = self._get_property(x)
         return dbus.Dictionary(ret, signature="sv")
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ssv')
     @dbus_handle_exceptions
     def Set(self, interface_name, property_name, new_value, sender=None):
@@ -160,7 +155,7 @@ class FirewallDConfigIPSet(slip.dbus.service.Object):
         log.debug1("%s.PropertiesChanged('%s', '%s', '%s')", self._log_prefix,
                    interface_name, changed_properties, invalidated_properties)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(dbus.INTROSPECTABLE_IFACE, out_signature='s')
     @dbus_handle_exceptions
     def Introspect(self, sender=None): # pylint: disable=W0613

--- a/src/firewall/server/config_policy.py
+++ b/src/firewall/server/config_policy.py
@@ -2,25 +2,20 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# force use of pygobject3 in python-slip
-from gi.repository import GObject
-import sys
-sys.modules['gobject'] = GObject
-
 import dbus
 import dbus.service
-import slip.dbus
-import slip.dbus.service
 
 from firewall import config
 from firewall.dbus_utils import dbus_to_python, \
     dbus_introspection_prepare_properties, \
     dbus_introspection_add_properties
 from firewall.core.logger import log
+from firewall.server.dbus import DbusServiceObject
 from firewall.server.decorators import handle_exceptions, \
-    dbus_handle_exceptions, dbus_service_method
+    dbus_handle_exceptions, dbus_service_method, \
+    dbus_polkit_require_auth
 
-class FirewallDConfigPolicy(slip.dbus.service.Object):
+class FirewallDConfigPolicy(DbusServiceObject):
     persistent = True
     default_polkit_auth_required = config.dbus.PK_ACTION_CONFIG
 
@@ -100,7 +95,7 @@ class FirewallDConfigPolicy(slip.dbus.service.Object):
             ret[x] = self._get_property(x)
         return dbus.Dictionary(ret, signature="sv")
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ssv')
     @dbus_handle_exceptions
     def Set(self, interface_name, property_name, new_value, sender=None):
@@ -129,7 +124,7 @@ class FirewallDConfigPolicy(slip.dbus.service.Object):
         log.debug1("%s.PropertiesChanged('%s', '%s', '%s')", self._log_prefix,
                    interface_name, changed_properties, invalidated_properties)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(dbus.INTROSPECTABLE_IFACE, out_signature='s')
     @dbus_handle_exceptions
     def Introspect(self, sender=None):

--- a/src/firewall/server/config_zone.py
+++ b/src/firewall/server/config_zone.py
@@ -18,15 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# force use of pygobject3 in python-slip
-from gi.repository import GObject
-import sys
-sys.modules['gobject'] = GObject
-
 import dbus
 import dbus.service
-import slip.dbus
-import slip.dbus.service
 
 from firewall import config
 from firewall.dbus_utils import dbus_to_python, \
@@ -37,8 +30,10 @@ from firewall.core.fw_ifcfg import ifcfg_set_zone_of_interface
 from firewall.core.base import DEFAULT_ZONE_TARGET
 from firewall.core.rich import Rich_Rule
 from firewall.core.logger import log
+from firewall.server.dbus import DbusServiceObject
 from firewall.server.decorators import handle_exceptions, \
-    dbus_handle_exceptions, dbus_service_method
+    dbus_handle_exceptions, dbus_service_method, \
+    dbus_polkit_require_auth
 from firewall import errors
 from firewall.errors import FirewallError
 from firewall.functions import portStr, portInPortRange, coalescePortRange, \
@@ -50,7 +45,7 @@ from firewall.functions import portStr, portInPortRange, coalescePortRange, \
 #
 ############################################################################
 
-class FirewallDConfigZone(slip.dbus.service.Object):
+class FirewallDConfigZone(DbusServiceObject):
     """FirewallD main class"""
 
     persistent = True
@@ -134,7 +129,7 @@ class FirewallDConfigZone(slip.dbus.service.Object):
             ret[x] = self._get_property(x)
         return dbus.Dictionary(ret, signature="sv")
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ssv')
     @dbus_handle_exceptions
     def Set(self, interface_name, property_name, new_value, sender=None):
@@ -163,7 +158,7 @@ class FirewallDConfigZone(slip.dbus.service.Object):
         log.debug1("%s.PropertiesChanged('%s', '%s', '%s')", self._log_prefix,
                    interface_name, changed_properties, invalidated_properties)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(dbus.INTROSPECTABLE_IFACE, out_signature='s')
     @dbus_handle_exceptions
     def Introspect(self, sender=None): # pylint: disable=W0613

--- a/src/firewall/server/dbus.py
+++ b/src/firewall/server/dbus.py
@@ -8,3 +8,8 @@ from firewall import config
 class FirewallDBusException(dbus.DBusException):
     """FirewallDBusException"""
     _dbus_error_name = "%s.Exception" % config.dbus.DBUS_INTERFACE
+
+class NotAuthorizedException(dbus.DBusException):
+    def __init__(self, action_id, method, *args, **kwargs):
+        self._dbus_error_name = config.dbus.DBUS_INTERFACE + ".NotAuthorizedException"
+        super().__init__("Not Authorized({}): {}".format(method, action_id))

--- a/src/firewall/server/dbus.py
+++ b/src/firewall/server/dbus.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import dbus
+from firewall import config
+
+class FirewallDBusException(dbus.DBusException):
+    """FirewallDBusException"""
+    _dbus_error_name = "%s.Exception" % config.dbus.DBUS_INTERFACE

--- a/src/firewall/server/dbus.py
+++ b/src/firewall/server/dbus.py
@@ -13,3 +13,17 @@ class NotAuthorizedException(dbus.DBusException):
     def __init__(self, action_id, method, *args, **kwargs):
         self._dbus_error_name = config.dbus.DBUS_INTERFACE + ".NotAuthorizedException"
         super().__init__("Not Authorized({}): {}".format(method, action_id))
+
+class DbusServiceObject(dbus.service.Object):
+    def __new__(cls, *args, **kwargs):
+        # Check each dbus method. If it does not have an explicit polkit auth
+        # then implicitly wrap it with the default
+        from firewall.server.decorators import dbus_polkit_require_auth
+        for attr_name in dir(cls):
+            method = getattr(cls, attr_name)
+            if hasattr(method, "_dbus_is_method") and \
+               not hasattr(method, "_polkit_auth_required"):
+                _decorator = dbus_polkit_require_auth(cls.default_polkit_auth_required)
+                setattr(cls, attr_name, _decorator(method))
+
+        return super().__new__(cls)

--- a/src/firewall/server/decorators.py
+++ b/src/firewall/server/decorators.py
@@ -20,8 +20,7 @@
 
 """This module contains decorators for use with and without D-Bus"""
 
-__all__ = ["FirewallDBusException", "handle_exceptions",
-           "dbus_handle_exceptions", "dbus_service_method"]
+__all__ = ["handle_exceptions", "dbus_handle_exceptions", "dbus_service_method"]
 
 import dbus
 import dbus.service
@@ -30,20 +29,16 @@ import functools
 import inspect
 from dbus.exceptions import DBusException
 
-from firewall import config
 from firewall.errors import FirewallError
 from firewall import errors
 from firewall.core.logger import log
+from firewall.server.dbus import FirewallDBusException
 
 ############################################################################
 #
 # Exception handler decorators
 #
 ############################################################################
-
-class FirewallDBusException(dbus.DBusException):
-    """FirewallDBusException"""
-    _dbus_error_name = "%s.Exception" % config.dbus.DBUS_INTERFACE
 
 def handle_exceptions(func):
     """Decorator to handle exceptions and log them. Used if not conneced

--- a/src/firewall/server/decorators.py
+++ b/src/firewall/server/decorators.py
@@ -32,7 +32,8 @@ from dbus.exceptions import DBusException
 from firewall.errors import FirewallError
 from firewall import errors
 from firewall.core.logger import log
-from firewall.server.dbus import FirewallDBusException
+from firewall.server.dbus import FirewallDBusException, NotAuthorizedException
+from firewall.dbus_utils import uid_of_sender
 
 ############################################################################
 #
@@ -123,3 +124,74 @@ class dbus_service_signal_deprecated(dbus_service_method_deprecated):
     interfaces.
     """
     pass
+
+class dbus_polkit_require_auth:
+    """Decorator factory that checks if the interface/method can be used by the
+    sender/user. Assumes wrapped function is a method inside a class derived
+    from DbusServiceObject.
+    """
+    _polkit_name = "org.freedesktop.PolicyKit1"
+    _polkit_path = "/org/freedesktop/PolicyKit1/Authority"
+    _polkit_interface = "org.freedesktop.PolicyKit1.Authority"
+
+    _bus = None
+    _bus_signal_receiver = None
+    _interface_polkit = None
+
+    def __init__(self, polkit_auth_required):
+        self._polkit_auth_required = polkit_auth_required
+
+    @classmethod
+    def _polkit_name_owner_changed(cls, name, old_owner, new_owner):
+        cls._bus.remove_signal_receiver(cls._bus_signal_receiver)
+        cls._bus_signal_receiver = None
+        cls._interface_polkit = None
+        pass
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def _impl(*args, **kwargs):
+
+            if not type(self)._bus:
+                type(self)._bus = dbus.SystemBus()
+
+            if not type(self)._bus_signal_receiver:
+                type(self)._bus_signal_receiver = type(self)._bus.add_signal_receiver(
+                                                                    handler_function=type(self)._polkit_name_owner_changed,
+                                                                    signal_name="NameOwnerChanged",
+                                                                    dbus_interface="org.freedesktop.DBus",
+                                                                    arg0=self._polkit_name)
+
+            if not type(self)._interface_polkit:
+                try:
+                    type(self)._interface_polkit = dbus.Interface(type(self)._bus.get_object(
+                                                                            type(self)._polkit_name,
+                                                                            type(self)._polkit_path),
+                                                                  type(self)._polkit_interface)
+                except dbus.DBusException:
+                    # polkit must not be available
+                    pass
+
+            action_id = self._polkit_auth_required
+            if not action_id:
+                raise dbus.DBusException("Not Authorized: No action_id specified.")
+
+            sender = kwargs.get("sender")
+            if sender:
+                # use polkit if it's available
+                if type(self)._interface_polkit:
+                    (result, _, _) = type(self)._interface_polkit.CheckAuthorization(
+                                                                    ("system-bus-name", {"name": sender}),
+                                                                    action_id, {}, 1, "")
+                    if not result:
+                        raise NotAuthorizedException(action_id, "polkit")
+                # fallback to checking UID
+                else:
+                    uid = uid_of_sender(type(self)._bus, sender)
+
+                    if uid != 0:
+                        raise NotAuthorizedException(action_id, "uid")
+
+            return func(*args, **kwargs)
+        _impl._polkit_auth_required = self._polkit_auth_required
+        return _impl

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -37,10 +37,10 @@ from firewall.core.fw import Firewall
 from firewall.core.rich import Rich_Rule
 from firewall.core.logger import log
 from firewall.client import FirewallClientZoneSettings
+from firewall.server.dbus import FirewallDBusException
 from firewall.server.decorators import dbus_handle_exceptions, \
                                        dbus_service_method, \
                                        handle_exceptions, \
-                                       FirewallDBusException, \
                                        dbus_service_method_deprecated, \
                                        dbus_service_signal_deprecated
 from firewall.server.config import FirewallDConfig

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -20,29 +20,24 @@
 
 __all__ = [ "FirewallD" ]
 
-from gi.repository import GLib, GObject
-
-# force use of pygobject3 in python-slip
-import sys
-sys.modules['gobject'] = GObject
+from gi.repository import GLib
 
 import copy
 import dbus
 import dbus.service
-import slip.dbus
-import slip.dbus.service
 
 from firewall import config
 from firewall.core.fw import Firewall
 from firewall.core.rich import Rich_Rule
 from firewall.core.logger import log
 from firewall.client import FirewallClientZoneSettings
-from firewall.server.dbus import FirewallDBusException
+from firewall.server.dbus import FirewallDBusException, DbusServiceObject
 from firewall.server.decorators import dbus_handle_exceptions, \
                                        dbus_service_method, \
                                        handle_exceptions, \
                                        dbus_service_method_deprecated, \
-                                       dbus_service_signal_deprecated
+                                       dbus_service_signal_deprecated, \
+                                       dbus_polkit_require_auth
 from firewall.server.config import FirewallDConfig
 from firewall.dbus_utils import dbus_to_python, \
     command_of_sender, context_of_sender, uid_of_sender, user_of_uid, \
@@ -65,7 +60,7 @@ from firewall.errors import FirewallError
 #
 ############################################################################
 
-class FirewallD(slip.dbus.service.Object):
+class FirewallD(DbusServiceObject):
     """FirewallD main class"""
 
     persistent = True
@@ -248,7 +243,7 @@ class FirewallD(slip.dbus.service.Object):
 
         return dbus.Dictionary(ret, signature="sv")
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(dbus.PROPERTIES_IFACE, in_signature='ssv')
     @dbus_handle_exceptions
     def Set(self, interface_name, property_name, new_value, sender=None):
@@ -294,7 +289,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("PropertiesChanged('%s', '%s', '%s')",
                    interface_name, changed_properties, invalidated_properties)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(dbus.INTROSPECTABLE_IFACE, out_signature='s')
     @dbus_handle_exceptions
     def Introspect(self, sender=None): # pylint: disable=W0613
@@ -316,7 +311,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # reload
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -331,7 +326,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # complete_reload
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -352,7 +347,7 @@ class FirewallD(slip.dbus.service.Object):
     def Reloaded(self):
         log.debug1("Reloaded()")
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -364,7 +359,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # runtime to permanent
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -570,7 +565,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # lockdown
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -582,7 +577,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.enable_lockdown()
         self.LockdownEnabled()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -594,7 +589,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.disable_lockdown()
         self.LockdownDisabled()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -619,7 +614,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # command
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -632,7 +627,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.lockdown_whitelist.add_command(command)
         self.LockdownWhitelistCommandAdded(command)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -645,7 +640,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.lockdown_whitelist.remove_command(command)
         self.LockdownWhitelistCommandRemoved(command)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -657,7 +652,7 @@ class FirewallD(slip.dbus.service.Object):
         # no access check here
         return self.fw.policies.lockdown_whitelist.has_command(command)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -680,7 +675,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # uid
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='i',
                          out_signature='')
     @dbus_handle_exceptions
@@ -693,7 +688,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.lockdown_whitelist.add_uid(uid)
         self.LockdownWhitelistUidAdded(uid)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='i',
                          out_signature='')
     @dbus_handle_exceptions
@@ -706,7 +701,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.lockdown_whitelist.remove_uid(uid)
         self.LockdownWhitelistUidRemoved(uid)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='i',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -718,7 +713,7 @@ class FirewallD(slip.dbus.service.Object):
         # no access check here
         return self.fw.policies.lockdown_whitelist.has_uid(uid)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='',
                          out_signature='ai')
     @dbus_handle_exceptions
@@ -741,7 +736,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # user
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -754,7 +749,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.lockdown_whitelist.add_user(user)
         self.LockdownWhitelistUserAdded(user)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -767,7 +762,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.lockdown_whitelist.remove_user(user)
         self.LockdownWhitelistUserRemoved(user)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -779,7 +774,7 @@ class FirewallD(slip.dbus.service.Object):
         # no access check here
         return self.fw.policies.lockdown_whitelist.has_user(user)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -802,7 +797,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # context
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -815,7 +810,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.lockdown_whitelist.add_context(context)
         self.LockdownWhitelistContextAdded(context)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -828,7 +823,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.policies.lockdown_whitelist.remove_context(context)
         self.LockdownWhitelistContextRemoved(context)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='s',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -840,7 +835,7 @@ class FirewallD(slip.dbus.service.Object):
         # no access check here
         return self.fw.policies.lockdown_whitelist.has_context(context)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_POLICIES_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICIES, in_signature='',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -865,7 +860,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # PANIC
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -879,7 +874,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.enable_panic_mode()
         self.PanicModeEnabled()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -894,7 +889,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.disable_panic_mode()
         self.PanicModeDisabled()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -917,7 +912,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # list functions
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='s',
                          out_signature="(sssbsasa(ss)asba(ssss)asasasasa(ss)b)")
     @dbus_handle_exceptions
@@ -927,7 +922,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("getZoneSettings(%s)", zone)
         return self.fw.zone.get_config_with_settings(zone)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature="a{sv}")
     @dbus_handle_exceptions
@@ -936,7 +931,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("getZoneSettings2(%s)", zone)
         return self.fw.zone.get_config_with_settings_dict(zone)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sa{sv}')
     @dbus_handle_exceptions
     def setZoneSettings2(self, zone, settings, sender=None):
@@ -951,7 +946,7 @@ class FirewallD(slip.dbus.service.Object):
     def ZoneUpdated(self, zone, settings):
         log.debug1("zone.ZoneUpdated('%s', '%s')" % (zone, settings))
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICY, in_signature='s',
                          out_signature="a{sv}")
     @dbus_handle_exceptions
@@ -960,7 +955,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("policy.getPolicySettings(%s)", policy)
         return self.fw.policy.get_config_with_settings_dict(policy)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICY, in_signature='sa{sv}')
     @dbus_handle_exceptions
     def setPolicySettings(self, policy, settings, sender=None):
@@ -975,7 +970,7 @@ class FirewallD(slip.dbus.service.Object):
     def PolicyUpdated(self, policy, settings):
         log.debug1("policy.PolicyUpdated('%s', '%s')" % (policy, settings))
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -986,7 +981,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("listServices()")
         return self.fw.service.get_services()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='s',
                          out_signature='(sssa(ss)asa{ss}asa(ss))')
     @dbus_handle_exceptions
@@ -1006,7 +1001,7 @@ class FirewallD(slip.dbus.service.Object):
                 conf_list.append(conf_dict[obj.IMPORT_EXPORT_STRUCTURE[i][0]])
         return tuple(conf_list)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='s',
                          out_signature='a{sv}')
     @dbus_handle_exceptions
@@ -1016,7 +1011,7 @@ class FirewallD(slip.dbus.service.Object):
         obj = self.fw.service.get_service(service)
         return obj.export_config_dict()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -1027,7 +1022,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("listIcmpTypes()")
         return self.fw.icmptype.get_icmptypes()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='s',
                          out_signature=IcmpType.DBUS_SIGNATURE)
     @dbus_handle_exceptions
@@ -1041,7 +1036,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # LOG DENIED
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1050,7 +1045,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("getLogDenied()")
         return self.fw.get_log_denied()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -1075,7 +1070,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # AUTOMATIC HELPER ASSIGNMENT
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1086,7 +1081,7 @@ class FirewallD(slip.dbus.service.Object):
         # call to keep API.
         return "no"
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -1107,7 +1102,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # DEFAULT ZONE
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1116,7 +1111,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("getDefaultZone()")
         return self.fw.get_default_zone()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='s',
                          out_signature='')
     @dbus_handle_exceptions
@@ -1139,7 +1134,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # POLICIES
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICY, in_signature='',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -1147,7 +1142,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("policy.getPolicies()")
         return self.fw.policy.get_policies_not_derived_from_zone()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_POLICY, in_signature='',
                          out_signature='a{sa{sas}}')
     @dbus_handle_exceptions
@@ -1166,7 +1161,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # ZONES
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     # TODO: shouldn't this be in DBUS_INTERFACE instead of DBUS_INTERFACE_ZONE ?
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='',
                          out_signature='as')
@@ -1176,7 +1171,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("zone.getZones()")
         return self.fw.zone.get_zones()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='',
                          out_signature='a{sa{sas}}')
     @dbus_handle_exceptions
@@ -1195,7 +1190,7 @@ class FirewallD(slip.dbus.service.Object):
                     zones[zone]["sources"] = sources
         return zones
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1214,7 +1209,7 @@ class FirewallD(slip.dbus.service.Object):
             return zone
         return ""
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1227,7 +1222,7 @@ class FirewallD(slip.dbus.service.Object):
             return zone
         return ""
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1239,7 +1234,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # INTERFACES
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1256,7 +1251,7 @@ class FirewallD(slip.dbus.service.Object):
         self.InterfaceAdded(_zone, interface)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1270,7 +1265,7 @@ class FirewallD(slip.dbus.service.Object):
         interface = dbus_to_python(interface, str)
         return self.changeZoneOfInterface(zone, interface, sender)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1287,7 +1282,7 @@ class FirewallD(slip.dbus.service.Object):
         self.ZoneOfInterfaceChanged(_zone, interface)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1304,7 +1299,7 @@ class FirewallD(slip.dbus.service.Object):
         self.InterfaceRemoved(_zone, interface)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1317,7 +1312,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("zone.queryInterface('%s', '%s')" % (zone, interface))
         return self.fw.zone.query_interface(zone, interface)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -1360,7 +1355,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # SOURCES
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1377,7 +1372,7 @@ class FirewallD(slip.dbus.service.Object):
         self.SourceAdded(_zone, source)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1394,7 +1389,7 @@ class FirewallD(slip.dbus.service.Object):
         self.ZoneOfSourceChanged(_zone, source)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1411,7 +1406,7 @@ class FirewallD(slip.dbus.service.Object):
         self.SourceRemoved(_zone, source)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1424,7 +1419,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("zone.querySource('%s', '%s')" % (zone, source))
         return self.fw.zone.query_source(zone, source)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -1465,7 +1460,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.zone.remove_rule(zone, obj)
         self.RichRuleRemoved(zone, rule)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ssi',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1485,7 +1480,7 @@ class FirewallD(slip.dbus.service.Object):
         self.RichRuleAdded(_zone, rule, timeout)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1499,7 +1494,7 @@ class FirewallD(slip.dbus.service.Object):
         self.RichRuleRemoved(_zone, rule)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1510,7 +1505,7 @@ class FirewallD(slip.dbus.service.Object):
         obj = Rich_Rule(rule_str=rule)
         return self.fw.zone.query_rule(zone, obj)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -1543,7 +1538,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.zone.remove_service(zone, service)
         self.ServiceRemoved(zone, service)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ssi',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1565,7 +1560,7 @@ class FirewallD(slip.dbus.service.Object):
         self.ServiceAdded(_zone, service, timeout)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1582,7 +1577,7 @@ class FirewallD(slip.dbus.service.Object):
         self.ServiceRemoved(_zone, service)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1593,7 +1588,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("zone.queryService('%s', '%s')" % (zone, service))
         return self.fw.zone.query_service(zone, service)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -1628,7 +1623,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.zone.remove_port(zone, port, protocol)
         self.PortRemoved(zone, port, protocol)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sssi',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1651,7 +1646,7 @@ class FirewallD(slip.dbus.service.Object):
         self.PortAdded(_zone, port, protocol, timeout)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1669,7 +1664,7 @@ class FirewallD(slip.dbus.service.Object):
         self.PortRemoved(_zone, port, protocol)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1681,7 +1676,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("zone.queryPort('%s', '%s', '%s')" % (zone, port, protocol))
         return self.fw.zone.query_port(zone, port, protocol)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='aas')
     @dbus_handle_exceptions
@@ -1716,7 +1711,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.zone.remove_protocol(zone, protocol)
         self.ProtocolRemoved(zone, protocol)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ssi',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1737,7 +1732,7 @@ class FirewallD(slip.dbus.service.Object):
         self.ProtocolAdded(_zone, protocol, timeout)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1753,7 +1748,7 @@ class FirewallD(slip.dbus.service.Object):
         self.ProtocolRemoved(_zone, protocol)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1764,7 +1759,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("zone.queryProtocol('%s', '%s')" % (zone, protocol))
         return self.fw.zone.query_protocol(zone, protocol)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -1799,7 +1794,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.zone.remove_source_port(zone, port, protocol)
         self.SourcePortRemoved(zone, port, protocol)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sssi',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1823,7 +1818,7 @@ class FirewallD(slip.dbus.service.Object):
         self.SourcePortAdded(_zone, port, protocol, timeout)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1841,7 +1836,7 @@ class FirewallD(slip.dbus.service.Object):
         self.SourcePortRemoved(_zone, port, protocol)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1854,7 +1849,7 @@ class FirewallD(slip.dbus.service.Object):
                                                                protocol))
         return self.fw.zone.query_source_port(zone, port, protocol)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='aas')
     @dbus_handle_exceptions
@@ -1888,7 +1883,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.zone.remove_masquerade(zone)
         self.MasqueradeRemoved(zone)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='si',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1908,7 +1903,7 @@ class FirewallD(slip.dbus.service.Object):
         self.MasqueradeAdded(_zone, timeout)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1923,7 +1918,7 @@ class FirewallD(slip.dbus.service.Object):
         self.MasqueradeRemoved(_zone)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -1953,7 +1948,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.zone.remove_forward_port(zone, port, protocol, toport, toaddr)
         self.ForwardPortRemoved(zone, port, protocol, toport, toaddr)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sssssi',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -1982,7 +1977,7 @@ class FirewallD(slip.dbus.service.Object):
         self.ForwardPortAdded(_zone, port, protocol, toport, toaddr, timeout)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sssss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -2004,7 +1999,7 @@ class FirewallD(slip.dbus.service.Object):
         self.ForwardPortRemoved(_zone, port, protocol, toport, toaddr)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='sssss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -2021,7 +2016,7 @@ class FirewallD(slip.dbus.service.Object):
         return self.fw.zone.query_forward_port(zone, port, protocol, toport,
                                                toaddr)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='aas')
     @dbus_handle_exceptions
@@ -2057,7 +2052,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.zone.remove_icmp_block(zone, icmp)
         self.IcmpBlockRemoved(zone, icmp)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ssi',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -2078,7 +2073,7 @@ class FirewallD(slip.dbus.service.Object):
         self.IcmpBlockAdded(_zone, icmp, timeout)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -2094,7 +2089,7 @@ class FirewallD(slip.dbus.service.Object):
         self.IcmpBlockRemoved(_zone, icmp)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='ss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -2105,7 +2100,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("zone.queryIcmpBlock('%s', '%s')" % (zone, icmp))
         return self.fw.zone.query_icmp_block(zone, icmp)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -2132,7 +2127,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # ICMP BLOCK INVERSION
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -2146,7 +2141,7 @@ class FirewallD(slip.dbus.service.Object):
         self.IcmpBlockInversionAdded(_zone)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='s')
     @dbus_handle_exceptions
@@ -2160,7 +2155,7 @@ class FirewallD(slip.dbus.service.Object):
         self.IcmpBlockInversionRemoved(_zone)
         return _zone
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_ZONE, in_signature='s',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -2186,7 +2181,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # DIRECT CHAIN
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sss',
                          out_signature='')
@@ -2201,7 +2196,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.direct.add_chain(ipv, table, chain)
         self.ChainAdded(ipv, table, chain)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sss',
                          out_signature='')
@@ -2216,7 +2211,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.direct.remove_chain(ipv, table, chain)
         self.ChainRemoved(ipv, table, chain)
     
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sss',
                          out_signature='b')
@@ -2229,7 +2224,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("direct.queryChain('%s', '%s', '%s')" % (ipv, table, chain))
         return self.fw.direct.query_chain(ipv, table, chain)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='ss',
                          out_signature='as')
@@ -2241,7 +2236,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("direct.getChains('%s', '%s')" % (ipv, table))
         return self.fw.direct.get_chains(ipv, table)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='',
                          out_signature='a(sss)')
@@ -2268,7 +2263,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # DIRECT RULE
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT,
                          in_signature='sssias', out_signature='')
@@ -2286,7 +2281,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.direct.add_rule(ipv, table, chain, priority, args)
         self.RuleAdded(ipv, table, chain, priority, args)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT,
                          in_signature='sssias', out_signature='')
@@ -2304,7 +2299,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.direct.remove_rule(ipv, table, chain, priority, args)
         self.RuleRemoved(ipv, table, chain, priority, args)
     
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sss',
                          out_signature='')
@@ -2320,7 +2315,7 @@ class FirewallD(slip.dbus.service.Object):
             self.fw.direct.remove_rule(ipv, table, chain, priority, args)
             self.RuleRemoved(ipv, table, chain, priority, args)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT,
                          in_signature='sssias', out_signature='b')
@@ -2336,7 +2331,7 @@ class FirewallD(slip.dbus.service.Object):
                        (ipv, table, chain, priority, "','".join(args)))
         return self.fw.direct.query_rule(ipv, table, chain, priority, args)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sss',
                          out_signature='a(ias)')
@@ -2349,7 +2344,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("direct.getRules('%s', '%s', '%s')" % (ipv, table, chain))
         return self.fw.direct.get_rules(ipv, table, chain)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='',
                          out_signature='a(sssias)')
@@ -2377,7 +2372,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # DIRECT PASSTHROUGH (untracked)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sas',
                          out_signature='s')
@@ -2405,7 +2400,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # DIRECT PASSTHROUGH (tracked)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sas',
                          out_signature='')
@@ -2420,7 +2415,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.direct.add_passthrough(ipv, args)
         self.PassthroughAdded(ipv, args)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sas',
                          out_signature='')
@@ -2435,7 +2430,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.direct.remove_passthrough(ipv, args)
         self.PassthroughRemoved(ipv, args)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='sas',
                          out_signature='b')
@@ -2448,7 +2443,7 @@ class FirewallD(slip.dbus.service.Object):
                        (ipv, "','".join(args)))
         return self.fw.direct.query_passthrough(ipv, args)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='',
                          out_signature='a(sas)')
@@ -2458,7 +2453,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("direct.getAllPassthroughs()")
         return self.fw.direct.get_all_passthroughs()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='',
                          out_signature='')
@@ -2470,7 +2465,7 @@ class FirewallD(slip.dbus.service.Object):
         for passthrough in reversed(self.getAllPassthroughs()):
             self.removePassthrough(*passthrough)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_DIRECT_INFO)
     @dbus_service_method_deprecated(config.dbus.DBUS_INTERFACE_DIRECT)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_DIRECT, in_signature='s',
                          out_signature='aas')
@@ -2497,7 +2492,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_ALL)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_ALL)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='')
     @dbus_handle_exceptions
@@ -2512,7 +2507,7 @@ class FirewallD(slip.dbus.service.Object):
     # IPSETS
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_IPSET, in_signature='s',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -2522,7 +2517,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("ipset.queryIPSet('%s')" % (ipset))
         return self.fw.ipset.query_ipset(ipset)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_IPSET, in_signature='',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -2531,7 +2526,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("ipsets.getIPSets()")
         return self.fw.ipset.get_ipsets()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_IPSET, in_signature='s',
                          out_signature=IPSet.DBUS_SIGNATURE)
     @dbus_handle_exceptions
@@ -2543,7 +2538,7 @@ class FirewallD(slip.dbus.service.Object):
 
     # set entries # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_IPSET, in_signature='ss',
                          out_signature='')
     @dbus_handle_exceptions
@@ -2556,7 +2551,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.ipset.add_entry(ipset, entry)
         self.EntryAdded(ipset, entry)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_IPSET, in_signature='ss',
                          out_signature='')
     @dbus_handle_exceptions
@@ -2569,7 +2564,7 @@ class FirewallD(slip.dbus.service.Object):
         self.fw.ipset.remove_entry(ipset, entry)
         self.EntryRemoved(ipset, entry)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_IPSET, in_signature='ss',
                          out_signature='b')
     @dbus_handle_exceptions
@@ -2580,7 +2575,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("ipset.queryEntry('%s', '%s')" % (ipset, entry))
         return self.fw.ipset.query_entry(ipset, entry)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_IPSET, in_signature='s',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -2590,7 +2585,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("ipset.getEntries('%s')" % ipset)
         return self.fw.ipset.get_entries(ipset)
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG)
     @dbus_service_method(config.dbus.DBUS_INTERFACE_IPSET, in_signature='sas')
     @dbus_handle_exceptions
     def setEntries(self, ipset, entries, sender=None): # pylint: disable=W0613
@@ -2625,7 +2620,7 @@ class FirewallD(slip.dbus.service.Object):
     # HELPERS
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='',
                          out_signature='as')
     @dbus_handle_exceptions
@@ -2634,7 +2629,7 @@ class FirewallD(slip.dbus.service.Object):
         log.debug1("helpers.getHelpers()")
         return self.fw.helper.get_helpers()
 
-    @slip.dbus.polkit.require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
+    @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(config.dbus.DBUS_INTERFACE, in_signature='s',
                          out_signature=Helper.DBUS_SIGNATURE)
     @dbus_handle_exceptions

--- a/src/firewall/server/server.py
+++ b/src/firewall/server/server.py
@@ -27,17 +27,13 @@
 
 __all__ = [ "run_server" ]
 
-import sys
 import signal
 
-# force use of pygobject3 in python-slip
-from gi.repository import GObject, GLib
-sys.modules['gobject'] = GObject
+from gi.repository import GLib
 
 import dbus
 import dbus.service
 import dbus.mainloop.glib
-import slip.dbus
 
 from firewall import config
 from firewall.core.logger import log
@@ -93,7 +89,6 @@ def run_server(debug_gc=False):
         service = FirewallD(name, config.dbus.DBUS_PATH)
 
         mainloop = GLib.MainLoop()
-        slip.dbus.service.set_mainloop(mainloop)
         if debug_gc:
             GLib.timeout_add_seconds(gc_timeout, gc_collect)
 

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -57,7 +57,7 @@ check-container-debian-sid-image: check-container-%-image:
 	echo "RUN apt-get install -y autoconf automake pkg-config intltool libglib2.0-dev \
 	                             xsltproc docbook-xsl docbook-xml iproute2 iptables ipset ebtables \
 	                             nftables libxml2-utils libdbus-1-dev libgirepository1.0-dev \
-	                             python3-dbus python3-gi python3-slip-dbus python3-nftables \
+	                             python3-dbus python3-gi python3-nftables \
 	                             procps network-manager gir1.2-nm-1.0" && \
 	echo "COPY . /tmp/firewalld"; \
 	} | $(PODMAN) build -t firewalld-testsuite-$* -f - . )
@@ -69,7 +69,7 @@ check-container-fedora-rawhide-image: check-container-%-image:
 	echo "RUN dnf -y install autoconf automake conntrack-tools desktop-file-utils \
 	                 docbook-style-xsl file gettext glib2-devel intltool ipset \
 	                 iptables iptables-nft libtool libxml2 libxslt make nftables \
-	                 python3-nftables python3-slip-dbus python3-gobject-base \
+	                 python3-nftables python3-gobject-base \
 	                 diffutils procps-ng iproute which dbus-daemon \
 	                 NetworkManager NetworkManager-ovs" && \
 	echo "RUN alternatives --set ebtables /usr/sbin/ebtables-nft" && \
@@ -84,7 +84,7 @@ check-container-centos8-stream-image: check-container-%-image:
 	echo "RUN dnf -y install autoconf automake conntrack-tools desktop-file-utils \
 	                 docbook-style-xsl file gettext glib2-devel intltool ipset \
 	                 iptables iptables-ebtables nftables libtool libxml2 \
-	                 libxslt make nftables python3-nftables python3-slip-dbus \
+	                 libxslt make nftables python3-nftables \
 	                 python3-gobject-base diffutils procps-ng iproute which dbus-daemon \
 	                 NetworkManager NetworkManager-ovs" && \
 	echo "COPY . /tmp/firewalld"; \

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -134,7 +134,9 @@ m4_define([FWD_START_TEST], [
         trap ". ./cleanup; kill_firewalld; kill_networkmanager; . ./cleanup_late" EXIT
 
         dnl create a namespace and dbus-daemon
-        m4_define([CURRENT_DBUS_ADDRESS], [unix:abstract=firewalld-testsuite-dbus-system-socket-${at_group_normalized}])
+        m4_ifdef([TESTING_INTEGRATION], [], [
+            m4_define([CURRENT_DBUS_ADDRESS], [unix:abstract=firewalld-testsuite-dbus-system-socket-${at_group_normalized}])
+        ])
         m4_define([CURRENT_TEST_NS], [fwd-test-${at_group_normalized}])
         echo "ip netns delete CURRENT_TEST_NS" >> ./cleanup_late
         AT_CHECK([ip netns add CURRENT_TEST_NS])
@@ -213,11 +215,22 @@ m4_define([FWD_START_TEST], [
             </policy>
             </busconfig>
 ])
-        DBUS_PID=`NS_CMD([dbus-daemon --address="CURRENT_DBUS_ADDRESS" --print-pid --config-file="./dbus.conf"])`
-        if test $? -ne 0; then
-            AT_FAIL_IF([:])
-        fi
-        echo "kill $DBUS_PID" >> ./cleanup_late
+        m4_ifdef([TESTING_INTEGRATION], [
+            AT_SKIP_IF([NS_CMD([pgrep firewalld >/dev/null 2>&1])])
+
+            dnl dbus has a firewalld spec
+            AT_SKIP_IF([! test -r /usr/share/dbus-1/system.d/FirewallD.conf])
+            dnl polkit is installed and can be started by dbus-daemon
+            AT_SKIP_IF([! test -r /usr/share/dbus-1/system-services/org.freedesktop.PolicyKit1.service])
+            dnl polkit has a firewalld policy (firewalld has been installed)
+            AT_SKIP_IF([! test -r /usr/share/polkit-1/actions/org.fedoraproject.FirewallD1.policy])
+        ], [
+            DBUS_PID=`NS_CMD([dbus-daemon --address="CURRENT_DBUS_ADDRESS" --print-pid --config-file="./dbus.conf"])`
+            if test $? -ne 0; then
+                AT_FAIL_IF([:])
+            fi
+            echo "kill $DBUS_PID" >> ./cleanup_late
+        ])
 
         IF_HOST_SUPPORTS_NFT_RULE_INDEX([], [
             AT_CHECK([sed -i 's/^IndividualCalls.*/IndividualCalls=yes/' ./firewalld.conf])
@@ -238,7 +251,7 @@ m4_define([FWD_END_TEST], [
             fi
             AT_FAIL_IF([[grep '^[0-9-]*[ ]\+[0-9:]*[ ]\+\(ERROR\|WARNING\)' ./firewalld.log]])
         fi
-        m4_undefine([CURRENT_DBUS_ADDRESS])
+        m4_ifdef([CURRENT_DBUS_ADDRESS], [m4_undefine([CURRENT_DBUS_ADDRESS])])
         m4_undefine([CURRENT_TEST_NS])
     ])
     AT_CLEANUP
@@ -318,7 +331,8 @@ m4_define([m4_strip],
                      [^ ?\(.*\) ?$], [\1])])
 
 m4_define([NS_CMD], [dnl
-    env DBUS_SYSTEM_BUS_ADDRESS="CURRENT_DBUS_ADDRESS" ip netns exec CURRENT_TEST_NS $1 dnl
+    m4_ifdef([TESTING_INTEGRATION], [], [env DBUS_SYSTEM_BUS_ADDRESS="CURRENT_DBUS_ADDRESS"]) dnl command continues to next line
+    ip netns exec CURRENT_TEST_NS $1 dnl
 ])
 
 m4_define([NS_CHECK], [

--- a/src/tests/integration/dbus.at
+++ b/src/tests/integration/dbus.at
@@ -1,0 +1,2 @@
+AT_BANNER([dbus])
+m4_include([integration/dbus_auth_uid.at])

--- a/src/tests/integration/dbus_auth_uid.at
+++ b/src/tests/integration/dbus_auth_uid.at
@@ -1,0 +1,28 @@
+FWD_START_TEST([dbus - UID auth, no polkit])
+AT_KEYWORDS(dbus auth)
+
+AT_SKIP_IF([! NS_CMD([which sudo >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([which getent >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([getent passwd nobody >/dev/null 2>&1])])
+
+dnl polkit will automatically be started by dbus. The only way to prevent it is
+dnl to mask the service. polkit must be stopped to exercises the UID auth.
+dnl
+echo "systemctl unmask polkit" >> ./cleanup
+systemctl mask polkit
+systemctl stop polkit
+
+dnl Verify we check the UID if polkit is not running.
+dnl
+dnl Note: must explicitly pass $PATH because sudo may scrub it.
+dnl
+AT_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --add-service http], 253, [ignore], [ignore])
+AT_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --list-all], 253, [ignore], [ignore])
+AT_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --query-panic], 253, [ignore], [ignore])
+AT_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --state], 253, [ignore], [ignore])
+AT_CHECK([firewall-cmd --add-service http], 0, [ignore], [ignore])
+AT_CHECK([firewall-cmd --list-all], 0, [ignore], [ignore])
+AT_CHECK([firewall-cmd --query-panic], 1, [ignore], [ignore])
+AT_CHECK([firewall-cmd --state], 0, [ignore], [ignore])
+
+FWD_END_TEST

--- a/src/tests/integration/polkit.at
+++ b/src/tests/integration/polkit.at
@@ -1,0 +1,2 @@
+AT_BANNER([polkit])
+m4_include([integration/polkit_auth_server.at])

--- a/src/tests/integration/polkit.at
+++ b/src/tests/integration/polkit.at
@@ -1,3 +1,4 @@
 AT_BANNER([polkit])
 m4_include([integration/polkit_auth_server.at])
 m4_include([integration/polkit_auth_desktop.at])
+m4_include([integration/polkit_restart.at])

--- a/src/tests/integration/polkit.at
+++ b/src/tests/integration/polkit.at
@@ -1,2 +1,3 @@
 AT_BANNER([polkit])
 m4_include([integration/polkit_auth_server.at])
+m4_include([integration/polkit_auth_desktop.at])

--- a/src/tests/integration/polkit_auth_desktop.at
+++ b/src/tests/integration/polkit_auth_desktop.at
@@ -1,0 +1,52 @@
+FWD_START_TEST([polkit - auth desktop])
+AT_KEYWORDS(dbus polkit auth)
+
+AT_SKIP_IF([! NS_CMD([which sudo >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([which getent >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([getent passwd nobody >/dev/null 2>&1])])
+
+dnl This test verifies the different policy permissions. It does not verify
+dnl every (dbus API, policy) pair. It is only using a subset of the dbus
+dnl interfaces sufficient to verify the policy actions. It's only verifying
+dnl that policy kit auth is functional.
+dnl 
+dnl A prime example of this is that both permanent and runtime config changes
+dnl fall under the "config" polkit action.
+
+FWD_OFFLINE_CHECK([--policy-desktop], 0, [ignore], [ignore])
+FWD_RESTART
+
+dnl org.fedoraproject.FirewallD1.all
+dnl
+dnl implicitly covered by org.fedoraproject.FirewallD1.config because the CLI
+dnl does authorizeAll() when it has command sequences.
+
+dnl org.fedoraproject.FirewallD1.info
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --query-panic], 1, [ignore], [ignore])
+NS_CHECK([firewall-cmd --query-panic], 1, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.config
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --add-service http], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --add-service http], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.config.info
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --list-all], 0, [ignore], [ignore])
+NS_CHECK([firewall-cmd --list-all], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.direct
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -j ACCEPT], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -j ACCEPT], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.direct.info
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --direct --get-all-rules], 0, [ignore], [ignore])
+NS_CHECK([firewall-cmd --direct --get-all-rules], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.policies
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --add-lockdown-whitelist-command="/usr/bin/firewall-cmd"], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --add-lockdown-whitelist-command="/usr/bin/firewall-cmd"], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.policies.info
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --query-lockdown], 1, [ignore], [ignore])
+NS_CHECK([firewall-cmd --query-lockdown], 1, [ignore], [ignore])
+
+FWD_END_TEST

--- a/src/tests/integration/polkit_auth_server.at
+++ b/src/tests/integration/polkit_auth_server.at
@@ -1,0 +1,52 @@
+FWD_START_TEST([polkit - auth server])
+AT_KEYWORDS(dbus polkit auth)
+
+AT_SKIP_IF([! NS_CMD([which sudo >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([which getent >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([getent passwd nobody >/dev/null 2>&1])])
+
+dnl This test verifies the different policy permissions. It does not verify
+dnl every (dbus API, policy) pair. It is only using a subset of the dbus
+dnl interfaces sufficient to verify the policy actions. It's only verifying
+dnl that policy kit auth is functional.
+dnl 
+dnl A prime example of this is that both permanent and runtime config changes
+dnl fall under the "config" polkit action.
+
+FWD_OFFLINE_CHECK([--policy-server], 0, [ignore], [ignore])
+FWD_RESTART
+
+dnl org.fedoraproject.FirewallD1.all
+dnl
+dnl implicitly covered by org.fedoraproject.FirewallD1.config because the CLI
+dnl does authorizeAll() when it has command sequences.
+
+dnl org.fedoraproject.FirewallD1.info
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --query-panic], 1, [ignore], [ignore])
+NS_CHECK([firewall-cmd --query-panic], 1, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.config
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --add-service http], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --add-service http], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.config.info
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --list-all], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --list-all], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.direct
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -j ACCEPT], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --direct --add-rule ipv4 filter INPUT 0 -j ACCEPT], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.direct.info
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --direct --get-all-rules], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --direct --get-all-rules], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.policies
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --add-lockdown-whitelist-command="/usr/bin/firewall-cmd"], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --add-lockdown-whitelist-command="/usr/bin/firewall-cmd"], 0, [ignore], [ignore])
+
+dnl org.fedoraproject.FirewallD1.policies.info
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --query-lockdown], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --query-lockdown], 1, [ignore], [ignore])
+
+FWD_END_TEST

--- a/src/tests/integration/polkit_restart.at
+++ b/src/tests/integration/polkit_restart.at
@@ -1,0 +1,26 @@
+FWD_START_TEST([polkit - restart])
+AT_KEYWORDS(dbus polkit auth)
+
+AT_SKIP_IF([! NS_CMD([which sudo >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([which getent >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([getent passwd nobody >/dev/null 2>&1])])
+AT_SKIP_IF([! NS_CMD([systemctl >/dev/null 2>&1])])
+
+FWD_OFFLINE_CHECK([--policy-server], 0, [ignore], [ignore])
+FWD_RESTART
+
+dnl Verify auth works before and after a policy kit restart
+dnl
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --query-panic], 1, [ignore], [ignore])
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --add-service http], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --add-service http], 0, [ignore], [ignore])
+NS_CHECK([firewall-cmd --remove-service http], 0, [ignore], [ignore])
+
+NS_CHECK([systemctl restart polkit], 0, [ignore], [ignore])
+
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --query-panic], 1, [ignore], [ignore])
+NS_CHECK([sudo -E -u nobody env PATH="$PATH" firewall-cmd --add-service http], 253, [ignore], [ignore])
+NS_CHECK([firewall-cmd --add-service http], 0, [ignore], [ignore])
+NS_CHECK([firewall-cmd --remove-service http], 0, [ignore], [ignore])
+
+FWD_END_TEST

--- a/src/tests/integration/testsuite.at
+++ b/src/tests/integration/testsuite.at
@@ -6,12 +6,12 @@ dnl
 m4_define([m4_include], [m4_builtin([include], [$1])])
 
 m4_define([TESTING_INTEGRATION])
+m4_define([FIREWALL_BACKEND], [nftables])
+
 m4_include([functions.at])
 
+m4_include([integration/networkmanager.at])
 m4_include([integration/polkit.at])
 m4_include([integration/dbus.at])
 
-m4_foreach([FIREWALL_BACKEND], [[nftables], [iptables]], [
-    m4_include([integration/networkmanager.at])
-])
 m4_undefine([TESTING_INTEGRATION])

--- a/src/tests/integration/testsuite.at
+++ b/src/tests/integration/testsuite.at
@@ -9,6 +9,7 @@ m4_define([TESTING_INTEGRATION])
 m4_include([functions.at])
 
 m4_include([integration/polkit.at])
+m4_include([integration/dbus.at])
 
 m4_foreach([FIREWALL_BACKEND], [[nftables], [iptables]], [
     m4_include([integration/networkmanager.at])

--- a/src/tests/integration/testsuite.at
+++ b/src/tests/integration/testsuite.at
@@ -5,8 +5,10 @@ dnl Override m4_include to avoid warning about inclusion
 dnl
 m4_define([m4_include], [m4_builtin([include], [$1])])
 
+m4_define([TESTING_INTEGRATION])
 m4_include([functions.at])
 
 m4_foreach([FIREWALL_BACKEND], [[nftables], [iptables]], [
     m4_include([integration/networkmanager.at])
 ])
+m4_undefine([TESTING_INTEGRATION])

--- a/src/tests/integration/testsuite.at
+++ b/src/tests/integration/testsuite.at
@@ -8,6 +8,8 @@ m4_define([m4_include], [m4_builtin([include], [$1])])
 m4_define([TESTING_INTEGRATION])
 m4_include([functions.at])
 
+m4_include([integration/polkit.at])
+
 m4_foreach([FIREWALL_BACKEND], [[nftables], [iptables]], [
     m4_include([integration/networkmanager.at])
 ])


### PR DESCRIPTION
This drops the dependency on `python-slip`. Policy Kit authorization is now done via a custom decorator.