### PR TITLE
fix(bash): fix ipset commands autocompletion

### DIFF
--- a/shell-completion/bash/firewall-cmd
+++ b/shell-completion/bash/firewall-cmd
@@ -88,7 +88,7 @@ OPTIONS_ZONE="${OPTIONS_ZONE_INTERFACES_SOURCES} \
 OPTIONS_POLICY="${OPTIONS_ZONE_POLICY_ACTION} \
                 ${OPTIONS_POLICY_ADAPT_QUERY}"
 
-OPTIONS_IPSET="${OPTIONS_IPSETACTION_ACTION} ${OPTIONS_IPSET_ADAPT_QUERY}"
+OPTIONS_IPSET="${OPTIONS_IPSET_ACTION_ACTION} ${OPTIONS_IPSET_ADAPT_QUERY}"
 
 OPTIONS_PERMANENT_ONLY="--new-icmptype= --new-icmptype-from-file= --delete-icmptype= \
                         --new-service= --new-service-from-file= --delete-service= \


### PR DESCRIPTION
Fix typo that prevent autocompletion of --ipset commands.