### PR TITLE
feat(service): add OTLP service

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -247,6 +247,7 @@ CONFIG_FILES = \
 	services/ntp.xml \
 	services/nut.xml \
 	services/openvpn.xml \
+	services/opentelemetry.xml \
 	services/ovirt-imageio.xml \
 	services/ovirt-storageconsole.xml \
 	services/ovirt-vmconsole.xml \

--- a/config/services/opentelemetry.xml
+++ b/config/services/opentelemetry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>OTLP</short>
+  <description>OpenTelemetry Protocol (OTLP) specification describes the encoding, transport, and delivery mechanism of telemetry data between telemetry sources, intermediate nodes such as collectors and telemetry backends.</description>
+  <port protocol="tcp" port="4317"/>
+  <port protocol="tcp" port="4318"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -180,6 +180,7 @@ config/services/nrpe.xml
 config/services/ntp.xml
 config/services/nut.xml
 config/services/openvpn.xml
+config/services/opentelemetry.xml
 config/services/ovirt-imageio.xml
 config/services/ovirt-storageconsole.xml
 config/services/ovirt-vmconsole.xml


### PR DESCRIPTION
Open Telemetry is a useful tool for collecting a bunch of system data and shipping it off for analysis.