### PR TITLE
improvement(testsuite): install to $(pkgdatadir)/testsuite

### DIFF
--- a/firewalld.spec
+++ b/firewalld.spec
@@ -49,6 +49,12 @@ Summary: Firewalld directory layout and rpm macros
 This package provides directories and rpm macros which
 are required by other packages that add firewalld configuration files.
 
+%package -n firewalld-test
+Summary: Firewalld testsuite
+
+%description -n firewalld-test
+This package provides the firewalld testsuite.
+
 %package -n firewall-applet
 Summary: Firewall panel applet
 Requires: %{name} = %{version}-%{release}
@@ -205,6 +211,18 @@ fi
 %dir %{_prefix}/lib/firewalld/services
 %dir %{_prefix}/lib/firewalld/zones
 %{_rpmconfigdir}/macros.d/macros.firewalld
+
+%files -n firewalld-test
+%dir %{_datadir}/firewalld/testsuite
+%{_datadir}/firewalld/testsuite/README
+%{_datadir}/firewalld/testsuite/testsuite
+%dir %{_datadir}/firewalld/testsuite/integration
+%{_datadir}/firewalld/testsuite/integration/testsuite
+%dir %{_datadir}/firewalld/testsuite/python
+%{_datadir}/firewalld/testsuite/python/firewalld_config.py
+%{_datadir}/firewalld/testsuite/python/firewalld_direct.py
+%{_datadir}/firewalld/testsuite/python/firewalld_rich.py
+%{_datadir}/firewalld/testsuite/python/firewalld_test.py
 
 %files -n firewall-applet
 %attr(0755,root,root) %dir %{_sysconfdir}/firewall

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -20,6 +20,16 @@ EXTRA_DIST = \
 
 DISTCLEANFILES = atconfig
 
+testsuitedir = $(pkgdatadir)/testsuite
+dist_testsuite_SCRIPTS = $(TESTSUITE)
+dist_testsuite_DATA = README
+
+testsuite_integrationdir = $(pkgdatadir)/testsuite/integration
+dist_testsuite_integration_SCRIPTS = $(TESTSUITE_INTEGRATION)
+
+testsuite_pythondir = $(pkgdatadir)/testsuite/python
+dist_testsuite_python_DATA = python/*.py
+
 $(srcdir)/package.m4: $(top_srcdir)/configure.ac $(top_srcdir)/firewalld.spec $(srcdir)/Makefile
 	:;{ \
 	echo 'm4_define([AT_PACKAGE_NAME],[$(PACKAGE_NAME)])' && \

--- a/src/tests/README
+++ b/src/tests/README
@@ -1,0 +1,36 @@
+# firewalld testsuite
+
+This is the firewalld testsuite. It consists of standalone autotest scripts
+that can be run from any location.
+
+# Example usage
+The tests can be run from any location. They generate output in the current
+directory so it's suggested to run them from `/tmp`. Tests must be run as root.
+
+## Standard tests
+The standard testsuite is run inside temporary network namespaces. As such
+they're non-destructive to the host and may be run while firewalld is running
+on the host.
+
+To run the tests serially:
+
+    # cd /tmp
+    # /usr/share/firewalld/testsuite/testsuite
+
+To run the tests in parallel:
+
+    # /usr/share/firewalld/testsuite/testsuite -j4
+
+To run a test for a specific bug use a keyword:
+
+    # /usr/share/firewalld/testsuite/testsuite -k rhbz1404076
+    # /usr/share/firewalld/testsuite/testsuite -k gh366
+
+## Integration tests
+The integration tests are destructive and require that at least firewalld and
+NetworkManager are _not_ running on the host.
+
+These tests _must_ be run serially:
+
+    # cd /tmp
+    # /usr/share/firewalld/testsuite/integration/testsuite

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -91,6 +91,18 @@ m4_define([FWD_START_TEST], [
     AT_SETUP([$1])
     AT_KEYWORDS(FIREWALL_BACKEND)
 
+    dnl Default values for things that should be defined in atlocal. If atlocal
+    dnl can't be found it's likely because the testsuite is run "standalone" and
+    dnl atconfig/atlocal aren't available. There should be one here for every value
+    dnl in atlocal.
+    dnl
+    test -z "$PYTHON" && export PYTHON="python3"
+    test -z "$IPTABLES" && export IPTABLES="iptables"
+    test -z "$IPTABLES_RESTORE" && export IPTABLES_RESTORE="iptables-restore"
+    test -z "$IP6TABLES" && export IP6TABLES="ip6tables"
+    test -z "$IP6TABLES_RESTORE" && export IP6TABLES_RESTORE="ip6tables-restore"
+    test -z "$IPSET" && export IPSET="ipset"
+
     dnl We test some unicode strings and autotest overrides LC_ALL=C, so set it
     dnl again for every test.
     if locale -a |grep "^C.utf8" >/dev/null; then

--- a/src/tests/python/python.at
+++ b/src/tests/python/python.at
@@ -2,21 +2,21 @@ AT_BANNER([python (FIREWALL_BACKEND)])
 
 FWD_START_TEST([firewalld_test.py])
 AT_KEYWORDS(python)
-NS_CHECK([$PYTHON ${srcdir}/python/firewalld_test.py], 0, [ignore], [ignore])
+NS_CHECK([$PYTHON $(dirname ${at_myself})/python/firewalld_test.py], 0, [ignore], [ignore])
 FWD_END_TEST([ignore])
 
 FWD_START_TEST([firewalld_config.py])
 AT_KEYWORDS(python)
-NS_CHECK([$PYTHON ${srcdir}/python/firewalld_config.py], 0, [ignore], [ignore])
+NS_CHECK([$PYTHON $(dirname ${at_myself})/python/firewalld_config.py], 0, [ignore], [ignore])
 FWD_END_TEST([ignore])
 
 FWD_START_TEST([firewalld_rich.py])
 AT_KEYWORDS(python)
-NS_CHECK([$PYTHON ${srcdir}/python/firewalld_rich.py], 0, [ignore], [ignore])
+NS_CHECK([$PYTHON $(dirname ${at_myself})/python/firewalld_rich.py], 0, [ignore], [ignore])
 FWD_END_TEST([ignore])
 
 FWD_START_TEST([firewalld_direct.py])
 AT_KEYWORDS(python)
 CHECK_IPTABLES
-NS_CHECK([$PYTHON ${srcdir}/python/firewalld_direct.py], 0, [ignore], [ignore])
+NS_CHECK([$PYTHON $(dirname ${at_myself})/python/firewalld_direct.py], 0, [ignore], [ignore])
 FWD_END_TEST([ignore])


### PR DESCRIPTION
Install the testsuite. This will make it easier for end users to verify
they have a sane environment for firewalld. Users often build custom
kernels which may be missing features firewalld relies upon.

--->8---

New RPM subpackage: firewalld-test

New files:
```
[root@vm-bos-rhel8-1 testsuite]# find /usr/share/firewalld/testsuite/
/usr/share/firewalld/testsuite/
/usr/share/firewalld/testsuite/README
/usr/share/firewalld/testsuite/testsuite
/usr/share/firewalld/testsuite/integration
/usr/share/firewalld/testsuite/integration/testsuite
/usr/share/firewalld/testsuite/python
/usr/share/firewalld/testsuite/python/firewalld_config.py
/usr/share/firewalld/testsuite/python/firewalld_direct.py
/usr/share/firewalld/testsuite/python/firewalld_rich.py
/usr/share/firewalld/testsuite/python/firewalld_test.py

[root@vm-bos-rhel8-1 testsuite]# du -sh /usr/share/firewalld/testsuite/
12M     /usr/share/firewalld/testsuite/
```

Run the base testsuite (equivalent of `make check`):
```
[root@vm-bos-rhel8-1 /tmp]# /usr/share/firewalld/testsuite/testsuite
## ----------------------------- ##
## firewalld 1.0.999 test suite. ##
## ----------------------------- ##

firewall-offline-cmd

  1: basic options                                   ok
  2: get/list options                                ok
[..]
```

Run the integration testsuite (equivalent of `make check-integration`):
```
[root@vm-bos-rhel8-1 /tmp]# /usr/share/firewalld/testsuite/integration/testsuite
## ----------------------------- ##
## firewalld 1.0.999 test suite. ##
## ----------------------------- ##

NetworkManager (nftables)

  1: NM overrides interface on reload                ok
  2: reload don't consider non IP capable interfaces ok
[..]
```