### PR TITLE
Revert "feat(service): add Kodi JSON-RPC and EventServer services"

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -193,8 +193,6 @@ CONFIG_FILES = \
 	services/kibana.xml \
 	services/klogin.xml \
 	services/kpasswd.xml \
-	services/kodi-eventserver.xml \
-	services/kodi-rpc.xml \
 	services/kprop.xml \
 	services/kshell.xml \
 	services/kubelet.xml \

--- a/config/services/kodi-eventserver.xml
+++ b/config/services/kodi-eventserver.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<service>
-  <short>Kodi EventServer</short>
-  <description>The Kodi EventServer accepts remote device input.</description>
-  <port protocol="udp" port="9777"/>
-</service>

--- a/config/services/kodi-rpc.xml
+++ b/config/services/kodi-rpc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<service>
-  <short>Kodi JSON-RPC</short>
-  <description>A JSON-RPC interface using TCP transport to communicate with Kodi.</description>
-  <port protocol="tcp" port="9090"/>
-</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -124,8 +124,6 @@ config/services/kdeconnect.xml
 config/services/kerberos.xml
 config/services/kibana.xml
 config/services/klogin.xml
-config/services/kodi-eventserver.xml
-config/services/kodi-rpc.xml
 config/services/kpasswd.xml
 config/services/kprop.xml
 config/services/kshell.xml


### PR DESCRIPTION
This reverts commit e79e99b71d1bab7e7dc88584001a9343c0bccba1.

As said in https://github.com/firewalld/firewalld/pull/552#issuecomment-1193254036, Kodi already provides firewalld services.
I don't know how I missed it, but I'm guessing that when I first created #552, the released version of Kodi didn't have them.