### PR TITLE
Revert "feat(service): Add jellyfin service"

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -192,7 +192,6 @@ CONFIG_FILES = \
 	services/irc.xml \
 	services/iscsi-target.xml \
 	services/isns.xml \
-	services/jellyfin.xml \
 	services/jenkins.xml \
 	services/kadmin.xml \
 	services/kdeconnect.xml \

--- a/config/services/jellyfin.xml
+++ b/config/services/jellyfin.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<service>
-  <short>Jellyfin</short>
-  <description>Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media.</description>
-  <port protocol="tcp" port="8096"/> <!-- HTTP traffic -->
-  <port protocol="tcp" port="8920"/> <!-- HTTPS traffic -->
-  <include service="ssdp"/> <!-- Auto-discovery -->
-  <port protocol="udp" port="7359"/> <!-- Auto-discovery -->
-</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -124,7 +124,6 @@ config/services/ircs.xml
 config/services/irc.xml
 config/services/iscsi-target.xml
 config/services/isns.xml
-config/services/jellyfin.xml
 config/services/jenkins.xml
 config/services/kadmin.xml
 config/services/kdeconnect.xml


### PR DESCRIPTION
This reverts commit 8c168d9eda5fd035d91422393ffea9b6ebcd2728.

As reported in https://github.com/jellyfin/jellyfin/issues/8587, this causes an issue with RPMs shipped by Jellyfin. This has been reported to firewalld in https://github.com/firewalld/firewalld/issues/1057, where @joshuaboniface stated that the Jellyfin project would like to remove the Jellyfin config from firewalld, which is what this change does.

CC: @erig0