### PR TITLE
fix(policy): unreachable when priority > 0

### DIFF
--- a/src/tests/cli/firewall-cmd.at
+++ b/src/tests/cli/firewall-cmd.at
@@ -1375,11 +1375,13 @@ FWD_START_TEST([rich rules priority])
     NFT_LIST_RULES([inet], [filter_IN_public], 0, [dnl
         table inet firewalld {
         chain filter_IN_public {
+        jump filter_INPUT_POLICIES_pre
         jump filter_IN_public_pre
         jump filter_IN_public_log
         jump filter_IN_public_deny
         jump filter_IN_public_allow
         jump filter_IN_public_post
+        jump filter_INPUT_POLICIES_post
         meta l4proto { icmp, ipv6-icmp } accept
         reject with icmpx type admin-prohibited
         }
@@ -1388,47 +1390,57 @@ FWD_START_TEST([rich rules priority])
     NFT_LIST_RULES([inet], [filter_FWD_public], 0, [dnl
         table inet firewalld {
         chain filter_FWD_public {
+        jump filter_FORWARD_POLICIES_pre
         jump filter_FWD_public_pre
         jump filter_FWD_public_log
         jump filter_FWD_public_deny
         jump filter_FWD_public_allow
         jump filter_FWD_public_post
+        jump filter_FORWARD_POLICIES_post
         reject with icmpx type admin-prohibited
         }
         }
     ])
     IPTABLES_LIST_RULES([filter], [IN_public], 0, [dnl
+        INPUT_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
         IN_public_pre all -- 0.0.0.0/0 0.0.0.0/0
         IN_public_log all -- 0.0.0.0/0 0.0.0.0/0
         IN_public_deny all -- 0.0.0.0/0 0.0.0.0/0
         IN_public_allow all -- 0.0.0.0/0 0.0.0.0/0
         IN_public_post all -- 0.0.0.0/0 0.0.0.0/0
+        INPUT_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
         ACCEPT icmp -- 0.0.0.0/0 0.0.0.0/0
         REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-port-unreachable
     ])
     IPTABLES_LIST_RULES([filter], [FWD_public], 0, [dnl
+        FORWARD_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
         FWD_public_pre all -- 0.0.0.0/0 0.0.0.0/0
         FWD_public_log all -- 0.0.0.0/0 0.0.0.0/0
         FWD_public_deny all -- 0.0.0.0/0 0.0.0.0/0
         FWD_public_allow all -- 0.0.0.0/0 0.0.0.0/0
         FWD_public_post all -- 0.0.0.0/0 0.0.0.0/0
+        FORWARD_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
         REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-port-unreachable
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public], 0, [dnl
+        INPUT_POLICIES_pre all ::/0 ::/0
         IN_public_pre all ::/0 ::/0
         IN_public_log all ::/0 ::/0
         IN_public_deny all ::/0 ::/0
         IN_public_allow all ::/0 ::/0
         IN_public_post all ::/0 ::/0
+        INPUT_POLICIES_post all ::/0 ::/0
         ACCEPT icmpv6 ::/0 ::/0
         REJECT all ::/0 ::/0 reject-with icmp6-port-unreachable
     ])
     IP6TABLES_LIST_RULES([filter], [FWD_public], 0, [dnl
+        FORWARD_POLICIES_pre all ::/0 ::/0
         FWD_public_pre all ::/0 ::/0
         FWD_public_log all ::/0 ::/0
         FWD_public_deny all ::/0 ::/0
         FWD_public_allow all ::/0 ::/0
         FWD_public_post all ::/0 ::/0
+        FORWARD_POLICIES_post all ::/0 ::/0
         REJECT all ::/0 ::/0 reject-with icmp6-port-unreachable
     ])
 
@@ -1554,9 +1566,7 @@ FWD_START_TEST([rich rules priority])
         ct state established,related accept
         ct status dnat accept
         iifname "lo" accept
-        jump filter_INPUT_POLICIES_pre
         jump filter_INPUT_ZONES
-        jump filter_INPUT_POLICIES_post
         ct state invalid drop
         reject with icmpx type admin-prohibited
         }

--- a/src/tests/features/rfc3964_ipv4.at
+++ b/src/tests/features/rfc3964_ipv4.at
@@ -12,9 +12,7 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
     ct status dnat accept
     iifname "lo" accept
     ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 type addr-unreachable
-    jump filter_FORWARD_POLICIES_pre
     jump filter_FORWARD_ZONES
-    jump filter_FORWARD_POLICIES_post
     ct state invalid log prefix "STATE_INVALID_DROP: "
     ct state invalid drop
     log prefix "FINAL_REJECT: "
@@ -58,9 +56,7 @@ IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all ::/0 ::/0
     FORWARD_direct all ::/0 ::/0
     RFC3964_IPv4 all ::/0 ::/0
-    FORWARD_POLICIES_pre all ::/0 ::/0
     FORWARD_ZONES all ::/0 ::/0
-    FORWARD_POLICIES_post all ::/0 ::/0
     LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
     DROP all ::/0 ::/0 ctstate INVALID
     LOG all ::/0 ::/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
@@ -84,9 +80,7 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
     ct state established,related accept
     ct status dnat accept
     iifname "lo" accept
-    jump filter_FORWARD_POLICIES_pre
     jump filter_FORWARD_ZONES
-    jump filter_FORWARD_POLICIES_post
     ct state invalid log prefix "STATE_INVALID_DROP: "
     ct state invalid drop
     log prefix "FINAL_REJECT: "
@@ -110,9 +104,7 @@ IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
     ACCEPT all ::/0 ::/0
     FORWARD_direct all ::/0 ::/0
-    FORWARD_POLICIES_pre all ::/0 ::/0
     FORWARD_ZONES all ::/0 ::/0
-    FORWARD_POLICIES_post all ::/0 ::/0
     LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
     DROP all ::/0 ::/0 ctstate INVALID
     LOG all ::/0 ::/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "

--- a/src/tests/features/rpfilter.at
+++ b/src/tests/features/rpfilter.at
@@ -24,9 +24,7 @@ IP6TABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl
     ACCEPT icmpv6 ::/0 ::/0 ipv6-icmptype 135
     DROP all ::/0 ::/0 rpfilter validmark invert
     PREROUTING_direct all ::/0 ::/0
-    PREROUTING_POLICIES_pre all ::/0 ::/0
     PREROUTING_ZONES all ::/0 ::/0
-    PREROUTING_POLICIES_post all ::/0 ::/0
 ])
 
 FWD_END_TEST

--- a/src/tests/features/zone.at
+++ b/src/tests/features/zone.at
@@ -16,29 +16,35 @@ FWD_RELOAD
 NFT_LIST_RULES([inet], [filter_IN_foobar], 0, [dnl
     table inet firewalld {
         chain filter_IN_foobar {
+            jump filter_INPUT_POLICIES_pre
             jump filter_IN_foobar_pre
             jump filter_IN_foobar_log
             jump filter_IN_foobar_deny
             jump filter_IN_foobar_allow
             jump filter_IN_foobar_post
+            jump filter_INPUT_POLICIES_post
             accept
         }
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar], 0, [dnl
+    INPUT_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_pre all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_log all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_deny all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_allow all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_post all -- 0.0.0.0/0 0.0.0.0/0
+    INPUT_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar], 0, [dnl
+    INPUT_POLICIES_pre all ::/0 ::/0
     IN_foobar_pre all ::/0 ::/0
     IN_foobar_log all ::/0 ::/0
     IN_foobar_deny all ::/0 ::/0
     IN_foobar_allow all ::/0 ::/0
     IN_foobar_post all ::/0 ::/0
+    INPUT_POLICIES_post all ::/0 ::/0
     ACCEPT all ::/0 ::/0
 ])
 
@@ -46,29 +52,35 @@ dnl ingress zone with target ACCEPT should still allow the forwarded traffic
 NFT_LIST_RULES([inet], [filter_FWD_foobar], 0, [dnl
     table inet firewalld {
         chain filter_FWD_foobar {
+            jump filter_FORWARD_POLICIES_pre
             jump filter_FWD_foobar_pre
             jump filter_FWD_foobar_log
             jump filter_FWD_foobar_deny
             jump filter_FWD_foobar_allow
             jump filter_FWD_foobar_post
+            jump filter_FORWARD_POLICIES_post
             accept
         }
     }
 ])
 IPTABLES_LIST_RULES([filter], [FWD_foobar], 0, [dnl
+    FORWARD_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_pre all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_log all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_deny all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_allow all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_post all -- 0.0.0.0/0 0.0.0.0/0
+    FORWARD_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
 ])
 IP6TABLES_LIST_RULES([filter], [FWD_foobar], 0, [dnl
+    FORWARD_POLICIES_pre all ::/0 ::/0
     FWD_foobar_pre all ::/0 ::/0
     FWD_foobar_log all ::/0 ::/0
     FWD_foobar_deny all ::/0 ::/0
     FWD_foobar_allow all ::/0 ::/0
     FWD_foobar_post all ::/0 ::/0
+    FORWARD_POLICIES_post all ::/0 ::/0
     ACCEPT all ::/0 ::/0
 ])
 
@@ -79,31 +91,37 @@ FWD_RELOAD
 NFT_LIST_RULES([inet], [filter_IN_foobar], 0, [dnl
     table inet firewalld {
         chain filter_IN_foobar {
+            jump filter_INPUT_POLICIES_pre
             jump filter_IN_foobar_pre
             jump filter_IN_foobar_log
             jump filter_IN_foobar_deny
             jump filter_IN_foobar_allow
             jump filter_IN_foobar_post
+            jump filter_INPUT_POLICIES_post
             meta l4proto { icmp, ipv6-icmp } accept
             reject with icmpx type admin-prohibited
         }
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar], 0, [dnl
+    INPUT_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_pre all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_log all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_deny all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_allow all -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_post all -- 0.0.0.0/0 0.0.0.0/0
+    INPUT_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
     ACCEPT icmp -- 0.0.0.0/0 0.0.0.0/0                                 
     REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-port-unreachable
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar], 0, [dnl
+    INPUT_POLICIES_pre all ::/0 ::/0
     IN_foobar_pre all ::/0 ::/0
     IN_foobar_log all ::/0 ::/0
     IN_foobar_deny all ::/0 ::/0
     IN_foobar_allow all ::/0 ::/0
     IN_foobar_post all ::/0 ::/0
+    INPUT_POLICIES_post all ::/0 ::/0
     ACCEPT icmpv6 ::/0 ::/0                                
     REJECT all ::/0 ::/0 reject-with icmp6-port-unreachable
 ])
@@ -111,29 +129,35 @@ IP6TABLES_LIST_RULES([filter], [IN_foobar], 0, [dnl
 NFT_LIST_RULES([inet], [filter_FWD_foobar], 0, [dnl
     table inet firewalld {
         chain filter_FWD_foobar {
+            jump filter_FORWARD_POLICIES_pre
             jump filter_FWD_foobar_pre
             jump filter_FWD_foobar_log
             jump filter_FWD_foobar_deny
             jump filter_FWD_foobar_allow
             jump filter_FWD_foobar_post
+            jump filter_FORWARD_POLICIES_post
             reject with icmpx type admin-prohibited
         }
     }
 ])
 IPTABLES_LIST_RULES([filter], [FWD_foobar], 0, [dnl
+    FORWARD_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_pre all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_log all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_deny all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_allow all -- 0.0.0.0/0 0.0.0.0/0
     FWD_foobar_post all -- 0.0.0.0/0 0.0.0.0/0
+    FORWARD_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
     REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-port-unreachable
 ])
 IP6TABLES_LIST_RULES([filter], [FWD_foobar], 0, [dnl
+    FORWARD_POLICIES_pre all ::/0 ::/0
     FWD_foobar_pre all ::/0 ::/0
     FWD_foobar_log all ::/0 ::/0
     FWD_foobar_deny all ::/0 ::/0
     FWD_foobar_allow all ::/0 ::/0
     FWD_foobar_post all ::/0 ::/0
+    FORWARD_POLICIES_post all ::/0 ::/0
     REJECT all ::/0 ::/0 reject-with icmp6-port-unreachable
 ])
 

--- a/src/tests/regression/gh258.at
+++ b/src/tests/regression/gh258.at
@@ -17,9 +17,7 @@ NFT_LIST_RULES([inet], [filter_INPUT], 0, [dnl
             ct state established,related accept
             ct status dnat accept
             iifname "lo" accept
-            jump filter_INPUT_POLICIES_pre
             jump filter_INPUT_ZONES
-            jump filter_INPUT_POLICIES_post
             ct state invalid drop
             reject with icmpx type admin-prohibited
         }
@@ -43,9 +41,7 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
             ct status dnat accept
             iifname "lo" accept
             ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } reject with icmpv6 type addr-unreachable
-            jump filter_FORWARD_POLICIES_pre
             jump filter_FORWARD_ZONES
-            jump filter_FORWARD_POLICIES_post
             ct state invalid drop
             reject with icmpx type admin-prohibited
         }
@@ -82,9 +78,7 @@ IF_HOST_SUPPORTS_NFT_FIB([
 NFT_LIST_RULES([inet], [mangle_PREROUTING], 0, [dnl
     table inet firewalld {
         chain mangle_PREROUTING {
-            jump mangle_PREROUTING_POLICIES_pre
             jump mangle_PREROUTING_ZONES
-            jump mangle_PREROUTING_POLICIES_post
         }
     }
 ])
@@ -102,9 +96,7 @@ NFT_LIST_RULES([inet], [mangle_PREROUTING_ZONES], 0, [dnl
 NFT_LIST_RULES([inet], [nat_PREROUTING], 0, [dnl
     table inet firewalld {
         chain nat_PREROUTING {
-            jump nat_PREROUTING_POLICIES_pre
             jump nat_PREROUTING_ZONES
-            jump nat_PREROUTING_POLICIES_post
         }
     }
 ])
@@ -122,9 +114,7 @@ NFT_LIST_RULES([inet], [nat_PREROUTING_ZONES], 0, [dnl
 NFT_LIST_RULES([inet], [nat_POSTROUTING], 0, [dnl
     table inet firewalld {
         chain nat_POSTROUTING {
-            jump nat_POSTROUTING_POLICIES_pre
             jump nat_POSTROUTING_ZONES
-            jump nat_POSTROUTING_POLICIES_post
         }
     }
 ])
@@ -144,9 +134,7 @@ IPTABLES_LIST_RULES([filter], [INPUT], 0, [dnl
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
     INPUT_direct all -- 0.0.0.0/0 0.0.0.0/0
-    INPUT_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     INPUT_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    INPUT_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
     DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited
 ])
@@ -160,9 +148,7 @@ IPTABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
     FORWARD_direct all -- 0.0.0.0/0 0.0.0.0/0
-    FORWARD_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     FORWARD_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    FORWARD_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
     DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited
 ])
@@ -174,9 +160,7 @@ IPTABLES_LIST_RULES([filter], [FORWARD_ZONES], 0,
 ]])
 IPTABLES_LIST_RULES([raw], [PREROUTING], 0, [dnl
     PREROUTING_direct all -- 0.0.0.0/0 0.0.0.0/0
-    PREROUTING_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     PREROUTING_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    PREROUTING_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
 ])
 IPTABLES_LIST_RULES([raw], [PREROUTING_ZONES], 0,
   [[PRE_trusted all -- 1.2.3.0/24 0.0.0.0/0 [goto]
@@ -186,9 +170,7 @@ IPTABLES_LIST_RULES([raw], [PREROUTING_ZONES], 0,
 ]])
 IPTABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl
     PREROUTING_direct all -- 0.0.0.0/0 0.0.0.0/0
-    PREROUTING_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     PREROUTING_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    PREROUTING_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
 ])
 IPTABLES_LIST_RULES([mangle], [PREROUTING_ZONES], 0,
   [[PRE_trusted all -- 1.2.3.0/24 0.0.0.0/0 [goto]
@@ -198,9 +180,7 @@ IPTABLES_LIST_RULES([mangle], [PREROUTING_ZONES], 0,
 ]])
 IPTABLES_LIST_RULES([nat], [PREROUTING], 0, [dnl
     PREROUTING_direct all -- 0.0.0.0/0 0.0.0.0/0
-    PREROUTING_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     PREROUTING_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    PREROUTING_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
 ])
 IPTABLES_LIST_RULES([nat], [PREROUTING_ZONES], 0,
   [[PRE_trusted all -- 1.2.3.0/24 0.0.0.0/0 [goto]
@@ -210,9 +190,7 @@ IPTABLES_LIST_RULES([nat], [PREROUTING_ZONES], 0,
 ]])
 IPTABLES_LIST_RULES([nat], [POSTROUTING], 0, [dnl
     POSTROUTING_direct all -- 0.0.0.0/0 0.0.0.0/0
-    POSTROUTING_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     POSTROUTING_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    POSTROUTING_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
 ])
 IPTABLES_LIST_RULES([nat], [POSTROUTING_ZONES], 0,
   [[POST_trusted all -- 0.0.0.0/0 1.2.3.0/24 [goto]
@@ -225,9 +203,7 @@ IP6TABLES_LIST_RULES([filter], [INPUT], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
     ACCEPT all ::/0 ::/0
     INPUT_direct all ::/0 ::/0
-    INPUT_POLICIES_pre all ::/0 ::/0
     INPUT_ZONES all ::/0 ::/0
-    INPUT_POLICIES_post all ::/0 ::/0
     DROP all ::/0 ::/0 ctstate INVALID
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
@@ -242,9 +218,7 @@ IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all ::/0 ::/0
     FORWARD_direct all ::/0 ::/0
     RFC3964_IPv4 all ::/0 ::/0
-    FORWARD_POLICIES_pre all ::/0 ::/0
     FORWARD_ZONES all ::/0 ::/0
-    FORWARD_POLICIES_post all ::/0 ::/0
     DROP all ::/0 ::/0 ctstate INVALID
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
@@ -256,9 +230,7 @@ IP6TABLES_LIST_RULES([filter], [FORWARD_ZONES], 0,
 ]])
 IP6TABLES_LIST_RULES([raw], [PREROUTING], 0, [dnl
     PREROUTING_direct all ::/0 ::/0
-    PREROUTING_POLICIES_pre all ::/0 ::/0
     PREROUTING_ZONES all ::/0 ::/0
-    PREROUTING_POLICIES_post all ::/0 ::/0
 ])
 IP6TABLES_LIST_RULES([raw], [PREROUTING_ZONES], 0,
   [[PRE_public all dead:beef::/54 ::/0 [goto]
@@ -271,9 +243,7 @@ IP6TABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl
     ACCEPT icmpv6 ::/0 ::/0 ipv6-icmptype 135
     DROP all ::/0 ::/0 rpfilter validmark invert
     PREROUTING_direct all ::/0 ::/0
-    PREROUTING_POLICIES_pre all ::/0 ::/0
     PREROUTING_ZONES all ::/0 ::/0
-    PREROUTING_POLICIES_post all ::/0 ::/0
 ])
 IP6TABLES_LIST_RULES([mangle], [PREROUTING_ZONES], 0,
   [[PRE_public all dead:beef::/54 ::/0 [goto]
@@ -283,9 +253,7 @@ IP6TABLES_LIST_RULES([mangle], [PREROUTING_ZONES], 0,
 ]])
 IP6TABLES_LIST_RULES([nat], [PREROUTING], 0, [dnl
     PREROUTING_direct all ::/0 ::/0
-    PREROUTING_POLICIES_pre all ::/0 ::/0
     PREROUTING_ZONES all ::/0 ::/0
-    PREROUTING_POLICIES_post all ::/0 ::/0
 ])
 IP6TABLES_LIST_RULES([nat], [PREROUTING_ZONES], 0,
   [[PRE_public all dead:beef::/54 ::/0 [goto]
@@ -295,9 +263,7 @@ IP6TABLES_LIST_RULES([nat], [PREROUTING_ZONES], 0,
 ]])
 IP6TABLES_LIST_RULES([nat], [POSTROUTING], 0, [dnl
     POSTROUTING_direct all ::/0 ::/0
-    POSTROUTING_POLICIES_pre all ::/0 ::/0
     POSTROUTING_ZONES all ::/0 ::/0
-    POSTROUTING_POLICIES_post all ::/0 ::/0
 ])
 IP6TABLES_LIST_RULES([nat], [POSTROUTING_ZONES], 0,
   [[POST_public all ::/0 dead:beef::/54 [goto]

--- a/src/tests/regression/rhbz1514043.at
+++ b/src/tests/regression/rhbz1514043.at
@@ -15,9 +15,7 @@ NFT_LIST_RULES([inet], [filter_INPUT], 0, [dnl
             ct state established,related accept
             ct status dnat accept
             iifname "lo" accept
-            jump filter_INPUT_POLICIES_pre
             jump filter_INPUT_ZONES
-            jump filter_INPUT_POLICIES_post
             ct state invalid log prefix "STATE_INVALID_DROP: "
             ct state invalid drop
             log prefix "FINAL_REJECT: "
@@ -32,9 +30,7 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
             ct status dnat accept
             iifname "lo" accept
             ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 type addr-unreachable
-            jump filter_FORWARD_POLICIES_pre
             jump filter_FORWARD_ZONES
-            jump filter_FORWARD_POLICIES_post
             ct state invalid log prefix "STATE_INVALID_DROP: "
             ct state invalid drop
             log prefix "FINAL_REJECT: "
@@ -47,9 +43,7 @@ IPTABLES_LIST_RULES([filter], [INPUT], 0, [dnl
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
     INPUT_direct all -- 0.0.0.0/0 0.0.0.0/0
-    INPUT_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     INPUT_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    INPUT_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
     LOG all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
     DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     LOG all -- 0.0.0.0/0 0.0.0.0/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
@@ -59,9 +53,7 @@ IPTABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
     FORWARD_direct all -- 0.0.0.0/0 0.0.0.0/0
-    FORWARD_POLICIES_pre all -- 0.0.0.0/0 0.0.0.0/0
     FORWARD_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    FORWARD_POLICIES_post all -- 0.0.0.0/0 0.0.0.0/0
     LOG all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
     DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     LOG all -- 0.0.0.0/0 0.0.0.0/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
@@ -71,9 +63,7 @@ IP6TABLES_LIST_RULES([filter], [INPUT], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
     ACCEPT all ::/0 ::/0
     INPUT_direct all ::/0 ::/0
-    INPUT_POLICIES_pre all ::/0 ::/0
     INPUT_ZONES all ::/0 ::/0
-    INPUT_POLICIES_post all ::/0 ::/0
     LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
     DROP all ::/0 ::/0 ctstate INVALID
     LOG all ::/0 ::/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
@@ -84,9 +74,7 @@ IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all ::/0 ::/0
     FORWARD_direct all ::/0 ::/0
     RFC3964_IPv4 all ::/0 ::/0
-    FORWARD_POLICIES_pre all ::/0 ::/0
     FORWARD_ZONES all ::/0 ::/0
-    FORWARD_POLICIES_post all ::/0 ::/0
     LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
     DROP all ::/0 ::/0 ctstate INVALID
     LOG all ::/0 ::/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "


### PR DESCRIPTION
Since f2896e43c3a5 ("fix(zone): target: default is now similar to
reject") zones are fully terminal. They always end in an
accept/drop/reject. As a result policies with a priority >0 are not
actually reachable. The dispatch happens _after_ the zone's chains.

The solution is to jump to the policy dispatch just before the catch-all
accept/drop/reject in the zone. Since we're doing that we might as well
move the < 0 policy dispatch into the zone chains for uniformity. The
latter has no functional difference.

The exception is the OUTPUT chains. They don't have zone dispatch so the
top level jump to policy dispatch is retained.

Fixes: f2896e43c3a5 ("fix(zone): target: default is now similar to reject")