### PR TITLE
add `.flake8` configuration file to ignore errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,55 @@
+[flake8]
+
+# Run this command, to check whether all the ignored errors still produce
+# errors. Over time, we want to reduce the number of suppressed warnings and
+# the command helps to find them.
+#
+#   $ sed -e '/^#        for e/,/^$/!d' -e 's/^#        //' .flake8 | bash -
+#
+#        for e in $(sed -n 's/^    \([EW]...\)$/\1/p' .flake8); do
+#            echo "Check for error $e";
+#            if flake8 --config <(grep -v "$e" .flake8) ; then
+#                echo "found no errors for $e"
+#                break;
+#            fi
+#        done
+
+extend-ignore =
+    E126
+    E127
+    E128
+    E201
+    E202
+    E203
+    E211
+    E221
+    E222
+    E225
+    E226
+    E231
+    E241
+    E251
+    E261
+    E262
+    E265
+    E266
+    E301
+    E302
+    E303
+    E305
+    E306
+    E402
+    E501
+    E502
+    E722
+    E741
+    W503
+    W504
+filename =
+    *.py
+    *.py.in
+    */src/firewall-applet.in
+    */src/firewall-cmd.in
+    */src/firewall-config.in
+    */src/firewalld.in
+    */src/firewall-offline-cmd.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 SUBDIRS = config doc po shell-completion src
 
 EXTRA_DIST = \
+	.flake8 \
 	CODE_OF_CONDUCT.md \
 	COPYING \
 	README.md \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,10 +81,8 @@ EXTRA_DIST = \
 
 CLEANFILES = *~ *\# .\#* *.py?
 
-FLAKE8_IGNORE = E126,E127,E128,E201,E202,E203,E211,E221,E222,E225,E226,E231,E241,E251,E261,E262,E265,E266,E301,E302,E303,E305,E306,E402,E501,E502,W503,W504,E722,E741
 check-local:
-	find . -name '*.py' -or -name '*.py.in' |xargs flake8 --ignore="$(FLAKE8_IGNORE)"
-	flake8 --ignore="$(FLAKE8_IGNORE)" $(dist_bin_SCRIPTS_in) $(dist_sbin_SCRIPTS_in)
+	flake8
 	@echo
 	@for file in $(filter-out $(EXTRA_DIST:.in=),$(nobase_dist_python_DATA) $(dist_bin_SCRIPTS_in) $(dist_sbin_SCRIPTS_in)); do \
 		if ! grep "$${file}" ${top_srcdir}/po/POTFILES.in > /dev/null; then \

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -2039,15 +2039,15 @@ class FirewallConfig:
         if obj.priority:
             priority = obj.priority
         if obj.action:
-            if type(obj.action) == rich.Rich_Accept:
+            if isinstance(obj.action, rich.Rich_Accept):
                 action = _("accept")
-            elif type(obj.action) == rich.Rich_Reject:
+            elif isinstance(obj.action, rich.Rich_Reject):
                 action = _("reject")
                 if obj.action.type is not None:
                     action += "\n" + obj.action.type
-            elif type(obj.action) == rich.Rich_Drop:
+            elif isinstance(obj.action, rich.Rich_Drop):
                 action = _("drop")
-            elif type(obj.action) == rich.Rich_Mark:
+            elif isinstance(obj.action, rich.Rich_Mark):
                 action = _("mark")
                 action += "\nset " + obj.action.set
             if obj.action.limit:
@@ -2066,24 +2066,24 @@ class FirewallConfig:
             if obj.destination.invert:
                 dest = "! %s" % dest
         if obj.element:
-            if type(obj.element) == rich.Rich_Service:
+            if isinstance(obj.element, rich.Rich_Service):
                 elem = _("service") + "\n" + obj.element.name
-            elif type(obj.element) == rich.Rich_Port:
+            elif isinstance(obj.element, rich.Rich_Port):
                 elem = _("port") + "\n%s/%s" % (obj.element.port,
                                                 obj.element.protocol)
-            elif type(obj.element) == rich.Rich_Protocol:
+            elif isinstance(obj.element, rich.Rich_Protocol):
                 elem = _("protocol") + "\n" + obj.element.value
-            elif type(obj.element) == rich.Rich_Masquerade:
+            elif isinstance(obj.element, rich.Rich_Masquerade):
                 elem = _("masquerade")
-            elif type(obj.element) == rich.Rich_IcmpBlock:
+            elif isinstance(obj.element, rich.Rich_IcmpBlock):
                 elem = _("icmp-block") + "\n%s" % obj.element.name
-            elif type(obj.element) == rich.Rich_IcmpType:
+            elif isinstance(obj.element, rich.Rich_IcmpType):
                 elem = _("icmp-type") + "\n%s" % obj.element.name
-            elif type(obj.element) == rich.Rich_ForwardPort:
+            elif isinstance(obj.element, rich.Rich_ForwardPort):
                 elem = _("forward-port") + "\n%s" % self.create_fwp_string(
                     obj.element.port, obj.element.protocol,
                     obj.element.to_port, obj.element.to_address)
-            elif type(obj.element) == rich.Rich_SourcePort:
+            elif isinstance(obj.element, rich.Rich_SourcePort):
                 elem = _("source-port") + "\n%s/%s" % (obj.element.port,
                                                        obj.element.protocol)
             else:
@@ -3168,36 +3168,36 @@ class FirewallConfig:
                 self.richRuleDialogElementCheck.set_active(True)
 
             # element
-            if type(old_obj.element) == rich.Rich_Service:
+            if isinstance(old_obj.element, rich.Rich_Service):
                 combobox_select_text(self.richRuleDialogElementCombobox,
                                      _("service"))
                 self.richRuleDialogElementChooser.set_text( \
                     old_obj.element.name)
 
-            elif type(old_obj.element) == rich.Rich_Port:
+            elif isinstance(old_obj.element, rich.Rich_Port):
                 combobox_select_text(self.richRuleDialogElementCombobox,
                                      _("port"))
                 self.richRuleDialogElementChooser.set_text( \
                     "%s/%s" % (old_obj.element.port, old_obj.element.protocol))
-            elif type(old_obj.element) == rich.Rich_Protocol:
+            elif isinstance(old_obj.element, rich.Rich_Protocol):
                 combobox_select_text(self.richRuleDialogElementCombobox,
                                      _("protocol"))
                 self.richRuleDialogElementChooser.set_text( \
                     old_obj.element.value)
-            elif type(old_obj.element) == rich.Rich_Masquerade:
+            elif isinstance(old_obj.element, rich.Rich_Masquerade):
                 combobox_select_text(self.richRuleDialogElementCombobox,
                                      _("masquerade"))
-            elif type(old_obj.element) == rich.Rich_IcmpBlock:
+            elif isinstance(old_obj.element, rich.Rich_IcmpBlock):
                 combobox_select_text(self.richRuleDialogElementCombobox,
                                      _("icmp-block"))
                 self.richRuleDialogElementChooser.set_text( \
                     old_obj.element.name)
-            elif type(old_obj.element) == rich.Rich_IcmpType:
+            elif isinstance(old_obj.element, rich.Rich_IcmpType):
                 combobox_select_text(self.richRuleDialogElementCombobox,
                                      _("icmp-type"))
                 self.richRuleDialogElementChooser.set_text( \
                     old_obj.element.name)
-            elif type(old_obj.element) == rich.Rich_ForwardPort:
+            elif isinstance(old_obj.element, rich.Rich_ForwardPort):
                 combobox_select_text(self.richRuleDialogElementCombobox,
                                      _("forward-port"))
                 s = "%s/%s" % (old_obj.element.port, old_obj.element.protocol)
@@ -3206,7 +3206,7 @@ class FirewallConfig:
                 if old_obj.element.to_address != "":
                     s += " @%s" % old_obj.element.to_address
                 self.richRuleDialogElementChooser.set_text(s)
-            elif type(old_obj.element) == rich.Rich_SourcePort:
+            elif isinstance(old_obj.element, rich.Rich_SourcePort):
                 combobox_select_text(self.richRuleDialogElementCombobox,
                                      _("source-port"))
                 self.richRuleDialogElementChooser.set_text( \
@@ -3215,9 +3215,9 @@ class FirewallConfig:
             if old_obj.action:
                 self.richRuleDialogActionCheck.set_active(True)
                 action = None
-                if type(old_obj.action) == rich.Rich_Accept:
+                if isinstance(old_obj.action, rich.Rich_Accept):
                     action = _("accept")
-                elif type(old_obj.action) == rich.Rich_Reject:
+                elif isinstance(old_obj.action, rich.Rich_Reject):
                     action = _("reject")
                     self.richRuleDialogActionRejectTypeCombobox.remove_all()
                     if old_obj.family is not None:
@@ -3232,9 +3232,9 @@ class FirewallConfig:
                         else:
                             self.richRuleDialogActionRejectTypeCombobox. \
                                 set_active_id(REJECT_TYPES[old_obj.family][0])
-                elif type(old_obj.action) == rich.Rich_Drop:
+                elif isinstance(old_obj.action, rich.Rich_Drop):
                     action = _("drop")
-                elif type(old_obj.action) == rich.Rich_Mark:
+                elif isinstance(old_obj.action, rich.Rich_Mark):
                     action = _("mark")
                     self.richRuleDialogActionMarkChooser.set_text(old_obj.action.set)
 

--- a/src/firewall/core/ebtables.py
+++ b/src/firewall/core/ebtables.py
@@ -255,7 +255,7 @@ class ebtables:
                 _default_rules.extend(LOG_RULES[table])
             prefix = [ "-t", table ]
             for rule in _default_rules:
-                if type(rule) == list:
+                if isinstance(rule, list):
                     default_rules.append(prefix + rule)
                 else:
                     default_rules.append(prefix + splitArgs(rule))

--- a/src/firewall/core/fw_policy.py
+++ b/src/firewall/core/fw_policy.py
@@ -1304,7 +1304,7 @@ class FirewallPolicy:
 
     def _rule_prepare(self, enable, policy, rule, transaction, included_services=None):
         # First apply any services this service may include
-        if type(rule.element) == Rich_Service:
+        if isinstance(rule.element, Rich_Service):
             svc = self._fw.service.get_service(rule.element.name)
             if included_services is None:
                 included_services = [rule.element.name]
@@ -1347,7 +1347,7 @@ class FirewallPolicy:
 
         for backend in set([self._fw.get_backend_by_ipv(x) for x in ipvs]):
             # SERVICE
-            if type(rule.element) == Rich_Service:
+            if isinstance(rule.element, Rich_Service):
                 svc = self._fw.service.get_service(rule.element.name)
 
                 destinations = []
@@ -1364,7 +1364,7 @@ class FirewallPolicy:
                     destinations.append(None)
 
                 for destination in destinations:
-                    if type(rule.action) == Rich_Accept:
+                    if isinstance(rule.action, Rich_Accept):
                         # only load modules for accept action
                         helpers = self.get_helpers_for_service_modules(svc.modules,
                                                                        enable)
@@ -1408,7 +1408,7 @@ class FirewallPolicy:
                         transaction.add_rules(backend, rules)
 
             # PORT
-            elif type(rule.element) == Rich_Port:
+            elif isinstance(rule.element, Rich_Port):
                 port = rule.element.port
                 protocol = rule.element.protocol
                 self.check_port(port, protocol)
@@ -1418,7 +1418,7 @@ class FirewallPolicy:
                 transaction.add_rules(backend, rules)
 
             # PROTOCOL
-            elif type(rule.element) == Rich_Protocol:
+            elif isinstance(rule.element, Rich_Protocol):
                 protocol = rule.element.value
                 self.check_protocol(protocol)
 
@@ -1427,7 +1427,7 @@ class FirewallPolicy:
                 transaction.add_rules(backend, rules)
 
             # TCP/MSS CLAMP
-            elif type(rule.element) == Rich_Tcp_Mss_Clamp:
+            elif isinstance(rule.element, Rich_Tcp_Mss_Clamp):
                 tcp_mss_clamp_value = rule.element.value
                 self.check_tcp_mss_clamp(tcp_mss_clamp_value)
 
@@ -1436,7 +1436,7 @@ class FirewallPolicy:
                 transaction.add_rules(backend, rules)
 
             # MASQUERADE
-            elif type(rule.element) == Rich_Masquerade:
+            elif isinstance(rule.element, Rich_Masquerade):
                 if enable:
                     for ipv in ipvs:
                         if backend.is_ipv_supported(ipv):
@@ -1446,7 +1446,7 @@ class FirewallPolicy:
                 transaction.add_rules(backend, rules)
 
             # FORWARD PORT
-            elif type(rule.element) == Rich_ForwardPort:
+            elif isinstance(rule.element, Rich_ForwardPort):
                 port = rule.element.port
                 protocol = rule.element.protocol
                 toport = rule.element.to_port
@@ -1463,7 +1463,7 @@ class FirewallPolicy:
                 transaction.add_rules(backend, rules)
 
             # SOURCE PORT
-            elif type(rule.element) == Rich_SourcePort:
+            elif isinstance(rule.element, Rich_SourcePort):
                 port = rule.element.port
                 protocol = rule.element.protocol
                 self.check_port(port, protocol)
@@ -1473,8 +1473,8 @@ class FirewallPolicy:
                 transaction.add_rules(backend, rules)
 
             # ICMP BLOCK and ICMP TYPE
-            elif type(rule.element) == Rich_IcmpBlock or \
-                 type(rule.element) == Rich_IcmpType:
+            elif isinstance(rule.element, Rich_IcmpBlock) or \
+                 isinstance(rule.element, Rich_IcmpType):
                 ict = self._fw.config.get_icmptype(rule.element.name)
 
                 if rule.family and ict.destination and \
@@ -1483,8 +1483,8 @@ class FirewallPolicy:
                                         "rich rule family '%s' conflicts with icmp type '%s'" % \
                                         (rule.family, rule.element.name))
 
-                if type(rule.element) == Rich_IcmpBlock and \
-                   rule.action and type(rule.action) == Rich_Accept:
+                if isinstance(rule.element, Rich_IcmpBlock) and \
+                   rule.action and isinstance(rule.action, Rich_Accept):
                     # icmp block might have reject or drop action, but not accept
                     raise FirewallError(errors.INVALID_RULE,
                                         "IcmpBlock not usable with accept action")

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -894,16 +894,16 @@ class FirewallZone:
 
     def _rich_rule_to_policies(self, zone, rule):
         zone = self._fw.check_zone(zone)
-        if type(rule.action) == Rich_Mark:
+        if isinstance(rule.action, Rich_Mark):
             return [self.policy_name_from_zones(zone, "ANY")]
-        elif type(rule.element) in [Rich_Service, Rich_Port, Rich_Protocol,
-                                    Rich_SourcePort, Rich_IcmpBlock, Rich_IcmpType]:
+        elif isinstance(rule.element, (Rich_Service, Rich_Port, Rich_Protocol,
+                                       Rich_SourcePort, Rich_IcmpBlock, Rich_IcmpType)):
             return [self.policy_name_from_zones(zone, "HOST")]
-        elif type(rule.element) in [Rich_ForwardPort]:
+        elif isinstance(rule.element, Rich_ForwardPort):
             return [self.policy_name_from_zones(zone, "ANY")]
-        elif type(rule.element) in [Rich_Masquerade]:
+        elif isinstance(rule.element, Rich_Masquerade):
             return [self.policy_name_from_zones("ANY", zone)]
-        elif type(rule.element) in [Rich_Tcp_Mss_Clamp]:
+        elif isinstance(rule.element, Rich_Tcp_Mss_Clamp):
             return [self.policy_name_from_zones(zone, "ANY")]
         elif rule.element is None:
             return [self.policy_name_from_zones(zone, "HOST")]

--- a/src/firewall/core/io/policy.py
+++ b/src/firewall/core/io/policy.py
@@ -576,29 +576,29 @@ def common_writer(obj, handler):
             element = ""
             attrs = { }
 
-            if type(rule.element) == rich.Rich_Service:
+            if isinstance(rule.element, rich.Rich_Service):
                 element = "service"
                 attrs["name"] = rule.element.name
-            elif type(rule.element) == rich.Rich_Port:
+            elif isinstance(rule.element, rich.Rich_Port):
                 element = "port"
                 attrs["port"] = rule.element.port
                 attrs["protocol"] = rule.element.protocol
-            elif type(rule.element) == rich.Rich_Protocol:
+            elif isinstance(rule.element, rich.Rich_Protocol):
                 element = "protocol"
                 attrs["value"] = rule.element.value
-            elif type(rule.element) == rich.Rich_Tcp_Mss_Clamp:
+            elif isinstance(rule.element, rich.Rich_Tcp_Mss_Clamp):
                 element = "tcp-mss-clamp"
                 if rule.element.value and rule.element.value != "pmtu":
                     attrs["value"] = rule.element.value
-            elif type(rule.element) == rich.Rich_Masquerade:
+            elif isinstance(rule.element, rich.Rich_Masquerade):
                 element = "masquerade"
-            elif type(rule.element) == rich.Rich_IcmpBlock:
+            elif isinstance(rule.element, rich.Rich_IcmpBlock):
                 element = "icmp-block"
                 attrs["name"] = rule.element.name
-            elif type(rule.element) == rich.Rich_IcmpType:
+            elif isinstance(rule.element, rich.Rich_IcmpType):
                 element = "icmp-type"
                 attrs["name"] = rule.element.name
-            elif type(rule.element) == rich.Rich_ForwardPort:
+            elif isinstance(rule.element, rich.Rich_ForwardPort):
                 element = "forward-port"
                 attrs["port"] = rule.element.port
                 attrs["protocol"] = rule.element.protocol
@@ -606,7 +606,7 @@ def common_writer(obj, handler):
                     attrs["to-port"] = rule.element.to_port
                 if rule.element.to_address != "":
                     attrs["to-addr"] = rule.element.to_address
-            elif type(rule.element) == rich.Rich_SourcePort:
+            elif isinstance(rule.element, rich.Rich_SourcePort):
                 element = "source-port"
                 attrs["port"] = rule.element.port
                 attrs["protocol"] = rule.element.protocol
@@ -623,7 +623,7 @@ def common_writer(obj, handler):
 
         # log
         if rule.log:
-            if type(rule.log) == rich.Rich_Log:
+            if isinstance(rule.log, rich.Rich_Log):
                 attrs = { }
                 if rule.log.prefix:
                     attrs["prefix"] = rule.log.prefix
@@ -682,15 +682,15 @@ def common_writer(obj, handler):
         if rule.action:
             action = ""
             attrs = { }
-            if type(rule.action) == rich.Rich_Accept:
+            if isinstance(rule.action, rich.Rich_Accept):
                 action = "accept"
-            elif type(rule.action) == rich.Rich_Reject:
+            elif isinstance(rule.action, rich.Rich_Reject):
                 action = "reject"
                 if rule.action.type:
                     attrs["type"] = rule.action.type
-            elif type(rule.action) == rich.Rich_Drop:
+            elif isinstance(rule.action, rich.Rich_Drop):
                 action = "drop"
-            elif type(rule.action) == rich.Rich_Mark:
+            elif isinstance(rule.action, rich.Rich_Mark):
                 action = "mark"
                 attrs["set"] = rule.action.set
             else:

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -241,7 +241,7 @@ class ip4tables:
             insert_add_index = -1
             rule.pop(i)
             priority = rule.pop(i)
-            if type(priority) != int:
+            if not isinstance(priority, int):
                 raise FirewallError(INVALID_RULE, "priority must be followed by a number")
 
             table = "filter"
@@ -981,7 +981,7 @@ class ip4tables:
         chain_suffix = self._rich_rule_chain_suffix_from_log(rich_rule)
         rule = ["-t", table, add_del, "%s_%s" % (_policy, chain_suffix)]
         rule += self._rich_rule_priority_fragment(rich_rule)
-        if type(rich_rule.log) == Rich_NFLog:
+        if isinstance(rich_rule.log, Rich_NFLog):
             rule += rule_fragment + [ "-j", "NFLOG" ]
             if rich_rule.log.group:
                 rule += [ "--nflog-group", rich_rule.log.group ]
@@ -1011,11 +1011,11 @@ class ip4tables:
         rule = ["-t", table, add_del, "%s_%s" % (_policy, chain_suffix)]
         rule += self._rich_rule_priority_fragment(rich_rule)
         rule += rule_fragment
-        if type(rich_rule.action) == Rich_Accept:
+        if isinstance(rich_rule.action, Rich_Accept):
             _type = "accept"
-        elif type(rich_rule.action) == Rich_Reject:
+        elif isinstance(rich_rule.action, Rich_Reject):
             _type = "reject"
-        elif type(rich_rule.action) ==  Rich_Drop:
+        elif isinstance(rich_rule.action, Rich_Drop):
             _type = "drop"
         else:
             _type = "unknown"
@@ -1034,15 +1034,15 @@ class ip4tables:
 
         chain_suffix = self._rich_rule_chain_suffix(rich_rule)
         chain = "%s_%s" % (_policy, chain_suffix)
-        if type(rich_rule.action) == Rich_Accept:
+        if isinstance(rich_rule.action, Rich_Accept):
             rule_action = [ "-j", "ACCEPT" ]
-        elif type(rich_rule.action) == Rich_Reject:
+        elif isinstance(rich_rule.action, Rich_Reject):
             rule_action = [ "-j", "REJECT" ]
             if rich_rule.action.type:
                 rule_action += [ "--reject-with", rich_rule.action.type ]
-        elif type(rich_rule.action) ==  Rich_Drop:
+        elif isinstance(rich_rule.action, Rich_Drop):
             rule_action = [ "-j", "DROP" ]
-        elif type(rich_rule.action) == Rich_Mark:
+        elif isinstance(rich_rule.action, Rich_Mark):
             table = "mangle"
             _policy = self._fw.policy.policy_base_chain_name(policy, table, POLICY_CHAIN_PREFIX)
             chain = "%s_%s" % (_policy, chain_suffix)

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -222,7 +222,7 @@ class nftables:
         if token in rule[verb]["rule"]:
             priority = rule[verb]["rule"][token]
             del rule[verb]["rule"][token]
-            if type(priority) != int:
+            if not isinstance(priority, int):
                 raise FirewallError(INVALID_RULE, "priority must be followed by a number")
             chain = (rule[verb]["rule"]["family"], rule[verb]["rule"]["chain"]) # family, chain
             # Add the rule to the priority counts. We don't need to store the
@@ -283,7 +283,7 @@ class nftables:
         policy_dispatch_index_cache = copy.deepcopy(self.policy_dispatch_index_cache)
         rule_ref_count = self.rule_ref_count.copy()
         for rule in rules:
-            if type(rule) != dict:
+            if not isinstance(rule, dict):
                 raise FirewallError(UNKNOWN_ERROR, "rule must be a dictionary, rule: %s" % (rule))
 
             for verb in _valid_verbs:
@@ -983,7 +983,7 @@ class nftables:
         chain_suffix = self._rich_rule_chain_suffix_from_log(rich_rule)
 
         log_options = {}
-        if type(rich_rule.log) == Rich_NFLog:
+        if isinstance(rich_rule.log, Rich_NFLog):
             log_options["group"] = int(rich_rule.log.group) if rich_rule.log.group else 0
             if rich_rule.log.threshold:
                 log_options["queue-threshold"] = int(rich_rule.log.threshold)
@@ -1032,16 +1032,16 @@ class nftables:
 
         chain_suffix = self._rich_rule_chain_suffix(rich_rule)
         chain = "%s_%s_%s" % (table, _policy, chain_suffix)
-        if type(rich_rule.action) == Rich_Accept:
+        if isinstance(rich_rule.action, Rich_Accept):
             rule_action = {"accept": None}
-        elif type(rich_rule.action) == Rich_Reject:
+        elif isinstance(rich_rule.action, Rich_Reject):
             if rich_rule.action.type:
                 rule_action = self._reject_types_fragment(rich_rule.action.type)
             else:
                 rule_action = {"reject": None}
-        elif type(rich_rule.action) ==  Rich_Drop:
+        elif isinstance(rich_rule.action, Rich_Drop):
             rule_action = {"drop": None}
-        elif type(rich_rule.action) == Rich_Mark:
+        elif isinstance(rich_rule.action, Rich_Mark):
             table = "mangle"
             _policy = self._fw.policy.policy_base_chain_name(policy, table, POLICY_CHAIN_PREFIX)
             chain = "%s_%s_%s" % (table, _policy, chain_suffix)

--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -240,7 +240,10 @@ class Rich_Reject:
                 valid_types = ", ".join(REJECT_TYPES[family])
                 raise FirewallError(errors.INVALID_RULE, "Wrong reject type %s.\nUse one of: %s." % (self.type, valid_types))
 
-class Rich_Drop(Rich_Accept):
+class Rich_Drop:
+    def __init__(self, limit=None):
+        self.limit = limit
+
     def __str__(self):
         return "drop%s" % (" %s" % self.limit if self.limit else "")
 

--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -90,7 +90,11 @@ class Rich_Port:
     def __str__(self):
         return 'port port="%s" protocol="%s"' % (self.port, self.protocol)
 
-class Rich_SourcePort(Rich_Port):
+class Rich_SourcePort:
+    def __init__(self, port, protocol):
+        self.port = port
+        self.protocol = protocol
+
     def __str__(self):
         return 'source-port port="%s" protocol="%s"' % (self.port,
                                                         self.protocol)

--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -617,7 +617,7 @@ class Rich_Rule:
             if (self.source is not None and self.source.addr is not None) or \
                self.destination is not None:
                 raise FirewallError(errors.MISSING_FAMILY)
-            if type(self.element) == Rich_ForwardPort:
+            if isinstance(self.element, Rich_ForwardPort):
                 raise FirewallError(errors.MISSING_FAMILY)
 
         if self.priority < self.priority_min or self.priority > self.priority_max:
@@ -682,33 +682,33 @@ class Rich_Rule:
                 raise FirewallError(errors.INVALID_RULE, "invalid destination")
 
         # service
-        if type(self.element) == Rich_Service:
+        if isinstance(self.element, Rich_Service):
             # service availability needs to be checked in Firewall, here is no
             # knowledge about this, therefore only simple check
             if self.element.name is None or len(self.element.name) < 1:
                 raise FirewallError(errors.INVALID_SERVICE, str(self.element.name))
 
         # port
-        elif type(self.element) == Rich_Port:
+        elif isinstance(self.element, Rich_Port):
             if not functions.check_port(self.element.port):
                 raise FirewallError(errors.INVALID_PORT, self.element.port)
             if self.element.protocol not in [ "tcp", "udp", "sctp", "dccp" ]:
                 raise FirewallError(errors.INVALID_PROTOCOL, self.element.protocol)
 
         # protocol
-        elif type(self.element) == Rich_Protocol:
+        elif isinstance(self.element, Rich_Protocol):
             if not functions.checkProtocol(self.element.value):
                 raise FirewallError(errors.INVALID_PROTOCOL, self.element.value)
 
         # masquerade
-        elif type(self.element) == Rich_Masquerade:
+        elif isinstance(self.element, Rich_Masquerade):
             if self.action is not None:
                 raise FirewallError(errors.INVALID_RULE, "masquerade and action")
             if self.source is not None and self.source.mac is not None:
                 raise FirewallError(errors.INVALID_RULE, "masquerade and mac source")
 
         # icmp-block
-        elif type(self.element) == Rich_IcmpBlock:
+        elif isinstance(self.element, Rich_IcmpBlock):
             # icmp type availability needs to be checked in Firewall, here is no
             # knowledge about this, therefore only simple check
             if self.element.name is None or len(self.element.name) < 1:
@@ -717,14 +717,14 @@ class Rich_Rule:
                 raise FirewallError(errors.INVALID_RULE, "icmp-block and action")
 
         # icmp-type
-        elif type(self.element) == Rich_IcmpType:
+        elif isinstance(self.element, Rich_IcmpType):
             # icmp type availability needs to be checked in Firewall, here is no
             # knowledge about this, therefore only simple check
             if self.element.name is None or len(self.element.name) < 1:
                 raise FirewallError(errors.INVALID_ICMPTYPE, str(self.element.name))
 
         # forward-port
-        elif type(self.element) == Rich_ForwardPort:
+        elif isinstance(self.element, Rich_ForwardPort):
             if not functions.check_port(self.element.port):
                 raise FirewallError(errors.INVALID_PORT, self.element.port)
             if self.element.protocol not in [ "tcp", "udp", "sctp", "dccp" ]:
@@ -744,14 +744,14 @@ class Rich_Rule:
                 raise FirewallError(errors.INVALID_RULE, "forward-port and action")
 
         # source-port
-        elif type(self.element) == Rich_SourcePort:
+        elif isinstance(self.element, Rich_SourcePort):
             if not functions.check_port(self.element.port):
                 raise FirewallError(errors.INVALID_PORT, self.element.port)
             if self.element.protocol not in [ "tcp", "udp", "sctp", "dccp" ]:
                 raise FirewallError(errors.INVALID_PROTOCOL, self.element.protocol)
 
         # tcp-mss-clamp
-        elif type(self.element) == Rich_Tcp_Mss_Clamp:
+        elif isinstance(self.element, Rich_Tcp_Mss_Clamp):
             if self.action is not None:
                 raise FirewallError(errors.INVALID_RULE, "tcp-mss-clamp and %s are mutually exclusive" % self.action)
             if self.element.value:
@@ -777,9 +777,9 @@ class Rich_Rule:
 
         # action
         if self.action is not None:
-            if type(self.action) == Rich_Reject:
+            if isinstance(self.action, Rich_Reject):
                 self.action.check(self.family)
-            elif type(self.action) == Rich_Mark:
+            elif isinstance(self.action, Rich_Mark):
                 self.action.check()
 
             if self.action.limit is not None:

--- a/src/firewall/fw_types.py
+++ b/src/firewall/fw_types.py
@@ -51,7 +51,7 @@ class LastUpdatedOrderedDict:
         self._dict[key] = value
 
     def __getitem__(self, key):
-        if type(key) == int:
+        if isinstance(key, int):
             return self._list[key]
         else:
             return self._dict[key]


### PR DESCRIPTION
add a `.flake8` config file. This allows to run plain `flake8` in our source tree, and it does the right thing.

Also, drop a few errors from the ignore list, which don't produce any failures (anymore).