### PR TITLE
docs(firewall-cmd): fix typo in set-target option

### DIFF
--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -523,7 +523,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>--permanent</option> <optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <optional><option>--policy</option>=<replaceable>policy</replaceable></optional> <option>--set-target</option>=<replaceable>zone</replaceable></term>
+        <term><option>--permanent</option> <optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <optional><option>--policy</option>=<replaceable>policy</replaceable></optional> <option>--set-target</option>=<replaceable>target</replaceable></term>
         <listitem>
           <para>
             Set the target.

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -615,7 +615,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <optional><option>--policy</option>=<replaceable>policy</replaceable></optional> <option>--set-target</option>=<replaceable>zone</replaceable></term>
+        <term><optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <optional><option>--policy</option>=<replaceable>policy</replaceable></optional> <option>--set-target</option>=<replaceable>target</replaceable></term>
         <listitem>
           <para>
             Set the target.


### PR DESCRIPTION
The value type should be target rather than zone