### PR TITLE
fix(ipset): fix configuring "timeout","maxelem" values for ipsets with nftables

### DIFF
--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -1618,9 +1618,9 @@ class nftables:
 
         if options:
             if "timeout" in options:
-                set_dict["timeout"] = options["timeout"]
+                set_dict["timeout"] = int(options["timeout"])
             if "maxelem" in options:
-                set_dict["size"] = options["maxelem"]
+                set_dict["size"] = int(options["maxelem"])
 
         return [{"add": {"set": set_dict}}]
 

--- a/src/tests/regression/rhbz1506742.at
+++ b/src/tests/regression/rhbz1506742.at
@@ -1,5 +1,5 @@
 FWD_START_TEST([ipset with timeout])
-AT_KEYWORDS(ipset rhbz1506742)
+AT_KEYWORDS(ipset rhbz1506742 rhbz2055330 gh699 gh908)
 
 CHECK_IPSET
 
@@ -9,7 +9,9 @@ NFT_LIST_SET([foobar], 0, [dnl
     table inet firewalld {
         set foobar {
             type ipv4_addr
-            flags interval
+            size 1000000
+            flags interval,timeout
+            timeout 10m
         }
     }
 ])

--- a/src/tests/regression/rhbz1506742.at
+++ b/src/tests/regression/rhbz1506742.at
@@ -5,6 +5,14 @@ CHECK_IPSET
 
 FWD_CHECK([-q --permanent --new-ipset=foobar --type=hash:ip --option=maxelem=1000000 --option=family=inet --option=hashsize=4096 --option=timeout=600])
 FWD_RELOAD
+NFT_LIST_SET([foobar], 0, [dnl
+    table inet firewalld {
+        set foobar {
+            type ipv4_addr
+            flags interval
+        }
+    }
+])
 FWD_CHECK([--permanent --ipset=foobar --add-entry=1.2.3.4], 32, ignore, ignore)
 FWD_CHECK([-q --ipset=foobar --add-entry=1.2.3.4])
 FWD_CHECK([-q --ipset=foobar --query-entry=1.2.3.4], 32, ignore, ignore)


### PR DESCRIPTION
With
```bash
    firewall-cmd --permanent --delete-ipset=testipset || :
    firewall-cmd --permanent --new-ipset=testipset --type=hash:ip --option=maxelem=65536 --option=family=inet --option=hashsize=4096 --option=timeout=14400
    firewall-cmd --reload
```
firewalld would send the JSON request
```json
    {
      "add": {
        "set": {
          "family": "inet",
          "table": "firewalld",
          "name": "testipset",
          "type": "ipv4_addr",
          "flags": [
            "interval"
          ],
          "timeout": "14400",
          "size": "65536"
        }
      }
    },
```
But the "timeout","size" keys are NUMBER types in libnftables-json. They are silently ignored otherwise ([1]). The fix is to pass them as numbers.

Try also:
```bash
    nft delete table inet testtable &>/dev/null || :
    nft add table inet testtable
    echo '
        {
          "nftables": [
            {
              "metainfo": {
                "json_schema_version": 1
              }
            },
            {
              "add": {
                "set": {
                  "family": "inet",
                  "table": "testtable",
                  "name": "testipset",
                  "type": "ipv4_addr",
                  "flags": [
                    "interval"
                  ],
                  "timeout": "14400",
                  "size": "65536"
                }
              }
            },
            {
              "flush": {
                "set": {
                  "family": "inet",
                  "table": "testtable",
                  "name": "testipset"
                }
              }
            }
          ]
        }
    ' | nft -j -f -
    nft list ruleset | grep -C6 testipset
```
[1] https://git.netfilter.org/nftables/tree/src/parser_json.c?id=1335ade24e55199069b8ae79e34746a59ae48c01#n1440

https://github.com/firewalld/firewalld/issues/699
https://bugzilla.redhat.com/show_bug.cgi?id=2055330

Fixes: 1582c5dd736a ('feat: nftables: convert to libnftables JSON interface')