### PR TITLE
test: functions: command substitution cannot use only redirections

### DIFF
--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -1,5 +1,5 @@
 m4_define([FWD_STOP_FIREWALLD], [
-    pid=$(< firewalld.pid)
+    pid=$(cat firewalld.pid)
     kill $pid
     for I in 1 2 3 4 5 6 7 8 9 0; do
         ps --pid $pid >/dev/null || { pid=0; break; }
@@ -78,7 +78,7 @@ unmanaged-devices=*,except:type:dummy,except:type:ovs-bridge,except:type:ovs-por
 ])
 
 m4_define([STOP_NETWORKMANAGER], [
-    pid=$(< networkmanager.pid)
+    pid=$(cat networkmanager.pid)
     kill $pid
     for I in 1 2 3 4 5 6 7 8 9 0; do
         ps --pid $pid >/dev/null || { pid=0; break; }


### PR DESCRIPTION
As noted in issue #1051, using only redirections inside $(command) is unspecified.

As per [POSIX][1]:

  With the $(command) form, all characters following the open
  parenthesis to the matching closing parenthesis constitute the
  command. Any valid shell script can be used for command, except a
  script consisting solely of redirections which produces unspecified
  results.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/