### PR TITLE
Add mqtt service to Foreman

### DIFF
--- a/config/services/foreman-proxy.xml
+++ b/config/services/foreman-proxy.xml
@@ -3,5 +3,6 @@
   <short>foreman-proxy</short>
   <description>The Smart Proxy is a project which provides a restful API to various sub-systems.</description>
   <include service="foreman"/>
+  <include service="mqtt"/>
   <port protocol="tcp" port="8443"/>
 </service>


### PR DESCRIPTION
There are two types for Foreman Clients: push-based (SSH from Foreman server/Smart Proxy to your managed hosts) and pull-based (from your managed host to Foreman server/Smart Proxies).
Pull-based Foreman clients use yggdrasil which use mqtt for communication.

current Foreman/Katello documentation: [Configuring a Host to Use the Pull Client](https://docs.theforeman.org/nightly/Managing_Hosts/index-katello.html#Configuring_a_Host_to_Use_the_Pull_Client_managing-hosts)