### PR TITLE
Update to Zabbix port configurations

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -337,6 +337,7 @@ CONFIG_FILES = \
 	services/zabbix-java-gateway.xml \
 	services/zabbix-server.xml \
 	services/zabbix-trapper.xml \
+	services/zabbix-web-service.xml \
 	services/zerotier.xml \
 	zones/block.xml \
 	zones/dmz.xml \

--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -334,6 +334,7 @@ CONFIG_FILES = \
 	services/xmpp-local.xml \
 	services/xmpp-server.xml \
 	services/zabbix-agent.xml \
+	services/zabbix-java-gateway.xml \
 	services/zabbix-server.xml \
 	services/zabbix-trapper.xml \
 	services/zerotier.xml \

--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -335,6 +335,7 @@ CONFIG_FILES = \
 	services/xmpp-server.xml \
 	services/zabbix-agent.xml \
 	services/zabbix-server.xml \
+	services/zabbix-trapper.xml \
 	services/zerotier.xml \
 	zones/block.xml \
 	zones/dmz.xml \

--- a/config/services/zabbix-agent.xml
+++ b/config/services/zabbix-agent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>Zabbix Agent</short>
-  <description>Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.</description>
+  <description>Listen port used by Zabbix agents deployed on monitoring targets.</description>
   <port protocol="tcp" port="10050"/>
 </service>

--- a/config/services/zabbix-java-gateway.xml
+++ b/config/services/zabbix-java-gateway.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Zabbix Java Gateway</short>
+  <description>Listen port for Zabbix Java Gateway for monitoring Java applications over JMX.</description>
+  <port protocol="tcp" port="10052"/>
+</service>

--- a/config/services/zabbix-server.xml
+++ b/config/services/zabbix-server.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>Zabbix Server</short>
-  <description>Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.</description>
-  <port protocol="tcp" port="10051"/>
+  <description>This is an alias for zabbix-trapper. This definition is deprecated in favor of zabbix-trapper.</description>
+  <include service="zabbix-trapper" />
 </service>

--- a/config/services/zabbix-trapper.xml
+++ b/config/services/zabbix-trapper.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Zabbix Trapper</short>
+  <description>Trapper port to receive monitoring data used by the Zabbix server and Zabbix proxy.</description>
+  <port protocol="tcp" port="10051"/>
+</service>

--- a/config/services/zabbix-web-service.xml
+++ b/config/services/zabbix-web-service.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Zabbix Web Service</short>
+  <description>Listen port of Zabbix web service for receiving HTTP based reporting requests.</description>
+  <port protocol="tcp" port="10053"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -267,6 +267,7 @@ config/services/xmpp-client.xml
 config/services/xmpp-local.xml
 config/services/xmpp-server.xml
 config/services/zabbix-agent.xml
+config/services/zabbix-java-gateway.xml
 config/services/zabbix-server.xml
 config/services/zabbix-trapper.xml
 config/services/zerotier.xml

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -268,6 +268,7 @@ config/services/xmpp-local.xml
 config/services/xmpp-server.xml
 config/services/zabbix-agent.xml
 config/services/zabbix-server.xml
+config/services/zabbix-trapper.xml
 config/services/zerotier.xml
 config/zones/block.xml
 config/zones/dmz.xml

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -270,6 +270,7 @@ config/services/zabbix-agent.xml
 config/services/zabbix-java-gateway.xml
 config/services/zabbix-server.xml
 config/services/zabbix-trapper.xml
+config/services/zabbix-web-service.xml
 config/services/zerotier.xml
 config/zones/block.xml
 config/zones/dmz.xml


### PR DESCRIPTION
### Hello, project firewalld!

We at Zabbix had a feature request filed ([ZBXNEXT-4737](https://support.zabbix.com/browse/ZBXNEXT-4737)) that requested we add `firewalld` configurations for networking Zabbix components.

In the course of discussion, we became aware that `firewalld` included configurations for Zabbix components [5 years ago](https://github.com/firewalld/firewalld/commit/bbf127bde23da98eae2697a3db6abdaa5a96fbb7), and after reviewing them, decided to contribute an update to them, hence this PR.

The gist of changes can be summarised as follows:
* a configuration for the Zabbix Java Gateway component was added ([zabbix-java-gateway.xml](https://github.com/firewalld/firewalld/compare/master...jxlambda:firewalld:master#diff-92c8d4f018bdd935586d4dbd54e27f134a1f42965cdd8cf90a0f3e9b6e175e4f))
* the `zabbix-server.xml` was renamed to `zabbix-trapper.xml`
  * the rationale for this is that the ports described are used by both the server and the proxy components
  * this is also the name used by IANA in their port assignment listings
* the descriptions have been updated to reflect the ports use, rather than describing the component that uses it

I've also listed the 10050/UDP and 10051/UDP ports in the configurations, as IANA has allocated them along-side their TCP equivalents, although in practice, these components don't use UDP, so maybe that's something to consider outright.

Feedback greatly appreciated!