### PR TITLE
improvement(doc): list required Python version in "README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These are the runtime dependencies:
 
 ```
   linux >= 5.3
+  python >= 3.7
   python3-dbus
   python3-gobject
   python3-nftables >= 0.9.4


### PR DESCRIPTION
It's not clear which is the minimally supported/required Python version. Document it. Pick 3.6, because that version is in Centos7 and contains a lot of API that we may want to rely on.

Optimally, we would have CI tests that check the minimum version. I think currently we don't test Python 3.6.