### PR TITLE
feat(service): add bareos-director bareos-filedaemon bareos-storage

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -125,6 +125,9 @@ CONFIG_FILES = \
 	services/ausweisapp2.xml \
 	services/bacula-client.xml \
 	services/bacula.xml \
+	services/bareos-director.xml \
+	services/bareos-filedaemon.xml \
+	services/bareos-storage.xml \
 	services/bb.xml \
 	services/bgp.xml \
 	services/bitcoin-rpc.xml \

--- a/config/services/bareos-director.xml
+++ b/config/services/bareos-director.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Bareos Director Daemon (bareos-dir)</short>
+  <description>This option allows connections to a local Bareos Director. These connections are typically initiated by Bareos consoles (bconsole). Bareos WebUI and Bareos File Daemon (when using Client Initiated Connections).</description>
+  <port protocol="tcp" port="9101"/>
+</service>

--- a/config/services/bareos-filedaemon.xml
+++ b/config/services/bareos-filedaemon.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Bareos File Daemon (bareos-fd)</short>
+  <description>This option allows a Bareos Director to connect to the local Bareos File Daemon.</description>
+  <port protocol="tcp" port="9102"/>
+</service>

--- a/config/services/bareos-storage.xml
+++ b/config/services/bareos-storage.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Bareos Storage Daemon (bareos-sd)</short>
+  <description>This option allows Bareos Director and File Daemons to connect to the local Bareos Storage Daemon to send/receive data and manage volumes.</description>
+  <port protocol="tcp" port="9103"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -58,6 +58,9 @@ config/services/audit.xml
 config/services/ausweisapp2.xml
 config/services/bacula-client.xml
 config/services/bacula.xml
+config/services/bareos-director.xml
+config/services/bareos-filedaemon.xml
+config/services/bareos-storage.xml
 config/services/bb.xml
 config/services/bgp.xml
 config/services/bitcoin-rpc.xml


### PR DESCRIPTION
- Add bareos-director (bareos-dir) service definition for default port 9101.
- Add bareos-filedaemon (bareos-fd) service definition for default port 9102.
- Add bareos-storage (bareos-sd) service definition for default port 9103.

Signed-off-by: Bruno Friedmann <bruno.friedmann@bareos.com>