### PR TITLE
typo fixes

### DIFF
--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -1631,7 +1631,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
          <term><option>--permanent</option> <option>--service</option>=<replaceable>service</replaceable> <option>--query-port</option>=<replaceable>portid</replaceable><optional>-<replaceable>portid</replaceable></optional>/<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
-             Return wether the port has been added to the permanent service.
+             Return whether the port has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1664,7 +1664,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
          <term><option>--permanent</option> <option>--service</option>=<replaceable>service</replaceable> <option>--query-protocol</option>=<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
-             Return wether the protocol has been added to the permanent service.
+             Return whether the protocol has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1697,7 +1697,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
          <term><option>--permanent</option> <option>--service</option>=<replaceable>service</replaceable> <option>--query-source-port</option>=<replaceable>portid</replaceable><optional>-<replaceable>portid</replaceable></optional>/<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
-             Return wether the source port has been added to the permanent service.
+             Return whether the source port has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1730,7 +1730,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
          <term><option>--permanent</option> <option>--service</option>=<replaceable>service</replaceable> <option>--query-helper</option>=<replaceable>helper</replaceable></term>
          <listitem>
            <para>
-             Return wether the helper has been added to the permanent service.
+             Return whether the helper has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1763,7 +1763,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
          <term><option>--permanent</option> <option>--service</option>=<replaceable>service</replaceable> <option>--query-destination</option>=<replaceable>ipv</replaceable>:<replaceable>address</replaceable><optional>/<replaceable>mask</replaceable></optional></term>
          <listitem>
            <para>
-             Return wether the destination ipv to address[/mask] has been set in the permanent service.
+             Return whether the destination ipv to address[/mask] has been set in the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1796,7 +1796,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
          <term><option>--permanent</option> <option>--service</option>=<replaceable>service</replaceable> <option>--query-include</option>=<replaceable>service</replaceable></term>
          <listitem>
            <para>
-             Return wether the include has been added to the permanent service.
+             Return whether the include has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1942,7 +1942,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
          <term><option>--permanent</option> <option>--helper</option>=<replaceable>helper</replaceable> <option>--query-port</option>=<replaceable>portid</replaceable><optional>-<replaceable>portid</replaceable></optional>/<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
-             Return wether the port has been added to the permanent helper.
+             Return whether the port has been added to the permanent helper.
            </para>
          </listitem>
        </varlistentry>

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -1633,7 +1633,7 @@
          <term><option>--service</option>=<replaceable>service</replaceable> <option>--query-port</option>=<replaceable>portid</replaceable><optional>-<replaceable>portid</replaceable></optional>/<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
-             Return wether the port has been added to the permanent service.
+             Return whether the port has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1666,7 +1666,7 @@
          <term><option>--service</option>=<replaceable>service</replaceable> <option>--query-protocol</option>=<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
-             Return wether the protocol has been added to the permanent service.
+             Return whether the protocol has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1699,7 +1699,7 @@
          <term><option>--service</option>=<replaceable>service</replaceable> <option>--query-source-port</option>=<replaceable>portid</replaceable><optional>-<replaceable>portid</replaceable></optional>/<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
-             Return wether the source port has been added to the permanent service.
+             Return whether the source port has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1732,7 +1732,7 @@
          <term><option>--service</option>=<replaceable>service</replaceable> <option>--query-helper</option>=<replaceable>helper</replaceable></term>
          <listitem>
            <para>
-             Return wether the helper has been added to the permanent service.
+             Return whether the helper has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1765,7 +1765,7 @@
          <term><option>--service</option>=<replaceable>service</replaceable> <option>--query-destination</option>=<replaceable>ipv</replaceable>:<replaceable>address</replaceable><optional>/<replaceable>mask</replaceable></optional></term>
          <listitem>
            <para>
-             Return wether the destination ipv to address[/mask] has been set in the permanent service.
+             Return whether the destination ipv to address[/mask] has been set in the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1798,7 +1798,7 @@
          <term><option>--service</option>=<replaceable>service</replaceable> <option>--query-include</option>=<replaceable>service</replaceable></term>
          <listitem>
            <para>
-             Return wether the include has been added to the permanent service.
+             Return whether the include has been added to the permanent service.
            </para>
          </listitem>
        </varlistentry>
@@ -1944,7 +1944,7 @@
          <term><option>--helper</option>=<replaceable>helper</replaceable> <option>--query-port</option>=<replaceable>portid</replaceable><optional>-<replaceable>portid</replaceable></optional>/<replaceable>protocol</replaceable></term>
          <listitem>
            <para>
-             Return wether the port has been added to the permanent helper.
+             Return whether the port has been added to the permanent helper.
            </para>
          </listitem>
        </varlistentry>

--- a/doc/xml/firewalld.dbus.xml
+++ b/doc/xml/firewalld.dbus.xml
@@ -488,7 +488,7 @@
     <refsect2 id="FirewallD1.ipset">
       <title>org.fedoraproject.FirewallD1.ipset</title>
       <para>
-	Operations in this interface allows to get, add, remove and query runtime ipset settings.
+	Operations in this interface allows one to get, add, remove and query runtime ipset settings.
 	For permanent configuration see <link linkend="FirewallD1.config.ipset">org.fedoraproject.FirewallD1.config.ipset</link> interface.
       </para>
 
@@ -1281,7 +1281,7 @@
     <refsect2 id="FirewallD1.zone">
       <title>org.fedoraproject.FirewallD1.zone</title>
       <para>
-	Operations in this interface allows to get, add, remove and query runtime zone's settings.
+	Operations in this interface allows one to get, add, remove and query runtime zone's settings.
 	For permanent settings see <link linkend="FirewallD1.config.zone">org.fedoraproject.FirewallD1.config.zone</link> interface.
       </para>
 
@@ -2313,7 +2313,7 @@
     <refsect2 id="FirewallD1.policy">
       <title>org.fedoraproject.FirewallD1.policy</title>
       <para>
-        Operations in this interface allows to get, add, remove and query runtime policy settings.
+        Operations in this interface allows one to get, add, remove and query runtime policy settings.
         For permanent settings see <link linkend="FirewallD1.config.policy">org.fedoraproject.FirewallD1.config.policy</link> interface.
       </para>
 
@@ -2391,7 +2391,7 @@
     <refsect2 id="FirewallD1.config">
       <title>org.fedoraproject.FirewallD1.config</title>
       <para>
-	Allows to permanently add, remove and query zones, services and icmp types.
+	Allows one to permanently add, remove and query zones, services and icmp types.
       </para>
 
       <refsect3 id="FirewallD1.config.Methods">

--- a/doc/xml/firewalld.direct.xml
+++ b/doc/xml/firewalld.direct.xml
@@ -72,7 +72,7 @@
     </para>
 
     <para>
-      A firewalld direct configuration file contains informations about permanent direct chains, rules and passthrough ...
+      A firewalld direct configuration file contains information about permanent direct chains, rules and passthrough ...
     </para>
 
     <para>


### PR DESCRIPTION
Spotted by lintian:
```
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-cmd.1.gz line 1300 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-cmd.1.gz line 1320 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-cmd.1.gz line 1340 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-cmd.1.gz line 1360 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-cmd.1.gz line 1380 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-cmd.1.gz line 1478 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-offline-cmd.1.gz line 1168 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-offline-cmd.1.gz line 1188 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-offline-cmd.1.gz line 1208 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-offline-cmd.1.gz line 1228 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-offline-cmd.1.gz line 1248 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-offline-cmd.1.gz line 1268 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man1/firewall-offline-cmd.1.gz line 1366 wether whether
N:
I: firewalld: typo-in-manual-page usr/share/man/man5/firewalld.dbus.5.gz line 1406 "allows to" "allows one to"
N:
I: firewalld: typo-in-manual-page usr/share/man/man5/firewalld.dbus.5.gz line 2454 "allows to" "allows one to"
N:
I: firewalld: typo-in-manual-page usr/share/man/man5/firewalld.dbus.5.gz line 2523 "Allows to" "Allows one to"
N:
I: firewalld: typo-in-manual-page usr/share/man/man5/firewalld.dbus.5.gz line 469 "allows to" "allows one to"
N:
I: firewalld: typo-in-manual-page usr/share/man/man5/firewalld.direct.5.gz line 61 informations information
```