### PR TITLE
fix(fw_nm): skip interfaces without a connection profile

### DIFF
--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -193,7 +193,7 @@ def nm_get_connection_of_interface(interface):
     """
     check_nm_imported()
 
-    device = nm_get_client().get_device_by_iface(interface)
+    device = nm_get_client().get_device_by_ip_iface(interface)
     if device is None:
         return None
 


### PR DESCRIPTION
Some interfaces may not have an associated connection profile. This is the case for down point-to-point interfaces.

Fixes: #878