### PR TITLE
feat: Switch PyQt5 to PySide2

### DIFF
--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -21,7 +21,7 @@
 #
 
 import sys
-from PyQt5 import QtGui, QtCore, QtWidgets
+from PySide2 import QtGui, QtCore, QtWidgets
 
 import gi
 gi.require_version('Notify', '0.7')


### PR DESCRIPTION
I had notice that some distrubitions has no packing PyQt5 (such as Fedora), but has PySide2 instead, so firewalld has no ability to show a applet for KDE, switch PyQt to PySide2 may can improve this stitution.

This code has test passed. All code need be change just replace `from PyQt5 import QtGui, QtCore, QtWidgets` to `from PySide2 import QtGui, QtCore, QtWidgets`