### PR TITLE
Fix for firewalld running on systems with non-modular kernels

### DIFF
--- a/src/firewall/core/modules.py
+++ b/src/firewall/core/modules.py
@@ -40,17 +40,20 @@ class modules(object):
         """ get all loaded kernel modules and their dependencies """
         mods = [ ]
         deps = { }
-        with open("/proc/modules", "r") as f:
-            for line in f:
-                if not line:
-                    break
-                line = line.strip()
-                splits = line.split()
-                mods.append(splits[0])
-                if splits[3] != "-":
-                    deps[splits[0]] = splits[3].split(",")[:-1]
-                else:
-                    deps[splits[0]] = [ ]
+        try:
+            with open("/proc/modules", "r") as f:
+                for line in f:
+                    if not line:
+                        break
+                    line = line.strip()
+                    splits = line.split()
+                    mods.append(splits[0])
+                    if splits[3] != "-":
+                        deps[splits[0]] = splits[3].split(",")[:-1]
+                    else:
+                        deps[splits[0]] = [ ]
+        except FileNotFoundError:
+            pass
 
         return mods, deps # [loaded modules], {module:[dependants]}
 


### PR DESCRIPTION
Don't error if /proc/modules is missing.
This is a fix for #1000 
Not extensively tested, but works well for me.

I'm not aware of why a kernel module would need to be unloaded.   This can't happen on non-modular kernels.  Without being aware of the reason why firewalld attempts to unload kernel modules, I can't comment on what effects the non-unloading of them will have.