### PR TITLE
docs(dbus): Fix invalid ipset method name

### DIFF
--- a/doc/xml/firewalld.dbus.xml
+++ b/doc/xml/firewalld.dbus.xml
@@ -524,7 +524,7 @@
           </varlistentry>
 
           <varlistentry id="FirewallD1.ipset.Methods.getIPSetSettings">
-            <term><methodname>getSettings</methodname>(s: ipset) &rarr; (ssssa{ss}as)</term>
+            <term><methodname>getIPSetSettings</methodname>(s: ipset) &rarr; (ssssa{ss}as)</term>
             <listitem>
               <para>
                 Return runtime settings of given <replaceable>ipset</replaceable>.


### PR DESCRIPTION
Fixes: #965