### PR TITLE
feat(service): add Ceph Prometheus exporter

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -136,6 +136,7 @@ CONFIG_FILES = \
 	services/bitcoin.xml \
 	services/bittorrent-lsd.xml \
 	services/lightning-network.xml \
+	services/ceph-exporter.xml \
 	services/ceph-mon.xml \
 	services/ceph.xml \
 	services/cfengine.xml \

--- a/config/services/ceph-exporter.xml
+++ b/config/services/ceph-exporter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>ceph-exporter</short>
+  <description>The Prometheus module running on Ceph manager to expose metrics.</description>
+  <port protocol="tcp" port="9283"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -68,6 +68,7 @@ config/services/bitcoin-testnet-rpc.xml
 config/services/bitcoin-testnet.xml
 config/services/bitcoin.xml
 config/services/bittorrent-lsd.xml
+config/services/ceph-exporter.xml
 config/services/ceph-mon.xml
 config/services/ceph.xml
 config/services/cfengine.xml


### PR DESCRIPTION
Add Prometheus module listening on default port 9283.
(https://docs.ceph.com/en/quincy/mgr/prometheus/)