### PR TITLE
improvement(build): add ctags' "tags" file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@
 /src/tests/integration/testsuite
 /src/tests/package.m4
 /src/tests/testsuite*
+tags
 Makefile
 Makefile.in
 !/po/*.po


### PR DESCRIPTION
Running `ctags -R .` is useful for firewalld, to get some basic indexing of the python functions.

Ignore the resulting "tags" file.