### PR TITLE
add gpsd-server service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -164,6 +164,7 @@ CONFIG_FILES = \
 	services/ganglia-client.xml \
 	services/ganglia-master.xml \
 	services/git.xml \
+	services/gpsd.xml \
 	services/grafana.xml \
 	services/gre.xml \
 	services/high-availability.xml \

--- a/config/services/gpsd.xml
+++ b/config/services/gpsd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>gpsd</short>
+  <description>gpsd is a service daemon that monitors one or more GPSes or AIS receivers attached to a host computer through serial or USB ports, making all data on the location/course/velocity of the sensors available to be queried on TCP port 2947 of the host computer.</description>
+  <port protocol="tcp" port="2947" />
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -96,6 +96,7 @@ config/services/galera.xml
 config/services/ganglia-client.xml
 config/services/ganglia-master.xml
 config/services/git.xml
+config/services/gpsd.xml
 config/services/grafana.xml
 config/services/gre.xml
 config/services/high-availability.xml


### PR DESCRIPTION
[gpsd](https://gpsd.io/) is a service daemon that monitors one or more GPSes or AIS receivers attached to a host computer through serial or USB ports, making all data on the location/course/velocity of the sensors available to be queried on TCP port 2947 of the host computer.