### PR TITLE
docs: fix reference to lockdown-whitelist.xml in SYNOPSIS section

### DIFF
--- a/doc/xml/firewalld.lockdown-whitelist.xml
+++ b/doc/xml/firewalld.lockdown-whitelist.xml
@@ -48,7 +48,7 @@
   <refsynopsisdiv>
     <para>
       <programlisting>
-<filename><config.sysconfdir/>/firewalld/lockdown-whitelists.xml</filename>
+        <filename><config.sysconfdir/>/firewalld/lockdown-whitelist.xml</filename>
       </programlisting>
     </para>
   </refsynopsisdiv>


### PR DESCRIPTION
Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1040547