### PR TITLE
fix(fw_nm): use IP interface names for connection lookup

### DIFF
--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -186,6 +186,22 @@ def nm_get_interfaces_in_zone(zone):
 
     return interfaces
 
+def nm_get_device_by_ip_iface(interface):
+    """Get device from NM which has the given IP interface
+    @param interface name
+    @returns NM.Device instance or None
+    """
+    check_nm_imported()
+
+    for device in nm_get_client().get_devices():
+        ip_iface = device.get_ip_iface()
+        if ip_iface is None:
+            continue
+        if ip_iface == interface:
+            return device
+
+    return None
+
 def nm_get_connection_of_interface(interface):
     """Get connection from NM that is using the interface
     @param interface name
@@ -193,7 +209,7 @@ def nm_get_connection_of_interface(interface):
     """
     check_nm_imported()
 
-    device = nm_get_client().get_device_by_iface(interface)
+    device = nm_get_device_by_ip_iface(interface)
     if device is None:
         return None
 


### PR DESCRIPTION
The glue layer between FirewallD and NetworkManager uses what NM calls "IP interface" names to identify interfaces. However, these names can't be passed to NM.Client.get_device_by_iface() since that checks the "interface name", not the IP interface name. Since NM does not provide a method to look up a device by its IP interface, we need to do that manually.

Fixes: #878