### PR TITLE
feat(service) Add syscomlan

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -319,6 +319,7 @@ CONFIG_FILES = \
 	services/syncthing-gui.xml \
 	services/syncthing-relay.xml \
 	services/synergy.xml \
+	services/syscomlan.xml \
 	services/syslog-tls.xml \
 	services/syslog.xml \
 	services/telnet.xml \

--- a/config/services/syscomlan.xml
+++ b/config/services/syscomlan.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>syscomlan</short>
+  <description>Local system communication</description>
+  <port protocol="tcp" port="1065"/>
+  <port protocol="udp" port="1065"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -252,6 +252,7 @@ config/services/syncthing-gui.xml
 config/services/syncthing-relay.xml
 config/services/syncthing.xml
 config/services/synergy.xml
+config/services/syscomlan.xml
 config/services/syslog-tls.xml
 config/services/syslog.xml
 config/services/telnet.xml


### PR DESCRIPTION
Port 1065 is registered to syscomlan at IANA.  I'll confess I don't totally understand what it is for, but one of our local applications is using this port so I figured I'd share.