### PR TITLE
ci(github): fix pip install permission issue

### DIFF
--- a/.github/workflows/integration-testsuite.yml
+++ b/.github/workflows/integration-testsuite.yml
@@ -64,7 +64,7 @@ jobs:
           git clone --depth=1 --branch ${{ matrix.nftables-version }} git://git.netfilter.org/nftables
           cd nftables
           ./autogen.sh
-          ./configure --disable-man-doc --with-json --enable-python
+          ./configure --disable-man-doc --with-json --disable-python
           make
           sudo make install
           cd py

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -89,7 +89,7 @@ jobs:
           git clone --depth=1 --branch ${{ matrix.nftables-version }} git://git.netfilter.org/nftables
           cd nftables
           ./autogen.sh
-          ./configure --disable-man-doc --with-json --enable-python
+          ./configure --disable-man-doc --with-json --disable-python
           make
           sudo make install
           cd py


### PR DESCRIPTION
Disable python in the nftables build since we're going to install it via pip.