### PR TITLE
[th/no-coding-comment] drop the "coding:utf-8" comments

### DIFF
--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -1,5 +1,4 @@
 #!@PYTHON@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2023 Red Hat, Inc.
 #

--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -1,5 +1,4 @@
 #!@PYTHON@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009-2016 Red Hat, Inc.
 #

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1,5 +1,4 @@
 #!@PYTHON@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2015 Red Hat, Inc.
 #

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -1,5 +1,4 @@
 #!@PYTHON@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009-2016 Red Hat, Inc.
 #

--- a/src/firewall/client.py
+++ b/src/firewall/client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009-2016 Red Hat, Inc.
 #

--- a/src/firewall/command.py
+++ b/src/firewall/command.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2007-2016 Red Hat, Inc.
 # Authors:

--- a/src/firewall/config/dbus.py
+++ b/src/firewall/config/dbus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011,2016 Red Hat, Inc.
 #

--- a/src/firewall/core/base.py
+++ b/src/firewall/core/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/ebtables.py
+++ b/src/firewall/core/ebtables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_config.py
+++ b/src/firewall/core/fw_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_direct.py
+++ b/src/firewall/core/fw_direct.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_helper.py
+++ b/src/firewall/core/fw_helper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_icmptype.py
+++ b/src/firewall/core/fw_icmptype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_ifcfg.py
+++ b/src/firewall/core/fw_ifcfg.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_ipset.py
+++ b/src/firewall/core/fw_ipset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_policies.py
+++ b/src/firewall/core/fw_policies.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_policy.py
+++ b/src/firewall/core/fw_policy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/src/firewall/core/fw_service.py
+++ b/src/firewall/core/fw_service.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_transaction.py
+++ b/src/firewall/core/fw_transaction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 Red Hat, Inc.
 #

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/helper.py
+++ b/src/firewall/core/helper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 Red Hat, Inc.
 #

--- a/src/firewall/core/icmp.py
+++ b/src/firewall/core/icmp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2017 Red Hat, Inc.
 #

--- a/src/firewall/core/io/__init__.py
+++ b/src/firewall/core/io/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2012 Red Hat, Inc.
 #

--- a/src/firewall/core/io/direct.py
+++ b/src/firewall/core/io/direct.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/io/firewalld_conf.py
+++ b/src/firewall/core/io/firewalld_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2012 Red Hat, Inc.
 #

--- a/src/firewall/core/io/functions.py
+++ b/src/firewall/core/io/functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2018 Red Hat, Inc.
 #

--- a/src/firewall/core/io/helper.py
+++ b/src/firewall/core/io/helper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/io/icmptype.py
+++ b/src/firewall/core/io/icmptype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/io/ifcfg.py
+++ b/src/firewall/core/io/ifcfg.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/io/lockdown_whitelist.py
+++ b/src/firewall/core/io/lockdown_whitelist.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/io/policy.py
+++ b/src/firewall/core/io/policy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/src/firewall/core/io/service.py
+++ b/src/firewall/core/io/service.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/io/zone.py
+++ b/src/firewall/core/io/zone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/ipset.py
+++ b/src/firewall/core/ipset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/logger.py
+++ b/src/firewall/core/logger.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2007,2012 Red Hat, Inc.
 #

--- a/src/firewall/core/logger.py
+++ b/src/firewall/core/logger.py
@@ -893,5 +893,3 @@ if __name__ == '__main__':
     except Exception as e:
         log.exception()
 """
-
-# vim:ts=4:sw=4:showmatch:expandtab

--- a/src/firewall/core/modules.py
+++ b/src/firewall/core/modules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2018-2023 Red Hat, Inc.
 #

--- a/src/firewall/core/prog.py
+++ b/src/firewall/core/prog.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2013-2016 Red Hat, Inc.
 #

--- a/src/firewall/core/watcher.py
+++ b/src/firewall/core/watcher.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2012-2016 Red Hat, Inc.
 #

--- a/src/firewall/dbus_utils.py
+++ b/src/firewall/dbus_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #

--- a/src/firewall/errors.py
+++ b/src/firewall/errors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2012 Red Hat, Inc.
 #

--- a/src/firewall/functions.py
+++ b/src/firewall/functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2007,2008,2011,2012 Red Hat, Inc.
 #

--- a/src/firewall/fw_types.py
+++ b/src/firewall/fw_types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2013-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/config.py
+++ b/src/firewall/server/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/config_helper.py
+++ b/src/firewall/server/config_helper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/config_icmptype.py
+++ b/src/firewall/server/config_icmptype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/config_ipset.py
+++ b/src/firewall/server/config_ipset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/config_policy.py
+++ b/src/firewall/server/config_policy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/src/firewall/server/config_service.py
+++ b/src/firewall/server/config_service.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/config_zone.py
+++ b/src/firewall/server/config_zone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/dbus.py
+++ b/src/firewall/server/dbus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/src/firewall/server/decorators.py
+++ b/src/firewall/server/decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2012-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewall/server/server.py
+++ b/src/firewall/server/server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #

--- a/src/firewalld.in
+++ b/src/firewalld.in
@@ -1,5 +1,4 @@
 #!@PYTHON@
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 # Authors:

--- a/src/gtk3_chooserbutton.py
+++ b/src/gtk3_chooserbutton.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python -Es
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2008,2012 Red Hat, Inc.
 #

--- a/src/gtk3_niceexpander.py
+++ b/src/gtk3_niceexpander.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python -Es
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2016 Red Hat, Inc.
 #

--- a/src/tests/python/firewalld_config.py
+++ b/src/tests/python/firewalld_config.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2012 Red Hat, Inc.
 #

--- a/src/tests/python/firewalld_direct.py
+++ b/src/tests/python/firewalld_direct.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2012 Red Hat, Inc.
 #

--- a/src/tests/python/firewalld_rich.py
+++ b/src/tests/python/firewalld_rich.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2013 Red Hat, Inc.
 #

--- a/src/tests/python/firewalld_test.py
+++ b/src/tests/python/firewalld_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2010-2012 Red Hat, Inc.
 #


### PR DESCRIPTION
In Python 3, the default encoding for files is utf-8 already.  And we
will never add a file is non-UTF-8 encoding either.  When Python 2 was
still supported, that was different. But now those lines are
unnecessary. Drop them.

    $ git grep -l coding:\ u | xargs sed '/coding: utf-8/d' -i

or

    $ ( git grep -l '#!.*\(PYTHON\|python\)' ; git ls-files '*.py' '*.py.in' ) \
        | sort -u \
        | xargs sed '/coding: utf-8/d' -i
