### PR TITLE
[th/no-all-module-variable] improvement(style): drop __all__ module variables

### DIFF
--- a/src/firewall/command.py
+++ b/src/firewall/command.py
@@ -21,8 +21,6 @@
 
 """FirewallCommand class for command line client simplification"""
 
-__all__ = [ "FirewallCommand" ]
-
 import sys
 
 from firewall import errors

--- a/src/firewall/core/ebtables.py
+++ b/src/firewall/core/ebtables.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "ebtables" ]
-
 import os.path
 from firewall.core.prog import runProg
 from firewall.core.logger import log

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "Firewall" ]
-
 import os
 import sys
 import copy

--- a/src/firewall/core/fw_config.py
+++ b/src/firewall/core/fw_config.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "FirewallConfig" ]
-
 import copy
 import os
 import os.path

--- a/src/firewall/core/fw_direct.py
+++ b/src/firewall/core/fw_direct.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "FirewallDirect" ]
-
 from firewall.fw_types import LastUpdatedOrderedDict
 from firewall.core import ipXtables
 from firewall.core import ebtables

--- a/src/firewall/core/fw_helper.py
+++ b/src/firewall/core/fw_helper.py
@@ -21,8 +21,6 @@
 
 """helper backend"""
 
-__all__ = [ "FirewallHelper" ]
-
 from firewall import errors
 from firewall.errors import FirewallError
 

--- a/src/firewall/core/fw_icmptype.py
+++ b/src/firewall/core/fw_icmptype.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "FirewallIcmpType" ]
-
 from firewall.core.logger import log
 from firewall import errors
 from firewall.errors import FirewallError

--- a/src/firewall/core/fw_ifcfg.py
+++ b/src/firewall/core/fw_ifcfg.py
@@ -21,8 +21,6 @@
 
 """Functions to search for and change ifcfg files"""
 
-__all__ = [ "search_ifcfg_of_interface", "ifcfg_set_zone_of_interface" ]
-
 import os
 import os.path
 

--- a/src/firewall/core/fw_ipset.py
+++ b/src/firewall/core/fw_ipset.py
@@ -21,8 +21,6 @@
 
 """ipset backend"""
 
-__all__ = [ "FirewallIPSet" ]
-
 from firewall.core.logger import log
 from firewall.core.ipset import remove_default_create_options as rm_def_cr_opts, \
                                 normalize_ipset_entry, check_entry_overlaps_existing, \

--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -21,11 +21,6 @@
 
 """Functions for NetworkManager interaction"""
 
-__all__ = [ "check_nm_imported", "nm_is_imported",
-            "nm_get_zone_of_connection", "nm_set_zone_of_connection",
-            "nm_get_connections", "nm_get_connection_of_interface",
-            "nm_get_bus_name", "nm_get_dbus_interface" ]
-
 import gi
 from gi.repository import GLib
 try:

--- a/src/firewall/core/fw_policies.py
+++ b/src/firewall/core/fw_policies.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "FirewallPolicies" ]
-
 from firewall import config
 from firewall.core.logger import log
 from firewall.core.io.lockdown_whitelist import LockdownWhitelist

--- a/src/firewall/core/fw_service.py
+++ b/src/firewall/core/fw_service.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "FirewallService" ]
-
 from firewall import errors
 from firewall.errors import FirewallError
 

--- a/src/firewall/core/fw_transaction.py
+++ b/src/firewall/core/fw_transaction.py
@@ -21,8 +21,6 @@
 
 """Transaction classes for firewalld"""
 
-__all__ = [ "FirewallTransaction" ]
-
 import traceback
 
 from firewall.core.logger import log

--- a/src/firewall/core/icmp.py
+++ b/src/firewall/core/icmp.py
@@ -19,9 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "ICMP_TYPES", "ICMPV6_TYPES",
-            "check_icmp_type", "check_icmpv6_type" ]
-
 ICMP_TYPES = {
      "echo-reply": "0/0",
      "pong": "0/0",

--- a/src/firewall/core/io/helper.py
+++ b/src/firewall/core/io/helper.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "Helper", "helper_reader", "helper_writer" ]
-
 import xml.sax as sax
 import os
 import io

--- a/src/firewall/core/io/icmptype.py
+++ b/src/firewall/core/io/icmptype.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "IcmpType", "icmptype_reader", "icmptype_writer" ]
-
 import xml.sax as sax
 import os
 import io

--- a/src/firewall/core/io/ifcfg.py
+++ b/src/firewall/core/io/ifcfg.py
@@ -21,8 +21,6 @@
 
 """ifcfg file parser"""
 
-__all__ = [ "ifcfg" ]
-
 import os.path
 import io
 import tempfile

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -21,9 +21,6 @@
 
 """Generic io_object handler, io specific check methods."""
 
-__all__ = [ "IO_Object", "IO_Object_ContentHandler", "IO_Object_XMLGenerator",
-            "check_port", "check_tcpudp", "check_protocol", "check_address" ]
-
 import xml.sax as sax
 import xml.sax.saxutils as saxutils
 import copy

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -21,8 +21,6 @@
 
 """ipset io XML handler, reader, writer"""
 
-__all__ = [ "IPSet", "ipset_reader", "ipset_writer" ]
-
 import xml.sax as sax
 import os
 import io

--- a/src/firewall/core/io/policy.py
+++ b/src/firewall/core/io/policy.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-__all__ = [ "Policy", "policy_reader", "policy_writer" ]
-
 import xml.sax as sax
 import os
 import io

--- a/src/firewall/core/io/service.py
+++ b/src/firewall/core/io/service.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "Service", "service_reader", "service_writer" ]
-
 import xml.sax as sax
 import os
 import io

--- a/src/firewall/core/io/zone.py
+++ b/src/firewall/core/io/zone.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "Zone", "zone_reader", "zone_writer" ]
-
 import xml.sax as sax
 import os
 import io

--- a/src/firewall/core/ipset.py
+++ b/src/firewall/core/ipset.py
@@ -21,8 +21,6 @@
 
 """The ipset command wrapper"""
 
-__all__ = [ "ipset", "check_ipset_name", "remove_default_create_options" ]
-
 import os.path
 import ipaddress
 

--- a/src/firewall/core/logger.py
+++ b/src/firewall/core/logger.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "LogTarget", "FileLog", "Logger", "log" ]
-
 import sys
 import types
 import time

--- a/src/firewall/core/modules.py
+++ b/src/firewall/core/modules.py
@@ -21,8 +21,6 @@
 
 """modules backend"""
 
-__all__ = [ "modules" ]
-
 from firewall.core.prog import runProg
 from firewall.core.logger import log
 from firewall.config import COMMANDS

--- a/src/firewall/core/prog.py
+++ b/src/firewall/core/prog.py
@@ -22,9 +22,6 @@
 import subprocess
 
 
-__all__ = ["runProg"]
-
-
 def runProg(prog, argv=None, stdin=None):
     if argv is None:
         argv = []

--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -19,13 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "Rich_Source", "Rich_Destination", "Rich_Service", "Rich_Port",
-            "Rich_Protocol", "Rich_Masquerade", "Rich_IcmpBlock",
-            "Rich_IcmpType",
-            "Rich_SourcePort", "Rich_ForwardPort", "Rich_Log", "Rich_NFLog",
-            "Rich_Accept", "Rich_Reject", "Rich_Drop", "Rich_Mark",
-            "Rich_Audit", "Rich_Limit", "Rich_Rule", "Rich_Tcp_Mss_Clamp" ]
-
 from firewall import functions
 from firewall.core.ipset import check_ipset_name
 from firewall.core.base import REJECT_TYPES

--- a/src/firewall/core/watcher.py
+++ b/src/firewall/core/watcher.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "Watcher" ]
-
 from gi.repository import Gio, GLib
 
 class Watcher(object):

--- a/src/firewall/dbus_utils.py
+++ b/src/firewall/dbus_utils.py
@@ -19,12 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "command_of_pid", "pid_of_sender", "uid_of_sender", "user_of_uid",
-            "context_of_sender", "command_of_sender", "user_of_sender",
-            "dbus_to_python", "dbus_signature",
-            "dbus_introspection_prepare_properties",
-            "dbus_introspection_add_properties" ]
-
 import dbus
 import pwd
 from xml.dom import minidom

--- a/src/firewall/functions.py
+++ b/src/firewall/functions.py
@@ -19,17 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "getPortID", "getPortRange", "portStr", "getServiceName",
-            "checkIP", "checkIP6", "checkIPnMask", "checkIP6nMask",
-            "checkProtocol", "checkInterface", "checkUINT16", "checkUINT32",
-            "firewalld_is_active", "tempFile", "readfile", "writefile",
-            "enable_ip_forwarding", "check_port", "check_address",
-            "check_single_address", "check_mac", "uniqify", "ppid_of_pid",
-            "max_zone_name_len", "checkUser", "checkUid", "checkCommand",
-            "checkContext", "joinArgs", "splitArgs",
-            "max_policy_name_len", "checkTcpMssClamp",
-            "stripNonPrintableCharacters"]
-
 import socket
 import os
 import os.path

--- a/src/firewall/fw_types.py
+++ b/src/firewall/fw_types.py
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = [ "LastUpdatedOrderedDict" ]
-
 class LastUpdatedOrderedDict(object):
     def __init__(self, x=None):
         self._dict = { }

--- a/src/firewall/server/decorators.py
+++ b/src/firewall/server/decorators.py
@@ -20,8 +20,6 @@
 
 """This module contains decorators for use with and without D-Bus"""
 
-__all__ = ["handle_exceptions", "dbus_handle_exceptions", "dbus_service_method"]
-
 import dbus
 import dbus.service
 import traceback

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = [ "FirewallD" ]
-
 from gi.repository import GLib
 
 import copy

--- a/src/firewall/server/server.py
+++ b/src/firewall/server/server.py
@@ -25,8 +25,6 @@
 #   Thomas Liu  <tliu@redhat.com>
 #   Dan Walsh <dwalsh@redhat.com>
 
-__all__ = [ "run_server" ]
-
 import signal
 
 from gi.repository import GLib


### PR DESCRIPTION
Their main practical use is to control what gets imported by `from
MODULE import *`.

But we never use such an import, and it seems bad style anyway.

Otherwise, `__all__` could act as a documentation of what is supposed to
be "public" API. For example, we could write a tool that checks that
every function that is considered public has a docstring. That doesn't
seem very useful.

Sure, our users install the firewalld Python code, so all of our code
provides some sort of API. It would therefore be good to properly
document it and make clear which part of it is supposed to be public.
But in practice, we probably have few external users. Also, I don't
think that we are sufficiently careful to not break API for the exported
symbols, so the API we mark with __all__ isn't really stable API for
external users.

Overall, it seems a pointless effort to maintain the `__all__` variable.
Often we forget to expose API, or we expose API that isn't actually used
by anybody outside the module that provides it. And nobody notices,
because it has no practical effect for us.

Just drop it.
