### PR TITLE
doc(firewall-*cmd): client conntrack helpers must use a policy

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -8,6 +8,7 @@ types:
   - build
   - chore
   - ci
+  - doc
   - docs
   - feat
   - fix

--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -601,6 +601,23 @@
 	    <para>
 	      The <option>--timeout</option> option is not combinable with the <option>--permanent</option> option.
 	    </para>
+            <para>
+              <emphasis role="bold">Note</emphasis>: Some services define connection tracking helpers.
+              Helpers that may operate in client mode (e.g. tftp) must be added to an
+              outbound policy instead of a zone to take effect for clients. Otherwise
+              the helper will not be applied to the outbound traffic. The related
+              traffic, as defined by the connection tracking helper, on the return
+              path (ingress) will be allowed by the stateful firewall rules.
+            </para>
+            <para>
+              An example of an outbound policy for connection tracking helpers:
+              <programlisting>
+# firewall-cmd --permanent --new-policy clientConntrack
+# firewall-cmd --permanent --policy clientConntrack --add-ingress-zone HOST
+# firewall-cmd --permanent --policy clientConntrack --add-egress-zone ANY
+# firewall-cmd --permanent --policy clientConntrack --add-service tftp
+              </programlisting>
+            </para>
 	  </listitem>
 	</varlistentry>
 

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -689,6 +689,23 @@
 	    <para>
 	      The service is one of the firewalld provided services. To get a list of the supported services, use <command>firewall-cmd --get-services</command>.
 	    </para>
+            <para>
+              <emphasis role="bold">Note</emphasis>: Some services define connection tracking helpers.
+              Helpers that may operate in client mode (e.g. tftp) must be added to an
+              outbound policy instead of a zone to take effect for clients. Otherwise
+              the helper will not be applied to the outbound traffic. The related
+              traffic, as defined by the connection tracking helper, on the return
+              path (ingress) will be allowed by the stateful firewall rules.
+            </para>
+            <para>
+              An example of an outbound policy for connection tracking helpers:
+              <programlisting>
+# firewall-cmd --new-policy clientConntrack
+# firewall-cmd --policy clientConntrack --add-ingress-zone HOST
+# firewall-cmd --policy clientConntrack --add-egress-zone ANY
+# firewall-cmd --policy clientConntrack --add-service tftp
+              </programlisting>
+            </para>
 	  </listitem>
 	</varlistentry>
 


### PR DESCRIPTION
Fixes: rhbz 1899933
Fixes: rhbz 1975484