### PR TITLE
Switch PyQt5 to PySide2

### DIFF
--- a/shell-completion/zsh/_firewalld
+++ b/shell-completion/zsh/_firewalld
@@ -208,6 +208,16 @@ _arguments -C -s $args $direct \
   '--load-helper-defaults=[load helper default settings]:helper:->helpers' \
   '(--zone -q --quiet)--info-helper=[print information about an helper]:helper:->helpers' \
   '--path-helper=[print file path of an helper]:helper:->helpers' \
+  '--get-policies[print predefined policies]' \
+  '--get-active-policies[print currently active policies]' \
+  '--list-all-policies[list everything added for or enabled in all policies]' \
+  '--new-policy=[add a new empty policy]:policy:->policies' \
+  '--new-policy-from-file=[add a new policy from file with optional name override]:file:_files' \
+  '--delete-policy=[delete an existing policy]:policy:->policies' \
+  '--load-policy-defaults=[load policy default settings]:policy:->policies' \
+  '--policy=[use this policy to set or query options]:policy:->policies' \
+  '--info-policy=[print information about a policy]:policy:->policies' \
+  '--path-policy=[print file path of a policy]:policy:->policies' \
   '(--zone -q --quiet)--get-helpers[print predefined helpers]' \
   '--set-module=[set module to helper]:module' \
   '--get-module[get module from helper]' \
@@ -298,6 +308,10 @@ case $state in
   zones)
     _description zones expl 'zone'
     compadd "$expl[@]" - $(_call_program zones $words[1] --get-zones)
+  ;;
+  policies)
+    _description policies expl 'policies'
+    compadd "$expl[@]" - $(_call_program policies $words[1] --get-policies)
   ;;
 esac
 

--- a/shell-completion/zsh/_firewalld
+++ b/shell-completion/zsh/_firewalld
@@ -244,6 +244,23 @@ _arguments -C -s $args $direct \
   '*--query-lockdown-whitelist-user=[query whether the specified user is on the whitelist]:user:_users' \
   '--direct[first option for all direct options]'
 
+
+# add sub option for policy.
+if [[ ${words[@]/'--policy'/} != ${words[@]} ]]
+then
+  _arguments \
+  '--get-priority[get the priority]' \
+  '--set-priority=[set the priority]' \
+  '--list-ingress-zones[list ingress zones that are bound to a policy]' \
+  '--add-ingress-zone=[add the ingress zone to a policy]:zone:->zones' \
+  '--remove-ingress-zone=[remove the ingress zone from a policy]:zone:->zones' \
+  '--query-ingress-zone=[wuery whether the ingress zone has been adedd to a policy]:zone:->zones' \
+  '--list-egress-zones[list egress zones that are bound to a policy]' \
+  '--add-egress-zone=[add the egress zone to a policy]:zone:->zones' \
+  '--remove-egress-zone=[remove the egress zone from a policy]:zone:->zones' \
+  '--query-egress-zone=[query whether the egress zone has been adedd to a policy]:zone:->zones'
+fi
+
 [[ $state = sources ]] && compset -P 'ipset:' && state=ipsets
 case $state in
   sources)

--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -21,7 +21,7 @@
 #
 
 import sys
-from PyQt5 import QtGui, QtCore, QtWidgets
+from PySide2 import QtGui, QtCore, QtWidgets
 
 import gi
 gi.require_version('Notify', '0.7')


### PR DESCRIPTION
I had notice that some distrubitions has no packing PyQt5 (such as Fedora), but has PySide2 instead, so firewalld has no ability to show a applet for KDE, switch PyQt to PySide2 may can improve this stitution.

This code has test passed. All code need be change just replace `from PyQt5 import QtGui, QtCore, QtWidgets` to `from PySide2 import QtGui, QtCore, QtWidgets`