### PR TITLE
fix(icmp): fix check_icmpv6_name() to use correct IPv6 names

### DIFF
--- a/src/firewall/core/icmp.py
+++ b/src/firewall/core/icmp.py
@@ -94,7 +94,7 @@ def check_icmp_type(_type):
     return False
 
 def check_icmpv6_name(_name):
-    if _name in ICMP_TYPES:
+    if _name in ICMPV6_TYPES:
         return True
     return False
 


### PR DESCRIPTION
This was only called from IPSet.check_entry() to validate the input. Also, some of the IPv4 names are the same as for IPv6. Overall, the impact of this was probably low.

Fixes: 11567b74317e ('New firewall.core.icmp providing names and types for icmp and icmpv6 values')