### PR TITLE
test(functions): nft: normalize ICMP type output

### DIFF
--- a/src/tests/cli/firewall-cmd.at
+++ b/src/tests/cli/firewall-cmd.at
@@ -1383,7 +1383,7 @@ FWD_START_TEST([rich rules priority])
         jump filter_IN_public_post
         jump filter_INPUT_POLICIES_post
         meta l4proto { icmp, ipv6-icmp } accept
-        reject with icmpx type admin-prohibited
+        reject with icmpx admin-prohibited
         }
         }
     ])
@@ -1397,7 +1397,7 @@ FWD_START_TEST([rich rules priority])
         jump filter_FWD_public_allow
         jump filter_FWD_public_post
         jump filter_FORWARD_POLICIES_post
-        reject with icmpx type admin-prohibited
+        reject with icmpx admin-prohibited
         }
         }
     ])
@@ -1568,7 +1568,7 @@ FWD_START_TEST([rich rules priority])
         iifname "lo" accept
         jump filter_INPUT_ZONES
         ct state invalid drop
-        reject with icmpx type admin-prohibited
+        reject with icmpx admin-prohibited
         }
         }
     ])
@@ -1704,18 +1704,18 @@ FWD_START_TEST([rich rules priority])
     NFT_LIST_RULES([inet], [filter_IN_public_pre], 0, [dnl
         table inet firewalld {
         chain filter_IN_public_pre {
-        icmp type destination-unreachable reject with icmpx type admin-prohibited
-        icmpv6 type destination-unreachable reject with icmpx type admin-prohibited
-        icmp type echo-request accept
-        icmpv6 type echo-request accept
+        icmp destination-unreachable reject with icmpx admin-prohibited
+        icmpv6 destination-unreachable reject with icmpx admin-prohibited
+        icmp echo-request accept
+        icmpv6 echo-request accept
         }
         }
     ])
     NFT_LIST_RULES([inet], [filter_IN_public_deny], 0, [dnl
         table inet firewalld {
         chain filter_IN_public_deny {
-        icmp type destination-unreachable reject with icmpx type admin-prohibited
-        icmpv6 type destination-unreachable reject with icmpx type admin-prohibited
+        icmp destination-unreachable reject with icmpx admin-prohibited
+        icmpv6 destination-unreachable reject with icmpx admin-prohibited
         }
         }
     ])
@@ -1724,8 +1724,8 @@ FWD_START_TEST([rich rules priority])
         chain filter_IN_public_allow {
         tcp dport 22 ct state new,untracked accept
         ip6 daddr fe80::/64 udp dport 546 ct state new,untracked accept
-        icmp type echo-request accept
-        icmpv6 type echo-request accept
+        icmp echo-request accept
+        icmpv6 echo-request accept
         }
         }
     ])

--- a/src/tests/features/icmp_blocks.at
+++ b/src/tests/features/icmp_blocks.at
@@ -34,13 +34,13 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
 NFT_LIST_RULES([inet], [filter_IN_policy_foobar_deny], 0, [dnl
     table inet firewalld {
         chain filter_IN_policy_foobar_deny {
-            icmp type echo-request reject with icmpx type admin-prohibited
-            icmpv6 type echo-request reject with icmpx type admin-prohibited
-            icmp type echo-reply reject with icmpx type admin-prohibited
-            icmpv6 type echo-reply reject with icmpx type admin-prohibited
-            icmp type redirect reject with icmpx type admin-prohibited
-            icmpv6 type nd-redirect reject with icmpx type admin-prohibited
-            ip6 saddr 1234:5678::/64 icmpv6 type nd-redirect reject with icmpx type admin-prohibited
+            icmp echo-request reject with icmpx admin-prohibited
+            icmpv6 echo-request reject with icmpx admin-prohibited
+            icmp echo-reply reject with icmpx admin-prohibited
+            icmpv6 echo-reply reject with icmpx admin-prohibited
+            icmp redirect reject with icmpx admin-prohibited
+            icmpv6 nd-redirect reject with icmpx admin-prohibited
+            ip6 saddr 1234:5678::/64 icmpv6 nd-redirect reject with icmpx admin-prohibited
         }
     }
 ])
@@ -102,9 +102,9 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
 NFT_LIST_RULES([inet], [filter_IN_policy_foobar_deny], 0, [dnl
     table inet firewalld {
         chain filter_IN_policy_foobar_deny {
-            icmp type echo-request reject with icmpx type admin-prohibited
-            icmpv6 type echo-request reject with icmpx type admin-prohibited
-            ip6 saddr 1234:5678::/64 icmpv6 type nd-redirect reject with icmpx type admin-prohibited
+            icmp echo-request reject with icmpx admin-prohibited
+            icmpv6 echo-request reject with icmpx admin-prohibited
+            ip6 saddr 1234:5678::/64 icmpv6 nd-redirect reject with icmpx admin-prohibited
         }
     }
 ])

--- a/src/tests/features/rfc3964_ipv4.at
+++ b/src/tests/features/rfc3964_ipv4.at
@@ -11,12 +11,12 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
     ct state established,related accept
     ct status dnat accept
     iifname "lo" accept
-    ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 type addr-unreachable
+    ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 addr-unreachable
     jump filter_FORWARD_ZONES
     ct state invalid log prefix "STATE_INVALID_DROP: "
     ct state invalid drop
     log prefix "FINAL_REJECT: "
-    reject with icmpx type admin-prohibited
+    reject with icmpx admin-prohibited
     }
     }
 ])
@@ -25,7 +25,7 @@ NFT_LIST_RULES([inet], [filter_OUTPUT], 0, [dnl
     chain filter_OUTPUT {
     ct state established,related accept
     oifname "lo" accept
-    ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 type addr-unreachable
+    ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 addr-unreachable
     jump filter_OUTPUT_POLICIES_pre
     jump filter_OUTPUT_POLICIES_post
     }
@@ -84,7 +84,7 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
     ct state invalid log prefix "STATE_INVALID_DROP: "
     ct state invalid drop
     log prefix "FINAL_REJECT: "
-    reject with icmpx type admin-prohibited
+    reject with icmpx admin-prohibited
     }
     }
 ])

--- a/src/tests/features/rich_rules.at
+++ b/src/tests/features/rich_rules.at
@@ -72,7 +72,7 @@ IPTABLES_LIST_RULES([filter], [IN_foobar_log], 0, [dnl
 NFT_LIST_RULES([inet], [filter_IN_policy_foobar_deny], 0, [dnl
     table inet firewalld {
         chain filter_IN_policy_foobar_deny {
-            ip saddr 10.10.10.12 reject
+            ip saddr 10.10.10.12 reject with icmp port-unreachable
             ip saddr 10.10.10.13 drop
         }
     }
@@ -144,11 +144,11 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_pre], 0, [dnl
             ip6 daddr 1234::4444 ip6 saddr 1234::4321 drop
             ip daddr 10.20.20.23 ip saddr 10.20.20.22 drop
             ip daddr 10.20.20.21 accept
-            icmp type echo-request accept
-            icmpv6 type echo-request accept
+            icmp echo-request accept
+            icmpv6 echo-request accept
             ip saddr 10.10.10.14 accept
             ip saddr 10.20.20.20 accept
-            icmpv6 type nd-neighbor-advert accept
+            icmpv6 nd-neighbor-advert accept
         }
     }
 ])

--- a/src/tests/features/zone.at
+++ b/src/tests/features/zone.at
@@ -99,7 +99,7 @@ NFT_LIST_RULES([inet], [filter_IN_foobar], 0, [dnl
             jump filter_IN_foobar_post
             jump filter_INPUT_POLICIES_post
             meta l4proto { icmp, ipv6-icmp } accept
-            reject with icmpx type admin-prohibited
+            reject with icmpx admin-prohibited
         }
     }
 ])
@@ -136,7 +136,7 @@ NFT_LIST_RULES([inet], [filter_FWD_foobar], 0, [dnl
             jump filter_FWD_foobar_allow
             jump filter_FWD_foobar_post
             jump filter_FORWARD_POLICIES_post
-            reject with icmpx type admin-prohibited
+            reject with icmpx admin-prohibited
         }
     }
 ])

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -419,6 +419,10 @@ m4_define([NFT_LIST_RULES_NORMALIZE], [dnl
         -e 's/reject with icmp\(x\|v6\)\? type port-unreachable/reject/' dnl
         dnl transform iifname { "foobar0" } to iifname "foobar0"
         -e ['s/\(iifname\|oifname\) [{] \([^, ]\+\) [}]/\1 \2/g'] dnl
+        dnl transform "icmp type foobar" to "icmp foobar"
+        -e ['s/\(icmp\|icmpv6\|icmpx\) type \([a-z-]\+\)/\1 \2/g'] dnl
+        dnl transform bare "reject" to "reject with icmp port-unreachable"
+        -e ['s/reject$/reject with icmp port-unreachable/g'] dnl
 ])
 
 m4_define([NFT_LIST_RULES_ALWAYS], [

--- a/src/tests/regression/gh258.at
+++ b/src/tests/regression/gh258.at
@@ -19,7 +19,7 @@ NFT_LIST_RULES([inet], [filter_INPUT], 0, [dnl
             iifname "lo" accept
             jump filter_INPUT_ZONES
             ct state invalid drop
-            reject with icmpx type admin-prohibited
+            reject with icmpx admin-prohibited
         }
     }
 ])
@@ -40,10 +40,10 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
             ct state established,related accept
             ct status dnat accept
             iifname "lo" accept
-            ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } reject with icmpv6 type addr-unreachable
+            ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } reject with icmpv6 addr-unreachable
             jump filter_FORWARD_ZONES
             ct state invalid drop
-            reject with icmpx type admin-prohibited
+            reject with icmpx admin-prohibited
         }
     }
 ])

--- a/src/tests/regression/icmp_block_in_forward_chain.at
+++ b/src/tests/regression/icmp_block_in_forward_chain.at
@@ -6,7 +6,7 @@ FWD_CHECK([-q --zone=public --add-icmp-block=host-prohibited])
 NFT_LIST_RULES([inet], [filter_IN_public_deny | sed -e 's/icmp code 10/icmp code host-prohibited/'], 0, [dnl
     table inet firewalld {
         chain filter_IN_public_deny {
-            icmp type destination-unreachable icmp code host-prohibited reject with icmpx type admin-prohibited
+            icmp destination-unreachable icmp code host-prohibited reject with icmpx admin-prohibited
         }
     }
 ])

--- a/src/tests/regression/rhbz1514043.at
+++ b/src/tests/regression/rhbz1514043.at
@@ -19,7 +19,7 @@ NFT_LIST_RULES([inet], [filter_INPUT], 0, [dnl
             ct state invalid log prefix "STATE_INVALID_DROP: "
             ct state invalid drop
             log prefix "FINAL_REJECT: "
-            reject with icmpx type admin-prohibited
+            reject with icmpx admin-prohibited
         }
     }
 ])
@@ -29,12 +29,12 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
             ct state established,related accept
             ct status dnat accept
             iifname "lo" accept
-            ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 type addr-unreachable
+            ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 addr-unreachable
             jump filter_FORWARD_ZONES
             ct state invalid log prefix "STATE_INVALID_DROP: "
             ct state invalid drop
             log prefix "FINAL_REJECT: "
-            reject with icmpx type admin-prohibited
+            reject with icmpx admin-prohibited
         }
     }
 ])

--- a/src/tests/regression/rhbz1855140.at
+++ b/src/tests/regression/rhbz1855140.at
@@ -9,7 +9,7 @@ FWD_RELOAD
 NFT_LIST_RULES([inet], [mangle_PRE_public_allow], 0, [dnl
     table inet firewalld {
         chain mangle_PRE_public_allow {
-            icmpv6 type parameter-problem icmpv6 code no-route mark set mark & 0x00000086 ^ 0x00000086
+            icmpv6 parameter-problem icmpv6 code no-route mark set mark & 0x00000086 ^ 0x00000086
         }
     }
 ])
@@ -18,10 +18,10 @@ NFT_LIST_RULES([inet], [filter_IN_public_allow], 0, [dnl
         chain filter_IN_public_allow {
             tcp dport 22 ct state new,untracked accept
             ip6 daddr fe80::/64 udp dport 546 ct state new,untracked accept
-            icmp type echo-request accept
-            icmpv6 type echo-request accept
-            icmpv6 type nd-neighbor-advert accept
-            icmp type timestamp-request accept
+            icmp echo-request accept
+            icmpv6 echo-request accept
+            icmpv6 nd-neighbor-advert accept
+            icmp timestamp-request accept
         }
     }
 ])


### PR DESCRIPTION
Since nftables commit d0f3b9eaab8d ("payload: auto-remove simple
icmp/icmpv6 dependency expressions") the ICMP output may remove
dependencies. As such normalize the output to be compatible with old and
new versions.