### PR TITLE
fix(policy): parse string None in tcp mss clamp value

### DIFF
--- a/src/firewall/core/fw_policy.py
+++ b/src/firewall/core/fw_policy.py
@@ -1432,6 +1432,10 @@ class FirewallPolicy(object):
                 tcp_mss_clamp_value = rule.element.value
                 self.check_tcp_mss_clamp(tcp_mss_clamp_value)
 
+                # Convert string "None" to actual None, so the backend can properly handle this value
+                if tcp_mss_clamp_value == "None":
+                    tcp_mss_clamp_value = None
+                
                 rules = backend.build_policy_tcp_mss_clamp_rules(
                             enable, policy, tcp_mss_clamp_value, None, rule)
                 transaction.add_rules(backend, rules)


### PR DESCRIPTION
**Case:**

```
$ firewall-cmd --add-rich-rule='rule tcp-mss-clamp' --permanent
$ systemctl restart firewalld
```

**Expected behavior:**

"pmtu" is used by default

**Current behavior:**

An error is thrown: ``ERROR: 'python-nftables' failed: internal:0:0-0: Error: Could not parse integer``

**Problem Cause:**

The value saved in the configuration xml is actually the "None" string:

```xml
<rule>
  <tcp-mss-clamp value="None">
</rule>
```

However, the backends only look for the actual None, so the "None" string is accidentally passed to python-nftables. This patch adds a guard that converts the "None" string to the actual None, so the backends can properly handle this case.
