### PR TITLE
Revert "firewall/client: handle_exceptions: Use loop in decorator"

### DIFF
--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1249,7 +1249,6 @@ class FirewallConfig(object):
         self.fw = client.FirewallClient(wait=1)
         self.__use_exception_handler = True
         self.fw.setExceptionHandler(self._exception_handler)
-        self.fw.setNotAuthorizedLoop(True)
 
         self.fw.connect("panic-mode-enabled", self.panic_mode_enabled_cb)
         self.fw.connect("panic-mode-disabled", self.panic_mode_disabled_cb)


### PR DESCRIPTION
From the commit message of e77a70ca4dad ('firewall/client: handle_exceptions: Use loop in decorator') it's not clear to me, what the purpose of NotAuthorizedLoop is.

It seems wrong to me, and very ugly. It's already ugly to wrap most function in a @handle_exceptions decorator. This retry loop seems extra ugly.

Revert it, to drop some code.

If a change is non-obvious, then the reasoning or background information must be recorded (e.g. in the commit message or a code comment). Otherwise, changes are bound to be reverted or broken.

This reverts commit e77a70ca4dade324b12b7a4bfc1f479fb1b5ce9e.