### PR TITLE
test(functions): network-manager - manage test dev

### DIFF
--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -46,6 +46,9 @@ plugins=
 [[logging]]
 #level=DEBUG
 #domains=ALL
+
+[[keyfile]]
+unmanaged-devices=*,except:type:dummy,except:type:ovs-bridge,except:type:ovs-port,except:type:ovs-interface
 ])
 
     NM_ARGS="--no-daemon --config ./NetworkManager.conf"


### PR DESCRIPTION
On some configurations, dummy devices may not be managed by
network-manager, even with specification of the config data.
Add dummy to the devices to be managed, along with other devices types
I've found in the test suites.

With this rhbz1928860.at is able to pass on Ubuntu.
From https://bugs.launchpad.net/ubuntu/+source/firewalld/+bug/1945596