### PR TITLE
chore(rpm): Recommend iptables et al.

### DIFF
--- a/firewalld.spec
+++ b/firewalld.spec
@@ -18,7 +18,7 @@ BuildRequires: docbook-style-xsl
 BuildRequires: libxslt
 BuildRequires: iptables, ebtables, ipset
 BuildRequires: python3-devel
-Requires: iptables, ebtables, ipset
+Recommends: iptables, ebtables, ipset
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd


### PR DESCRIPTION
Instead of Requires. iptables, et al. have been optional for a long time. The spec file should reflect that.