### PR TITLE
tests/functions: Remove bashism

### DIFF
--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -141,10 +141,10 @@ m4_define([FWD_START_TEST], [
         ])
 
         dnl dummy wrapper for trap syntax
-        function kill_firewalld() {
+        kill_firewalld() {
             FWD_STOP_FIREWALLD
         }
-        function kill_networkmanager() {
+        kill_networkmanager() {
             if test -f networkmanager.pid; then
                 STOP_NETWORKMANAGER
             fi


### PR DESCRIPTION
On Debian derived systems, /bin/sh points to dash and not bash.
This leads to the following lintian error:
```
E: firewalld-tests: shell-script-fails-syntax-check [usr/share/firewalld/testsuite/integration/testsuite]
N:
N:   Running this shell script with the shell's -n option set fails, which means that the script has syntax errors.
N:   The most common cause of this problem is a script expecting /bin/sh to be bash checked on a system using dash as
N:   /bin/sh.
N:
N:   Run e.g. sh -n yourscript to see the errors yourself.
N:
N:   Note this can have false-positives, for an example with bash scripts using "extglob".
N:
N:   Visibility: error
N:   Show-Always: no
N:   Check: script/syntax
N:
N:
E: firewalld-tests: shell-script-fails-syntax-check [usr/share/firewalld/testsuite/testsuite]
```
Running sh -n points at the problem:

$ sh -n src/tests/testsuite
src/tests/testsuite: 58436: Syntax error: "(" unexpected (expecting ")")
$ sh -n src/tests/integration/testsuite
src/tests/integration/testsuite: 2082: Syntax error: "(" unexpected (expecting ")")