### PR TITLE
ci: automatic releases on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: release
+
+on: 
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+
+  build:
+    env:
+      apt-dependencies: |
+        autoconf automake docbook-xml docbook-xsl ebtables intltool ipset \
+        iptables libdbus-1-dev libgirepository1.0-dev libglib2.0-dev \
+        libxml2-utils nftables pkg-config python3-nftables xsltproc
+
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+      - name: checkout (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: apt update
+        run: sudo apt update
+
+      - name: apt install dependencies
+        run: sudo apt install -y ${{ env.apt-dependencies }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: dist firewalld
+        run: |
+          ./autogen.sh
+          ./configure
+          make dist
+      
+      - name: make release notes
+        run: |
+          set -- $(grep "^Version:" firewalld.spec |cut -f2 -d ' ' |tr '.' ' ')
+          test ${{ github.ref_name }} = v${1}.${2}.${3} || { echo "pushed tag doesn't match rpm spec file"; exit 1; }
+          if test 0 -eq ${2} && test 0 -eq ${3}; then
+            echo "This is a major release. It includes breaking changes."
+            echo
+            git shortlog --format="%s (%h)" --no-merges --grep "BREAKING" v$(expr ${1} - 1).0.0..HEAD
+          elif test 0 -eq ${3}; then
+            echo "This is a feature release. It also includes all bug fixes since v${1}.$(expr ${2} - 1).0."
+            echo
+            git shortlog --format="%s (%h)" --no-merges --grep "^feat" v${1}.$(expr ${2} - 1).0..HEAD
+          else
+            echo "This is a bug fix only release."
+            echo
+            git shortlog --format="%s (%h)" --grep "^\(fix\|doc\)" v${1}.${2}.$(expr ${3} - 1)..HEAD
+          fi | sed -e 's/^[ ]\+/- /' > body.md
+
+      - uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: "firewalld-*.tar.gz"
+          bodyFile: "body.md"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,34 +14,6 @@ DISTCLEANFILES = config.log intltool-*
 
 DISTCLEANDIRS = autom4te.cache ${PACKAGE_NAME}-*
 
-tag:
-	@spec_ver=`awk '/Version:/ { print $$2}' ${PACKAGE_NAME}.spec`; \
-	if test "$$spec_ver" != "${PACKAGE_VERSION}"; then \
-		echo "Spec file and package versions differ: $$spec_ver != ${PACKAGE_VERSION}"; \
-		secs=10; \
-		echo -n "Using ./autogen.sh in $$secs seconds: "; \
-		for i in `seq $$secs -1 1`; do echo -n "."; sleep 1; done; echo; \
-		./autogen.sh; \
-		echo; \
-		echo "Please run make again to apply version changes."; \
-		exit 1; \
-	fi
-	@if ! git diff --quiet --exit-code; then \
-		clear; \
-		echo -n "========================================"; \
-		echo "========================================"; \
-		PAGER= git diff; \
-		echo -n "========================================"; \
-		echo "========================================"; \
-		echo "Do you want to commit these changes? (y/N)"; \
-		read answer; \
-		[ "$$answer" == "Y" -o "$$answer" == "y" ] || exit 1; \
-		git commit -a -m "$(PACKAGE_TAG)"; \
-	fi
-	git tag -f $(PACKAGE_TAG)
-	git push
-	git push --tags
-
 dist: clean-docs update-docs
 
 dist-container:
@@ -54,39 +26,6 @@ dist-container:
 	$(PODMAN) push quay.io/firewalld/firewalld:latest
 	$(PODMAN) save --format oci-archive --output firewalld-oci-$(PACKAGE_VERSION).tar firewalld:$(PACKAGE_VERSION)
 
-dist-check:
-	@rm -f _dist_check_failed
-	@(cat config/Makefile.am | sed -n '/^CONFIG_FILES/,/^$$/p' | head -n-1 | tail -n+2) > _config
-	@(cd config; git ls-files icmptypes helpers ipsets services zones | sort | sed -e 's/^/\t/' | sed ':a;N;$$!ba;s/\n/ \\\n/g') > _provided_config
-	@diff -u1B _config _provided_config > _missing_config; \
-	if [ $$? -ne 0 ]; then \
-		echo; \
-		echo "============================================================================="; \
-		echo "    Fix config/Makefile.am:"; \
-		echo "============================================================================="; \
-		touch _dist_check_failed; \
-		cat _missing_config | tail -n +3; \
-		echo; \
-	fi
-	@rm -f _config _provided_config _missing_config
-	@(cat src/Makefile.am | sed -n '/^nobase_dist_python_DATA/,/^$$/p' | head -n-1 | tail -n+2) > _config
-	@(cd src; git ls-files firewall | sort | sed -e 's/^/\t/' -e "s/.py.in/.py/" | sed ':a;N;$$!ba;s/\n/ \\\n/g') > _provided_config
-	@diff -u1B _config _provided_config > _missing_config; \
-	if [ $$? -ne 0 ]; then \
-		echo; \
-		echo "============================================================================="; \
-		echo "    Fix src/Makefile.am:"; \
-		echo "============================================================================="; \
-		touch _dist_check_failed; \
-		cat _missing_config | tail -n +3; \
-		echo; \
-	fi
-	@rm -f _config _provided_config _missing_config
-	@if [ -f "_dist_check_failed" ]; then \
-		rm -f _dist_check_failed; \
-		exit 1; \
-	fi
-
 check-container check-integration installcheck-integration:
 	$(MAKE) -C src/tests $@
 
@@ -98,17 +37,6 @@ update-docs:
 
 clean-docs:
 	$(MAKE) -C doc/xml clean
-
-archive: dist-check $(desktop_DATA) tag dist
-
-local: distclean
-	@rm -rf ${PACKAGE_NAME}-$(PACKAGE_VERSION).tar.gz
-	@rm -rf /tmp/${PACKAGE_NAME}-$(PACKAGE_VERSION) /tmp/${PACKAGE_NAME}
-	@dir=$$PWD; cd /tmp; cp -a $$dir ${PACKAGE_NAME}
-	@mv /tmp/${PACKAGE_NAME} /tmp/${PACKAGE_NAME}-$(PACKAGE_VERSION)
-	@dir=$$PWD; cd /tmp; tar --gzip -cSpf $$dir/${PACKAGE_NAME}-$(PACKAGE_VERSION).tar.gz ${PACKAGE_NAME}-$(PACKAGE_VERSION)
-	@rm -rf /tmp/${PACKAGE_NAME}-$(PACKAGE_VERSION)	
-	@echo "The archive is in ${PACKAGE_NAME}-$(PACKAGE_VERSION).tar.gz"
 
 test-rpm: dist-gzip
 	@rpmbuild -ta $(PACKAGE_NAME)-$(PACKAGE_VERSION).tar.gz


### PR DESCRIPTION
This will create a new release with generated release notes and distribution tarball.

The goal is to use PRs to do the backports and spec file version bump. Then trigger the release with by manually pushing a tag based on that PR. If this works well, then in the future we could consider letting the gh action also create the tag.