### PR TITLE
fix(systemd): order Before network.target

### DIFF
--- a/config/firewalld.service.in
+++ b/config/firewalld.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=firewalld - dynamic firewall daemon
-Before=network-pre.target
-Wants=network-pre.target
+Before=network.target
 After=dbus.service
 After=polkit.service
 Conflicts=iptables.service ip6tables.service ebtables.service ipset.service nftables.service


### PR DESCRIPTION
This avoids a dependency loop with cloud-init and other early boot
services.

The alternative is to also become an early boot service by using
`DefaultDependencies=no`, but that would mean changes inside of firewalld
to handle dbus not being available.

Fixes: #414