### PR TITLE
fix(tests): avoid deprecated assertRaisesRegexp for assertRaisesRegex

### DIFF
--- a/src/firewall/functions.py
+++ b/src/firewall/functions.py
@@ -34,7 +34,6 @@ import socket
 import os
 import os.path
 import shlex
-import pipes
 import string
 import tempfile
 from firewall.core.logger import log
@@ -607,10 +606,7 @@ def checkContext(context):
     return True
 
 def joinArgs(args):
-    if "quote" in dir(shlex):
-        return " ".join(shlex.quote(a) for a in args)
-    else:
-        return " ".join(pipes.quote(a) for a in args)
+    return " ".join(shlex.quote(a) for a in args)
 
 def splitArgs(_string):
     return shlex.split(_string)

--- a/src/tests/python/firewalld_config.py
+++ b/src/tests/python/firewalld_config.py
@@ -58,7 +58,7 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         """
 
         print ("\nGetting invalid zone")
-        self.assertRaisesRegexp(Exception, 'INVALID_ZONE', self.fw.config().getZoneByName, "dummyname")
+        self.assertRaisesRegex(Exception, 'INVALID_ZONE', self.fw.config().getZoneByName, "dummyname")
 
         zone_version = "1.0"
         zone_short = "Testing"
@@ -81,9 +81,9 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         settings.setForwardPorts(zone_forward_ports)
 
         print ("Adding zone with name that already exists")
-        self.assertRaisesRegexp(Exception, 'NAME_CONFLICT', self.fw.config().addZone, "home", settings)
+        self.assertRaisesRegex(Exception, 'NAME_CONFLICT', self.fw.config().addZone, "home", settings)
         print ("Adding zone with empty name")
-        self.assertRaisesRegexp(Exception, 'INVALID_NAME', self.fw.config().addZone, "", settings)
+        self.assertRaisesRegex(Exception, 'INVALID_NAME', self.fw.config().addZone, "", settings)
         zone_name = "test"
         print ("Adding proper zone")
         self.fw.config().addZone (zone_name, settings)
@@ -124,13 +124,13 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
 
         print ("Renaming zone to name that already exists")
         config_zone = self.fw.config().getZoneByName(zone_name)
-        self.assertRaisesRegexp(Exception, 'NAME_CONFLICT', config_zone.rename, "home")
+        self.assertRaisesRegex(Exception, 'NAME_CONFLICT', config_zone.rename, "home")
         new_zone_name = "renamed"
         print ("Renaming zone '%s' to '%s'" % (zone_name, new_zone_name))
         config_zone.rename(new_zone_name)
 
         print ("Checking whether the zone '%s' is accessible (it shouldn't be)" % zone_name)
-        self.assertRaisesRegexp(Exception, 'INVALID_ZONE', self.fw.config().getZoneByName, zone_name)
+        self.assertRaisesRegex(Exception, 'INVALID_ZONE', self.fw.config().getZoneByName, zone_name)
         print ("Checking whether the zone '%s' is accessible" % new_zone_name)
         config_zone = self.fw.config().getZoneByName(new_zone_name)
         zone_settings = config_zone.getSettings()
@@ -147,7 +147,7 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         print ("Removing the zone '%s'" % new_zone_name)
         config_zone.remove()
         print ("Checking whether the removed zone is accessible (it shouldn't be)")
-        self.assertRaisesRegexp(Exception, 'INVALID_ZONE', self.fw.config().getZoneByName, new_zone_name)
+        self.assertRaisesRegex(Exception, 'INVALID_ZONE', self.fw.config().getZoneByName, new_zone_name)
 
         # TODO test loadDefaults() ?
 
@@ -167,7 +167,7 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         """
 
         print ("\nGetting invalid service")
-        self.assertRaisesRegexp(Exception, 'INVALID_SERVICE', self.fw.config().getServiceByName, "dummyname")
+        self.assertRaisesRegex(Exception, 'INVALID_SERVICE', self.fw.config().getServiceByName, "dummyname")
 
         service_version = "1.0"
         service_short = "Testing"
@@ -184,9 +184,9 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         settings.setDestinations(service_destinations)
 
         print ("Adding service with name that already exists")
-        self.assertRaisesRegexp(Exception, 'NAME_CONFLICT', self.fw.config().addService, "mdns", settings)
+        self.assertRaisesRegex(Exception, 'NAME_CONFLICT', self.fw.config().addService, "mdns", settings)
         print ("Adding service with empty name")
-        self.assertRaisesRegexp(Exception, 'INVALID_NAME', self.fw.config().addService, "", settings)
+        self.assertRaisesRegex(Exception, 'INVALID_NAME', self.fw.config().addService, "", settings)
         service_name = "test"
         print ("Adding proper service")
         self.fw.config().addService (service_name, settings)
@@ -212,13 +212,13 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
 
         print ("Renaming service to name that already exists")
         config_service = self.fw.config().getServiceByName(service_name)
-        self.assertRaisesRegexp(Exception, 'NAME_CONFLICT', config_service.rename, "mdns")
+        self.assertRaisesRegex(Exception, 'NAME_CONFLICT', config_service.rename, "mdns")
         new_service_name = "renamed"
         print ("Renaming service '%s' to '%s'" % (service_name, new_service_name))
         config_service.rename(new_service_name)
 
         print ("Checking whether the service '%s' is accessible (it shouldn't be)" % service_name)
-        self.assertRaisesRegexp(Exception, 'INVALID_SERVICE', self.fw.config().getServiceByName, service_name)
+        self.assertRaisesRegex(Exception, 'INVALID_SERVICE', self.fw.config().getServiceByName, service_name)
         print ("Checking whether the service '%s' is accessible" % new_service_name)
         config_service = self.fw.config().getServiceByName(new_service_name)
         service_settings = config_service.getSettings()
@@ -232,7 +232,7 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         print ("Removing the service '%s'" % new_service_name)
         config_service.remove()
         print ("Checking whether the removed service is accessible (it shouldn't be)")
-        self.assertRaisesRegexp(Exception, 'INVALID_SERVICE', self.fw.config().getServiceByName, new_service_name)
+        self.assertRaisesRegex(Exception, 'INVALID_SERVICE', self.fw.config().getServiceByName, new_service_name)
 
         # TODO test loadDefaults() ?
 
@@ -251,7 +251,7 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
            remove()
         """
         print ("\nGetting invalid icmp-type")
-        self.assertRaisesRegexp(Exception, 'INVALID_ICMPTYPE', self.fw.config().getIcmpTypeByName, "dummyname")
+        self.assertRaisesRegex(Exception, 'INVALID_ICMPTYPE', self.fw.config().getIcmpTypeByName, "dummyname")
 
         icmptype_version = "1.0"
         icmptype_short = "Testing"
@@ -264,9 +264,9 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         settings.setDestinations(icmptype_destinations)
 
         print ("Adding icmp type with name that already exists")
-        self.assertRaisesRegexp(Exception, 'NAME_CONFLICT', self.fw.config().addIcmpType, "echo-reply", settings)
+        self.assertRaisesRegex(Exception, 'NAME_CONFLICT', self.fw.config().addIcmpType, "echo-reply", settings)
         print ("Adding icmp type with empty name")
-        self.assertRaisesRegexp(Exception, 'INVALID_NAME', self.fw.config().addIcmpType, "", settings)
+        self.assertRaisesRegex(Exception, 'INVALID_NAME', self.fw.config().addIcmpType, "", settings)
         icmptype_name = "test"
         print ("Adding proper icmp type")
         self.fw.config().addIcmpType (icmptype_name, settings)
@@ -288,13 +288,13 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
 
         print ("Renaming icmp type to name that already exists")
         config_icmptype = self.fw.config().getIcmpTypeByName(icmptype_name)
-        self.assertRaisesRegexp(Exception, 'NAME_CONFLICT', config_icmptype.rename, "echo-reply")
+        self.assertRaisesRegex(Exception, 'NAME_CONFLICT', config_icmptype.rename, "echo-reply")
         new_icmptype_name = "renamed"
         print ("Renaming icmp type '%s' to '%s'" % (icmptype_name, new_icmptype_name))
         config_icmptype.rename(new_icmptype_name)
 
         print ("Checking whether the icmp type '%s' is accessible (it shouldn't be)" % icmptype_name)
-        self.assertRaisesRegexp(Exception, 'INVALID_ICMPTYPE', self.fw.config().getIcmpTypeByName, icmptype_name)
+        self.assertRaisesRegex(Exception, 'INVALID_ICMPTYPE', self.fw.config().getIcmpTypeByName, icmptype_name)
         print ("Checking whether the icmp type '%s' is accessible" % new_icmptype_name)
         config_icmptype = self.fw.config().getIcmpTypeByName(new_icmptype_name)
         icmptype_settings = config_icmptype.getSettings()
@@ -306,7 +306,7 @@ class TestFirewallDInterfaceConfig(unittest.TestCase):
         print ("Removing the icmp type '%s'" % new_icmptype_name)
         config_icmptype.remove()
         print ("Checking whether the removed icmp type is accessible (it shouldn't be)")
-        self.assertRaisesRegexp(Exception, 'INVALID_ICMPTYPE', self.fw.config().getIcmpTypeByName, new_icmptype_name)
+        self.assertRaisesRegex(Exception, 'INVALID_ICMPTYPE', self.fw.config().getIcmpTypeByName, new_icmptype_name)
 
         # TODO test loadDefaults() ?
 

--- a/src/tests/python/firewalld_direct.py
+++ b/src/tests/python/firewalld_direct.py
@@ -56,7 +56,7 @@ class TestFirewallDInterfaceDirect(unittest.TestCase):
     def test_add_removeChain(self):
         self.fw_direct.addChain("ipv4", "filter", "direct_foo2")
         # Re-adding
-        self.assertRaisesRegexp(Exception, 'ALREADY_ENABLED',
+        self.assertRaisesRegex(Exception, 'ALREADY_ENABLED',
                                 self.fw_direct.addChain, "ipv4", "filter", "direct_foo2")
         ret = self.fw_direct.getChains("ipv4", "filter")
         self.assertTrue(len(ret)==2) # "direct_foo1" and "direct_foo2"
@@ -66,7 +66,7 @@ class TestFirewallDInterfaceDirect(unittest.TestCase):
 
         self.fw_direct.removeChain("ipv4", "filter", "direct_foo2")
         # Re-removing
-        self.assertRaisesRegexp(Exception, 'NOT_ENABLED',
+        self.assertRaisesRegex(Exception, 'NOT_ENABLED',
                                 self.fw_direct.removeChain, "ipv4", "filter", "direct_foo2")
         ret = self.fw_direct.getChains("ipv4", "filter")
         self.assertTrue(len(ret)==1) # "direct_foo1"
@@ -81,7 +81,7 @@ class TestFirewallDInterfaceDirect(unittest.TestCase):
         self.fw_direct.addRule("ipv4", "filter", "direct_foo1", -10, [ "-m", "tcp", "-p", "tcp", "--dport", "330", "-j", "ACCEPT" ])
         self.fw_direct.addRule("ipv4", "filter", "direct_foo1", -5, [ "-m", "udp", "-p", "udp", "--dport", "331", "-j", "ACCEPT" ])
         # Re-adding
-        self.assertRaisesRegexp(Exception, 'ALREADY_ENABLED',
+        self.assertRaisesRegex(Exception, 'ALREADY_ENABLED',
                                 self.fw_direct.addRule, "ipv4", "filter", "direct_foo1", -5, [ "-m", "udp", "-p", "udp", "--dport", "331", "-j", "ACCEPT" ])
         ret = self.fw_direct.queryRule("ipv4", "filter", "direct_foo1", -5, [ "-m", "udp", "-p", "udp", "--dport", "331", "-j", "ACCEPT" ])
         self.assertTrue(dbus_to_python(ret))
@@ -96,7 +96,7 @@ class TestFirewallDInterfaceDirect(unittest.TestCase):
         self.fw_direct.removeRule("ipv4", "filter", "direct_foo1", 0, [ "-m", "tcp", "-p", "tcp", "--dport", "333", "-j", "ACCEPT" ])
         self.fw_direct.removeRule("ipv4", "filter", "direct_foo1", 1, [ "-m", "tcp", "-p", "tcp", "--dport", "334", "-j", "ACCEPT" ])
         # Re-removing
-        self.assertRaisesRegexp(Exception, 'NOT_ENABLED',
+        self.assertRaisesRegex(Exception, 'NOT_ENABLED',
                                 self.fw_direct.removeRule, "ipv4", "filter", "direct_foo1", 1, [ "-m", "tcp", "-p", "tcp", "--dport", "334", "-j", "ACCEPT" ])
         ret = self.fw_direct.queryRule("ipv4", "filter", "direct_foo1", 1, [ "-m", "tcp", "-p", "tcp", "--dport", "334", "-j", "ACCEPT" ])
         self.assertFalse(dbus_to_python(ret))

--- a/src/tests/python/firewalld_test.py
+++ b/src/tests/python/firewalld_test.py
@@ -81,14 +81,14 @@ class TestFirewallD(unittest.TestCase):
         self.assertTrue(self.fw_zone.queryInterface(zone, interface))
 
         print ("Re-adding")
-        self.assertRaisesRegexp(Exception, 'ZONE_ALREADY_SET', self.fw_zone.addInterface, zone, interface)
+        self.assertRaisesRegex(Exception, 'ZONE_ALREADY_SET', self.fw_zone.addInterface, zone, interface)
 
         zone = "block"
         print ("Re-adding interface '%s' to '%s' zone" % (interface, zone))
-        self.assertRaisesRegexp(Exception, 'ZONE_CONFLICT', self.fw_zone.addInterface, zone, interface)
+        self.assertRaisesRegex(Exception, 'ZONE_CONFLICT', self.fw_zone.addInterface, zone, interface)
 
         print ("Removing interface '%s' from '%s' zone" % (interface, zone))
-        self.assertRaisesRegexp(Exception, 'ZONE_CONFLICT', self.fw_zone.removeInterface, zone, interface)
+        self.assertRaisesRegex(Exception, 'ZONE_CONFLICT', self.fw_zone.removeInterface, zone, interface)
 
         zone = "trusted"
         print ("Removing interface '%s' from '%s' zone" % (interface, zone))
@@ -130,7 +130,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.addService(zone, service, 0)
         self.assertEqual(ret, zone)
         print ("Re-adding")
-        self.assertRaisesRegexp(Exception, 'ALREADY_ENABLED', self.fw_zone.addService, zone, service, 0)
+        self.assertRaisesRegex(Exception, 'ALREADY_ENABLED', self.fw_zone.addService, zone, service, 0)
 
         print ("Get services of zone '%s'" % (zone))
         ret = self.fw_zone.getServices(zone)
@@ -141,7 +141,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.removeService(zone, service)
         self.assertEqual(ret, zone)
         print ("Re-removing")
-        self.assertRaisesRegexp(Exception, 'NOT_ENABLED', self.fw_zone.removeService, zone, service)
+        self.assertRaisesRegex(Exception, 'NOT_ENABLED', self.fw_zone.removeService, zone, service)
 
         zone = "dmz"
         timeout = 2
@@ -161,7 +161,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.addPort(zone, port, protocol, 0)
         self.assertEqual(ret, zone)
         print ("Re-adding port")
-        self.assertRaisesRegexp(Exception, 'ALREADY_ENABLED', self.fw_zone.addPort, zone, port, protocol, 0)
+        self.assertRaisesRegex(Exception, 'ALREADY_ENABLED', self.fw_zone.addPort, zone, port, protocol, 0)
 
         print ("Get ports of zone '%s': " % (zone))
         ret = self.fw_zone.getPorts(zone)
@@ -172,7 +172,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.removePort(zone, port, protocol)
         self.assertEqual(ret, zone)
         print ("Re-removing")
-        self.assertRaisesRegexp(Exception, 'NOT_ENABLED', self.fw_zone.removePort, zone, port, protocol)
+        self.assertRaisesRegex(Exception, 'NOT_ENABLED', self.fw_zone.removePort, zone, port, protocol)
 
         port = "443-445"
         protocol="udp"
@@ -192,7 +192,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.addMasquerade(zone, 0)
         self.assertEqual(ret, zone)
         print ("Re-adding")
-        self.assertRaisesRegexp(Exception, 'ALREADY_ENABLED', self.fw_zone.addMasquerade, zone, 0)
+        self.assertRaisesRegex(Exception, 'ALREADY_ENABLED', self.fw_zone.addMasquerade, zone, 0)
 
         print ("Checking if masquerade is added to zone '%s'" % (zone))
         self.assertTrue(self.fw_zone.queryMasquerade(zone))
@@ -201,7 +201,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.removeMasquerade(zone)
         self.assertEqual(ret, zone)
         print ("Re-adding")
-        self.assertRaisesRegexp(Exception, 'NOT_ENABLED', self.fw_zone.removeMasquerade, zone)
+        self.assertRaisesRegex(Exception, 'NOT_ENABLED', self.fw_zone.removeMasquerade, zone)
 
         zone = "dmz"
         timeout = 2
@@ -223,7 +223,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.addForwardPort(zone, port, protocol, toport, toaddr, 0)
         self.assertEqual(ret, zone)
         print ("Re-adding")
-        self.assertRaisesRegexp(Exception, 'ALREADY_ENABLED', self.fw_zone.addForwardPort, zone, port, protocol, toport, toaddr, 0)
+        self.assertRaisesRegex(Exception, 'ALREADY_ENABLED', self.fw_zone.addForwardPort, zone, port, protocol, toport, toaddr, 0)
 
         print ("Get forward ports of zone '%s': " % (zone))
         ret = self.fw_zone.getForwardPorts(zone)
@@ -234,7 +234,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.removeForwardPort(zone, port, protocol, toport, toaddr)
         self.assertEqual(ret, zone)
         print ("Re-removing")
-        self.assertRaisesRegexp(Exception, 'NOT_ENABLED', self.fw_zone.removeForwardPort, zone, port, protocol, toport, toaddr)
+        self.assertRaisesRegex(Exception, 'NOT_ENABLED', self.fw_zone.removeForwardPort, zone, port, protocol, toport, toaddr)
 
         port = "443-445"
         protocol="udp"
@@ -257,7 +257,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.addIcmpBlock(zone, icmp, 0)
         self.assertEqual(ret, zone)
         print ("Re-adding")
-        self.assertRaisesRegexp(Exception, 'ALREADY_ENABLED', self.fw_zone.addIcmpBlock, zone, icmp, 0)
+        self.assertRaisesRegex(Exception, 'ALREADY_ENABLED', self.fw_zone.addIcmpBlock, zone, icmp, 0)
 
         print ("Get icmp blocks of zone '%s': " % (zone))
         ret = self.fw_zone.getIcmpBlocks(zone)
@@ -268,7 +268,7 @@ class TestFirewallD(unittest.TestCase):
         ret = self.fw_zone.removeIcmpBlock(zone, icmp)
         self.assertEqual(ret, zone)
         print ("Re-removing")
-        self.assertRaisesRegexp(Exception, 'NOT_ENABLED', self.fw_zone.removeIcmpBlock, zone, icmp)
+        self.assertRaisesRegex(Exception, 'NOT_ENABLED', self.fw_zone.removeIcmpBlock, zone, icmp)
 
         icmp = "redirect"
         zone = "dmz"


### PR DESCRIPTION
Avoid warnings:
```
    src/tests/python/firewalld_test.py::TestFirewallD::test_zone_add_get_query_removeForwardPort
      /data/src/firewalld/src/tests/python/firewalld_test.py:226: DeprecationWarning: Please use assertRaisesRegex instead.
        self.assertRaisesRegexp(Exception, 'ALREADY_ENABLED', self.fw_zone.addForwardPort, zone, port, protocol, toport, toaddr, 0)
```
unittest.TestCase.assertRaisesRegexp is deprecated for assertRaisesRegex since Python 3.2. It exists since Python 3.1. Even CentOS Linux 8 brings Python 3.6.

- https://docs.python.org/3.3/library/unittest.html#unittest.TestCase.assertRaisesRegex
- https://bugs.python.org/issue10273