### PR TITLE
docs(policy): fix typo in 'target' values

### DIFF
--- a/doc/xml/firewalld.policy.xml
+++ b/doc/xml/firewalld.policy.xml
@@ -108,13 +108,13 @@
                 </varlistentry>
 
                 <varlistentry>
-                    <term>target="<literal>CONTINUE</literal><literal>ACCEPT</literal>|<literal>REJECT</literal>|<literal>DROP</literal>"</term>
+                    <term>target="<literal>CONTINUE</literal>|<literal>ACCEPT</literal>|<literal>REJECT</literal>|<literal>DROP</literal>"</term>
                     <listitem>
                         <para>
                             Can be used to accept, reject or drop every packet
                             that doesn't match any rule (port, service, etc.).
                             The <literal>CONTINUE</literal> is the default and
-                            used for policies that an non-terminal.
+                            used for policies that are non-terminal.
                         </para>
                     </listitem>
                 </varlistentry>


### PR DESCRIPTION
A typo in manpage causes following content in keys description:
`target="CONTINUEACCEPT|REJECT|DROP"` 