### PR TITLE
Simplify logging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,12 @@ AC_ARG_WITH([ipset],
        [AC_PATH_PROG([IPSET], [ipset], [/bin/false], [$FW_TOOLS_PATH])])
 AC_SUBST(IPSET)
 
+DEFAULT_LOG_TARGET=${DEFAULT_LOG_TARGET:-mixed}
+AC_ARG_VAR([DEFAULT_LOG_TARGET], m4_flatten([
+            Select the default logging backend. One of: mixed, syslog, file, console.
+            Mixed means both syslog and file targets. Mixed is the default.
+           ]))
+
 #############################################################
 
 AC_SUBST([GETTEXT_PACKAGE], '[PKG_NAME]')

--- a/doc/xml/firewalld.xml.in
+++ b/doc/xml/firewalld.xml.in
@@ -90,7 +90,7 @@
         <term><option>--debug</option><optional>=<replaceable>level</replaceable></optional></term>
         <listitem>
 	  <para>
-	    Set the debug level for firewalld to <replaceable>level</replaceable>. The range of the debug level is 1 (lowest level) to 10 (highest level). The debug output will be written to the firewalld log file <filename class="directory">/var/log/firewalld</filename>.
+	    Set the debug level for firewalld to <replaceable>level</replaceable>. The range of the debug level is 1 (lowest level) to 10 (highest level). The debug output will be written to the firewalld log file specified by --log-file.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -102,6 +102,28 @@
 	    Print garbage collector leak information. The collector runs every 10 seconds and if there are leaks, it prints information about the leaks.
 	  </para>
 	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>--log-target</option>
+        </term>
+        <listitem>
+          <para>
+            Define the output target to which log messages are written. In mixed mode, Firewalld writes info-level log messages to syslog. Debug messages are written to a file (see the --log-file parameter). Info messages also go to stdout and stderr. The syslog, file or console modes write all messages to the one configured target only.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>
+          <option>--log-file</option>
+        </term>
+        <listitem>
+          <para>
+            Define the file where debug messages are written to. The default file is <filename class="directory">/var/log/firewalld</filename>.
+          </para>
+        </listitem>
       </varlistentry>
 
       <varlistentry>

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -93,6 +93,8 @@ set_default_config_paths('/usr/lib/firewalld')
 
 FIREWALLD_LOGFILE = '/var/log/firewalld'
 
+FIREWALLD_LOGTARGET = '@DEFAULT_LOG_TARGET@'
+
 FIREWALLD_PIDFILE = "/var/run/firewalld.pid"
 
 FIREWALLD_TEMPDIR = '/run/firewalld'

--- a/src/firewalld.in
+++ b/src/firewalld.in
@@ -61,6 +61,12 @@ def parse_cmdline():
     parser.add_argument('--default-config',
                         help="""Path to firewalld default configuration""",
                         metavar="path")
+    parser.add_argument('--log-target',
+                        choices=['mixed', 'syslog', 'file', 'console'],
+                        default='@DEFAULT_LOG_TARGET@',
+                        help="""Log target.
+                        mixed is a backward compatible mode logging to multiple targets.
+                        The modes syslog, file or console log to one target only.""")
     parser.add_argument('--log-file',
                         help="""Path to firewalld log file""",
                         metavar="path")
@@ -68,34 +74,68 @@ def parse_cmdline():
 
 def setup_logging(args):
     # Set up logging capabilities
-    log.setDateFormat("%Y-%m-%d %H:%M:%S")
-    log.setFormat("%(date)s %(label)s%(message)s")
-    log.setInfoLogging("*", log.syslog, [ log.FATAL, log.ERROR, log.WARNING,
-                                          log.TRACEBACK ],
-                       fmt="%(label)s%(message)s")
-    log.setDebugLogLevel(log.NO_INFO)
-    log.setDebugLogLevel(log.NO_DEBUG)
-
-    if args.debug:
-        log.setInfoLogLevel(log.INFO_MAX)
-        log.setDebugLogLevel(args.debug)
-        if args.nofork:
-            log.addInfoLogging("*", log.stdout)
-            log.addDebugLogging("*", log.stdout)
-
-    log_file = FileLog(config.FIREWALLD_LOGFILE, "a")
-    try:
-        log_file.open()
-    except IOError as e:
-        log.error("Failed to open log file '%s': %s", config.FIREWALLD_LOGFILE,
-                  str(e))
-    else:
-        log.addInfoLogging("*", log_file, [ log.FATAL, log.ERROR, log.WARNING,
-                                            log.TRACEBACK ])
-        log.addDebugLogging("*", log_file)
+    if config.FIREWALLD_LOGTARGET == 'syslog':
+        log.setFormat("%(label)s%(message)s")
+        log.setInfoLogging("*", log.syslog)
         if args.debug:
-            log.addInfoLogging("*", log_file)
+            log.setDebugLogging("*", log.syslog)
+            log.setInfoLogLevel(log.INFO_MAX)
+            log.setDebugLogLevel(args.debug)
+
+    elif config.FIREWALLD_LOGTARGET == 'file':
+        log.setDateFormat("%Y-%m-%d %H:%M:%S")
+        log.setFormat("%(date)s %(label)s%(message)s")
+        log_file = FileLog(config.FIREWALLD_LOGFILE, "a")
+        try:
+            log_file.open()
+        except IOError as e:
+            print("Failed to open log file '%s': %s", config.FIREWALLD_LOGFILE,
+                    str(e))
+        else:
+            log.setInfoLogging("*", log_file)
+            if args.debug:
+                log.setDebugLogging("*", log_file)
+                log.setInfoLogLevel(log.INFO_MAX)
+                log.setDebugLogLevel(args.debug)
+
+    elif config.FIREWALLD_LOGTARGET == 'console':
+        log.setDateFormat("%Y-%m-%d %H:%M:%S")
+        log.setFormat("%(date)s %(label)s%(message)s")
+        log.setInfoLogging("*", log.stdout)
+        if args.debug:
+            log.setDebugLogging("*", log.stdout)
+            log.setInfoLogLevel(log.INFO_MAX)
+            log.setDebugLogLevel(args.debug)
+
+    else:
+        log.setDateFormat("%Y-%m-%d %H:%M:%S")
+        log.setFormat("%(date)s %(label)s%(message)s")
+        log.setInfoLogging("*", log.syslog, [ log.FATAL, log.ERROR, log.WARNING,
+                                            log.TRACEBACK ],
+                        fmt="%(label)s%(message)s")
+        log.setDebugLogLevel(log.NO_INFO)
+        log.setDebugLogLevel(log.NO_DEBUG)
+
+        if args.debug:
+            log.setInfoLogLevel(log.INFO_MAX)
+            log.setDebugLogLevel(args.debug)
+            if args.nofork:
+                log.addInfoLogging("*", log.stdout)
+                log.addDebugLogging("*", log.stdout)
+
+        log_file = FileLog(config.FIREWALLD_LOGFILE, "a")
+        try:
+            log_file.open()
+        except IOError as e:
+            log.error("Failed to open log file '%s': %s", config.FIREWALLD_LOGFILE,
+                    str(e))
+        else:
+            log.addInfoLogging("*", log_file, [ log.FATAL, log.ERROR, log.WARNING,
+                                                log.TRACEBACK ])
             log.addDebugLogging("*", log_file)
+            if args.debug:
+                log.addInfoLogging("*", log_file)
+                log.addDebugLogging("*", log_file)
 
 def startup(args):
     try:
@@ -197,6 +237,7 @@ def main():
     # Process the command-line arguments
     args = parse_cmdline()
 
+    config.FIREWALLD_LOGTARGET = args.log_target
     if args.log_file:
         config.FIREWALLD_LOGFILE = args.log_file
 


### PR DESCRIPTION
This adds a new parameter to firewalld: --log-target. It allows to configure firewalld to send log messages to only one output channel. I think this allows a much better integration with systemd journald and simplifies the usage in general.

Requiring logrotate on a systemd machine seems like a drawback to me.

Generating log messages and redirecting them to /dev/null looks more like a workaround than a great design.