### PR TITLE
[WIP] fix: drop invalid packets before zone dispatch

### DIFF
--- a/src/tests/cli/firewall-cmd.at
+++ b/src/tests/cli/firewall-cmd.at
@@ -1577,9 +1577,9 @@ FWD_START_TEST([rich rules priority])
         chain filter_INPUT {
         ct state established,related accept
         ct status dnat accept
+        ct state invalid drop
         iifname "lo" accept
         jump filter_INPUT_ZONES
-        ct state invalid drop
         reject with icmpx admin-prohibited
         }
         }

--- a/src/tests/features/policy.at
+++ b/src/tests/features/policy.at
@@ -720,18 +720,18 @@ NFT_LIST_RULES([inet], [filter_INPUT], 0, [dnl
 ])
 IPTABLES_LIST_RULES([filter], [INPUT], 0, [dnl
 ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
+DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
 ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
 INPUT_direct all -- 0.0.0.0/0 0.0.0.0/0
 INPUT_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
 REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited
 ])
 IP6TABLES_LIST_RULES([filter], [INPUT], 0, [dnl
 ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
+DROP all ::/0 ::/0 ctstate INVALID
 ACCEPT all ::/0 ::/0
 INPUT_direct all ::/0 ::/0
 INPUT_ZONES all ::/0 ::/0
-DROP all ::/0 ::/0 ctstate INVALID
 REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
 dnl (filter, forward)
@@ -750,19 +750,19 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
 ])
 IPTABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
 ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
+DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
 ACCEPT all -- 0.0.0.0/0 0.0.0.0/0                                 
 FORWARD_direct all -- 0.0.0.0/0 0.0.0.0/0
 FORWARD_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
 REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited
 ])
 IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
 ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
+DROP all ::/0 ::/0 ctstate INVALID
 ACCEPT all ::/0 ::/0
 FORWARD_direct all ::/0 ::/0
 RFC3964_IPv4 all ::/0 ::/0
 FORWARD_ZONES all ::/0 ::/0
-DROP all ::/0 ::/0 ctstate INVALID
 REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
 dnl (filter, output)

--- a/src/tests/features/policy.at
+++ b/src/tests/features/policy.at
@@ -711,9 +711,9 @@ NFT_LIST_RULES([inet], [filter_INPUT], 0, [dnl
         chain filter_INPUT {
             ct state established,related accept
             ct status dnat accept
+            ct state invalid drop
             iifname "lo" accept
             jump filter_INPUT_ZONES
-            ct state invalid drop
             reject with icmpx admin-prohibited
         }
     }
@@ -740,10 +740,10 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
         chain filter_FORWARD {
             ct state established,related accept
             ct status dnat accept
+            ct state invalid drop
             iifname "lo" accept
             ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } reject with icmpv6 addr-unreachable
             jump filter_FORWARD_ZONES
-            ct state invalid drop
             reject with icmpx admin-prohibited
         }
     }

--- a/src/tests/features/rfc3964_ipv4.at
+++ b/src/tests/features/rfc3964_ipv4.at
@@ -53,12 +53,12 @@ IP6TABLES_LIST_RULES([filter], [RFC3964_IPv4], 0, [dnl
 ])
 IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
+    LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
+    DROP all ::/0 ::/0 ctstate INVALID
     ACCEPT all ::/0 ::/0
     FORWARD_direct all ::/0 ::/0
     RFC3964_IPv4 all ::/0 ::/0
     FORWARD_ZONES all ::/0 ::/0
-    LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
-    DROP all ::/0 ::/0 ctstate INVALID
     LOG all ::/0 ::/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
@@ -102,11 +102,11 @@ NFT_LIST_RULES([inet], [filter_OUTPUT], 0, [dnl
 IP6TABLES_LIST_RULES([filter], [RFC3964_IPv4], 1, [ignore], [ignore])
 IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
+    LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
+    DROP all ::/0 ::/0 ctstate INVALID
     ACCEPT all ::/0 ::/0
     FORWARD_direct all ::/0 ::/0
     FORWARD_ZONES all ::/0 ::/0
-    LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
-    DROP all ::/0 ::/0 ctstate INVALID
     LOG all ::/0 ::/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])

--- a/src/tests/features/rfc3964_ipv4.at
+++ b/src/tests/features/rfc3964_ipv4.at
@@ -10,11 +10,11 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
     chain filter_FORWARD {
     ct state established,related accept
     ct status dnat accept
+    ct state invalid log prefix "STATE_INVALID_DROP: "
+    ct state invalid drop
     iifname "lo" accept
     ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 addr-unreachable
     jump filter_FORWARD_ZONES
-    ct state invalid log prefix "STATE_INVALID_DROP: "
-    ct state invalid drop
     log prefix "FINAL_REJECT: "
     reject with icmpx admin-prohibited
     }
@@ -79,10 +79,10 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
     chain filter_FORWARD {
     ct state established,related accept
     ct status dnat accept
-    iifname "lo" accept
-    jump filter_FORWARD_ZONES
     ct state invalid log prefix "STATE_INVALID_DROP: "
     ct state invalid drop
+    iifname "lo" accept
+    jump filter_FORWARD_ZONES
     log prefix "FINAL_REJECT: "
     reject with icmpx admin-prohibited
     }

--- a/src/tests/regression/gh258.at
+++ b/src/tests/regression/gh258.at
@@ -132,10 +132,10 @@ NFT_LIST_RULES([inet], [nat_POSTROUTING_ZONES], 0, [dnl
 
 IPTABLES_LIST_RULES([filter], [INPUT], 0, [dnl
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
+    DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
     INPUT_direct all -- 0.0.0.0/0 0.0.0.0/0
     INPUT_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited
 ])
 IPTABLES_LIST_RULES([filter], [INPUT_ZONES], 0,
@@ -146,10 +146,10 @@ IPTABLES_LIST_RULES([filter], [INPUT_ZONES], 0,
 ]])
 IPTABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
+    DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
     FORWARD_direct all -- 0.0.0.0/0 0.0.0.0/0
     FORWARD_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited
 ])
 IPTABLES_LIST_RULES([filter], [FORWARD_ZONES], 0,
@@ -201,10 +201,10 @@ IPTABLES_LIST_RULES([nat], [POSTROUTING_ZONES], 0,
 
 IP6TABLES_LIST_RULES([filter], [INPUT], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
+    DROP all ::/0 ::/0 ctstate INVALID
     ACCEPT all ::/0 ::/0
     INPUT_direct all ::/0 ::/0
     INPUT_ZONES all ::/0 ::/0
-    DROP all ::/0 ::/0 ctstate INVALID
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
 IP6TABLES_LIST_RULES([filter], [INPUT_ZONES], 0,
@@ -215,11 +215,11 @@ IP6TABLES_LIST_RULES([filter], [INPUT_ZONES], 0,
 ]])
 IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
+    DROP all ::/0 ::/0 ctstate INVALID
     ACCEPT all ::/0 ::/0
     FORWARD_direct all ::/0 ::/0
     RFC3964_IPv4 all ::/0 ::/0
     FORWARD_ZONES all ::/0 ::/0
-    DROP all ::/0 ::/0 ctstate INVALID
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
 IP6TABLES_LIST_RULES([filter], [FORWARD_ZONES], 0,

--- a/src/tests/regression/gh258.at
+++ b/src/tests/regression/gh258.at
@@ -16,9 +16,9 @@ NFT_LIST_RULES([inet], [filter_INPUT], 0, [dnl
         chain filter_INPUT {
             ct state established,related accept
             ct status dnat accept
+            ct state invalid drop
             iifname "lo" accept
             jump filter_INPUT_ZONES
-            ct state invalid drop
             reject with icmpx admin-prohibited
         }
     }
@@ -39,10 +39,10 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
         chain filter_FORWARD {
             ct state established,related accept
             ct status dnat accept
+            ct state invalid drop
             iifname "lo" accept
             ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } reject with icmpv6 addr-unreachable
             jump filter_FORWARD_ZONES
-            ct state invalid drop
             reject with icmpx admin-prohibited
         }
     }

--- a/src/tests/regression/rhbz1514043.at
+++ b/src/tests/regression/rhbz1514043.at
@@ -41,42 +41,42 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
 
 IPTABLES_LIST_RULES([filter], [INPUT], 0, [dnl
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
+    LOG all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
+    DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
     INPUT_direct all -- 0.0.0.0/0 0.0.0.0/0
     INPUT_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    LOG all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
-    DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     LOG all -- 0.0.0.0/0 0.0.0.0/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
     REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited
 ])
 IPTABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0 ctstate RELATED,ESTABLISHED,DNAT
+    LOG all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
+    DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     ACCEPT all -- 0.0.0.0/0 0.0.0.0/0
     FORWARD_direct all -- 0.0.0.0/0 0.0.0.0/0
     FORWARD_ZONES all -- 0.0.0.0/0 0.0.0.0/0
-    LOG all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
-    DROP all -- 0.0.0.0/0 0.0.0.0/0 ctstate INVALID
     LOG all -- 0.0.0.0/0 0.0.0.0/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
     REJECT all -- 0.0.0.0/0 0.0.0.0/0 reject-with icmp-host-prohibited
 ])
 IP6TABLES_LIST_RULES([filter], [INPUT], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
+    LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
+    DROP all ::/0 ::/0 ctstate INVALID
     ACCEPT all ::/0 ::/0
     INPUT_direct all ::/0 ::/0
     INPUT_ZONES all ::/0 ::/0
-    LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
-    DROP all ::/0 ::/0 ctstate INVALID
     LOG all ::/0 ::/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])
 IP6TABLES_LIST_RULES([filter], [FORWARD], 0, [dnl
     ACCEPT all ::/0 ::/0 ctstate RELATED,ESTABLISHED,DNAT
+    LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
+    DROP all ::/0 ::/0 ctstate INVALID
     ACCEPT all ::/0 ::/0
     FORWARD_direct all ::/0 ::/0
     RFC3964_IPv4 all ::/0 ::/0
     FORWARD_ZONES all ::/0 ::/0
-    LOG all ::/0 ::/0 ctstate INVALID LOG flags 0 level 4 prefix "STATE_INVALID_DROP: "
-    DROP all ::/0 ::/0 ctstate INVALID
     LOG all ::/0 ::/0 LOG flags 0 level 4 prefix "FINAL_REJECT: "
     REJECT all ::/0 ::/0 reject-with icmp6-adm-prohibited
 ])

--- a/src/tests/regression/rhbz1514043.at
+++ b/src/tests/regression/rhbz1514043.at
@@ -14,10 +14,10 @@ NFT_LIST_RULES([inet], [filter_INPUT], 0, [dnl
         chain filter_INPUT {
             ct state established,related accept
             ct status dnat accept
-            iifname "lo" accept
-            jump filter_INPUT_ZONES
             ct state invalid log prefix "STATE_INVALID_DROP: "
             ct state invalid drop
+            iifname "lo" accept
+            jump filter_INPUT_ZONES
             log prefix "FINAL_REJECT: "
             reject with icmpx admin-prohibited
         }
@@ -28,11 +28,11 @@ NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
         chain filter_FORWARD {
             ct state established,related accept
             ct status dnat accept
+            ct state invalid log prefix "STATE_INVALID_DROP: "
+            ct state invalid drop
             iifname "lo" accept
             ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } log prefix "RFC3964_IPv4_REJECT: " reject with icmpv6 addr-unreachable
             jump filter_FORWARD_ZONES
-            ct state invalid log prefix "STATE_INVALID_DROP: "
-            ct state invalid drop
             log prefix "FINAL_REJECT: "
             reject with icmpx admin-prohibited
         }


### PR DESCRIPTION
- [X] move ct state INVALID drop to before zone/policy dispatch
- [ ] remove ct state { NEW, UNTRACKED } from all zone/policy rules