### PR TITLE
fix(applet): ActivationReason.Trigger

### DIFF
--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -642,7 +642,7 @@ class TrayApplet(QtWidgets.QSystemTrayIcon):
             self.setVisible(True)
 
     def activated_cb(self, reason):
-        if reason == QtWidgets.QSystemTrayIcon.Trigger:
+        if reason == QtWidgets.QSystemTrayIcon.ActivationReason.Trigger:
             self.left_menu.popup(QtGui.QCursor.pos())
 
     def update_active_zones(self):


### PR DESCRIPTION
QtWidgets.QSystemTrayIcon.Trigger was moved to QtWidgets.QSystemTrayIcon.ActivationReason.Trigger in qt6