### PR TITLE
[th/spdx-license] add SPDX license identifiers and drop the GPL license comments 

### DIFF
--- a/.github/workflows/integration-testsuite.yml
+++ b/.github/workflows/integration-testsuite.yml
@@ -71,7 +71,7 @@ jobs:
           cd py
           pip install .
           sudo ldconfig
-      
+
       - name: build firewalld
         run: |
           ./autogen.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: release
 
-on: 
+on:
   push:
     tags:
     - 'v*'
@@ -44,7 +44,7 @@ jobs:
           ./autogen.sh
           ./configure
           make dist
-      
+
       - name: make release notes
         run: |
           set -- $(grep "^Version:" firewalld.spec |cut -f2 -d ' ' |tr '.' ' ')

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -95,7 +95,7 @@ jobs:
           cd py
           pip install .
           sudo ldconfig
-      
+
       - name: remove iptables, et al.
         if: ${{ matrix.no-iptables }}
         run: |

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 FirewallD - A firewall daemon with D-Bus interface providing a dynamic firewall
 ====================
 
-firewalld provides a dynamically managed firewall with support for network or 
-firewall zones to define the trust level of network connections or interfaces. 
-It has support for IPv4, IPv6 firewall settings and for ethernet bridges and a 
-separation of runtime and permanent configuration options. It also provides an 
-interface for services or applications to add ip*tables and ebtables rules 
-directly. 
+firewalld provides a dynamically managed firewall with support for network or
+firewall zones to define the trust level of network connections or interfaces.
+It has support for IPv4, IPv6 firewall settings and for ethernet bridges and a
+separation of runtime and permanent configuration options. It also provides an
+interface for services or applications to add ip*tables and ebtables rules
+directly.
 
 
 Development
@@ -195,7 +195,7 @@ podman pull quay.io/firewalld/firewalld:<ver>
 ```
 
 where `<ver>` is optional, the latest version will be used if omitted.
-                  
+
 To start the daemon/container:
 
 ```sh

--- a/config/FirewallD.conf
+++ b/config/FirewallD.conf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE busconfig PUBLIC
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"

--- a/config/FirewallD.conf
+++ b/config/FirewallD.conf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!DOCTYPE busconfig PUBLIC
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"

--- a/config/firewall-config.appdata.xml.in
+++ b/config/firewall-config.appdata.xml.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2014 Jiri Popelka <jpopelka@redhat.com> -->
 <component type="desktop">
   <id>firewall-config.desktop</id>

--- a/config/firewalld.init
+++ b/config/firewalld.init
@@ -13,13 +13,13 @@
 ### BEGIN INIT INFO
 # Provides:  firewalld
 # Required-Start: $syslog $local_fs messagebus
-# Required-Stop: 
-# Should-Start: 
-# Should-Stop: 
-# Default-Start: 
-# Default-Stop: 
-# Short-Description: 
-# Description: 
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Default-Start:
+# Default-Stop:
+# Short-Description:
+# Description:
 ### END INIT INFO
 
 # Source function library.

--- a/config/org.fedoraproject.FirewallConfig.gschema.xml.in
+++ b/config/org.fedoraproject.FirewallConfig.gschema.xml.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <schemalist>
   <schema path="/org/fedoraproject/FirewallConfig/" id="org.fedoraproject.FirewallConfig">
     <key type="b" name="show-ipsets">

--- a/config/org.fedoraproject.FirewallD1.desktop.policy.in
+++ b/config/org.fedoraproject.FirewallD1.desktop.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">

--- a/config/org.fedoraproject.FirewallD1.server.policy.in
+++ b/config/org.fedoraproject.FirewallD1.server.policy.in
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">

--- a/config/services/jenkins.xml
+++ b/config/services/jenkins.xml
@@ -3,4 +3,4 @@
   <short>jenkins</short>
   <description>Jenkins is an open source automation server written in Java.</description>
   <port protocol="tcp" port="8080"/>
-</service> 
+</service>

--- a/config/services/redis.xml
+++ b/config/services/redis.xml
@@ -3,4 +3,4 @@
   <short>redis</short>
   <description>Redis is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker.</description>
   <port protocol="tcp" port="6379"/>
-</service> 
+</service>

--- a/doc/config-interface
+++ b/doc/config-interface
@@ -1,10 +1,10 @@
     /org/fedoraproject/FirewallD1/config
     ====================================
-    
+
       Interfaces
       ----------
         org.fedoraproject.FirewallD1.config
-    
+
           Methods
           -------
             listZones() -> (Array of [Object Path] zones)
@@ -12,28 +12,28 @@
             getZoneOfInterface(String iface) -> (String zone)
             getZoneOfSource(String source) -> (String zone)
             addZone(String name, Dict of {String, Variant} zone_settings) -> (Ob
-    
+
             listServices() -> (Array of [Object Path] services)
             getServiceByName(String name) -> (Object Path service)
-            addService(String name, Dict of {String, Variant} service_settings) 
-    
+            addService(String name, Dict of {String, Variant} service_settings)
+
             listIcmpTypes() -> (Array of [Object Path] icmptypes)
             getIcmpTypeByName(String name) -> (Object Path icmptype)
             addIcmpType(String name, Dict of {String, Variant} icmptype_settings
-    
+
           Signals
           -------
             ZoneAdded(Object Path zone)
             ServiceAdded(Object Path service)
             IcmpTypeAdded(Object Path icmptype)
-    
+
     /org/fedoraproject/FirewallD1/config/zone/<id>
     ==============================================
-    
+
       Interfaces
       ----------
         org.fedoraproject.FirewallD1.config.zone
-    
+
           Methods
           -------
             getSettings() -> (Struct of (
@@ -61,35 +61,35 @@
             loadDefaults()
             remove()
             rename(String name)
-    
+
           Properties
           ----------
             String name (ro)
             String filename (ro)
             String path (ro)
             Boolean default (ro)
-    
+
           Signals
           -------
             Updated(String name)
             Removed(String name)
             Renamed(String name)
-    
+
         org.freedesktop.DBus.Properties
-    
+
           Methods
           -------
             Get(String interface, String, propname) -> (Variant value)
             GetAll(String interface) -> (Dict of {String, Variant} props)
             Set(String interface, String propname, Variant value)
-    
+
     /org/fedoraproject/FirewallD1/config/service/<id>
     =================================================
-    
+
       Interfaces
       ----------
         org.fedoraproject.FirewallD1.config.service
-    
+
           Methods
           -------
             getSettings() -> (Struct of (
@@ -109,35 +109,35 @@
             loadDefaults()
             remove()
             rename(String name)
-    
+
           Properties
           ----------
             String name (ro)
             String filename (ro)
             String path (ro)
             Boolean default (ro)
-    
+
           Signals
           -------
             Updated(String name)
             Removed(String name)
             Renamed(String name)
-    
+
         org.freedesktop.DBus.Properties
-    
+
           Methods
           -------
             Get(String interface, String, propname) -> (Variant value)
             GetAll(String interface) -> (Dict of {String, Variant} props)
             Set(String interface, String propname, Variant value)
-    
+
     /org/fedoraproject/FirewallD1/config/icmptype/<id>
     ==================================================
-    
+
       Interfaces
       ----------
         org.fedoraproject.FirewallD1.config.icmptype
-    
+
           Methods
           -------
             getSettings() -> (Struct of (
@@ -153,22 +153,22 @@
             loadDefaults()
             remove()
             rename(String name)
-    
+
           Properties
           ----------
             String name (ro)
             String filename (ro)
             String path (ro)
             Boolean default (ro)
-    
+
           Signals
           -------
             Updated(String name)
             Removed(String name)
             Renamed(String name)
-    
+
         org.freedesktop.DBus.Properties
-    
+
           Methods
           -------
             Get(String interface, String, propname) -> (Variant value)

--- a/doc/xml/Makefile.am
+++ b/doc/xml/Makefile.am
@@ -39,7 +39,7 @@ DISTCLEANFILES = $(man_MANS) $(HTMLS) transform-*.xsl \
 
 #SGML_CATALOG_FILES
 #XSLTPROC_FLAGS = --catalogs --nonet --xinclude
-XSLTPROC_FLAGS = --nonet --xinclude 
+XSLTPROC_FLAGS = --nonet --xinclude
 XSLTPROC_MAN_FLAGS = $(XSLTPROC_FLAGS) transform-man.xsl
 XSLTPROC_HTML_FLAGS = $(XSLTPROC_FLAGS) transform-html.xsl
 

--- a/doc/xml/authors.xml
+++ b/doc/xml/authors.xml
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2019 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <authorgroup>

--- a/doc/xml/authors.xml
+++ b/doc/xml/authors.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   This file is part of firewalld.

--- a/doc/xml/firewall-applet.xml
+++ b/doc/xml/firewall-applet.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2015 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewall-applet">

--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -1993,7 +1993,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
            </para>
          </listitem>
        </varlistentry>
-       
+
        <varlistentry>
          <term><option>--permanent</option> <option>--helper</option>=<replaceable>helper</replaceable> <option>--add-port</option>=<replaceable>portid</replaceable><optional>-<replaceable>portid</replaceable></optional>/<replaceable>protocol</replaceable></term>
          <listitem>
@@ -2468,7 +2468,7 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
 	The context is the security (SELinux) context of a running application or service. To get the context of a running application use <command>ps -e --context</command>.
       </para>
       <para>
-	<emphasis role="bold">Warning:</emphasis> If the context is unconfined, then this will open access for more than the desired application. 
+	<emphasis role="bold">Warning:</emphasis> If the context is unconfined, then this will open access for more than the desired application.
       </para>
       <para>
 	The lockdown whitelist entries are checked in the following order:

--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -8,24 +8,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2014 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewall-cmd">

--- a/doc/xml/firewall-config.xml
+++ b/doc/xml/firewall-config.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewall-config">

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -223,7 +223,7 @@
           <term><option>--remove-service</option>=<replaceable>service</replaceable></term>
           <listitem>
 	    <para>
-	      Remove a service from the default zone. This option can be specified multiple times. 
+	      Remove a service from the default zone. This option can be specified multiple times.
 	    </para>
 	    <para>
 	      The service is one of the firewalld provided services. To get a list of the supported services, use <command>firewall-cmd --get-services</command>.
@@ -236,7 +236,7 @@
           <term><option>--service</option>=<replaceable>service</replaceable></term>
           <listitem>
 	    <para>
-	      Add a service to the default zone. This option can be specified multiple times. 
+	      Add a service to the default zone. This option can be specified multiple times.
 	    </para>
 	    <para>
 	      The service is one of the firewalld provided services. To get a list of the supported services, use <command>firewall-cmd --get-services</command>.
@@ -305,7 +305,7 @@
 	      This option will result in a warning message.
 	    </para>
 	    <para>
-	      Add the <emphasis>IPv4</emphasis> forward port in the default zone. This option can be specified multiple times. 
+	      Add the <emphasis>IPv4</emphasis> forward port in the default zone. This option can be specified multiple times.
 	    </para>
 	    <para>
 	      The port can either be a single port number <replaceable>portid</replaceable> or a port range <replaceable>portid</replaceable>-<replaceable>portid</replaceable>. The protocol can either be <literal>tcp</literal>, <literal>udp</literal>, <literal>sctp</literal> or <literal>dccp</literal>. The destination address is an IP address.
@@ -1988,7 +1988,7 @@
            </para>
          </listitem>
        </varlistentry>
-       
+
        <varlistentry>
          <term><option>--helper</option>=<replaceable>helper</replaceable> <option>--add-port</option>=<replaceable>portid</replaceable><optional>-<replaceable>portid</replaceable></optional>/<replaceable>protocol</replaceable></term>
          <listitem>
@@ -2425,13 +2425,13 @@
 	If a command entry on the whitelist ends with an asterisk '*', then all command lines starting with the command will match. If the '*' is not there the absolute command inclusive arguments must match.
       </para>
       <para>
-	Commands for user root and others is not always the same. Example: As root <command>/bin/firewall-cmd</command> is used, as a normal user <command>/usr/bin/firewall-cmd</command> is be used on Fedora. 
+	Commands for user root and others is not always the same. Example: As root <command>/bin/firewall-cmd</command> is used, as a normal user <command>/usr/bin/firewall-cmd</command> is be used on Fedora.
       </para>
       <para>
 	The context is the security (SELinux) context of a running application or service. To get the context of a running application use <command>ps -e --context</command>.
       </para>
       <para>
-	<emphasis role="bold">Warning:</emphasis> If the context is unconfined, then this will open access for more than the desired application. 
+	<emphasis role="bold">Warning:</emphasis> If the context is unconfined, then this will open access for more than the desired application.
       </para>
       <para>
 	The lockdown whitelist entries are checked in the following order:

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewall-offline-cmd">

--- a/doc/xml/firewalld.conf.xml
+++ b/doc/xml/firewalld.conf.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.conf">

--- a/doc/xml/firewalld.dbus.xml
+++ b/doc/xml/firewalld.dbus.xml
@@ -130,7 +130,7 @@
 		Reload firewall completely, even netfilter kernel modules.
 		This will most likely terminate active connections, because state information is lost.
 		This option should only be used in case of severe firewall problems.
-		For example if there are state information problems that no connection can be established with correct firewall rules. 
+		For example if there are state information problems that no connection can be established with correct firewall rules.
               </para>
             </listitem>
           </varlistentry>
@@ -639,7 +639,7 @@
     <refsect2 id="FirewallD1.direct">
       <title>org.fedoraproject.FirewallD1.direct</title>
 
-      
+
       <refsect3>
         <title>DEPRECATED</title>
 
@@ -932,7 +932,7 @@
             <term>ChainAdded(s: ipv, s: table, s: chain)</term>
             <listitem>
               <para>
-		Emitted when <replaceable>chain</replaceable> has been added into <replaceable>table</replaceable> for <replaceable>ipv</replaceable> being either <literal>ipv4</literal> (iptables) or <literal>ipv6</literal> (ip6tables) or <literal>eb</literal> (ebtables). 
+		Emitted when <replaceable>chain</replaceable> has been added into <replaceable>table</replaceable> for <replaceable>ipv</replaceable> being either <literal>ipv4</literal> (iptables) or <literal>ipv6</literal> (ip6tables) or <literal>eb</literal> (ebtables).
               </para>
             </listitem>
           </varlistentry>
@@ -940,7 +940,7 @@
             <term>ChainRemoved(s: ipv, s: table, s: chain)</term>
             <listitem>
               <para>
-		Emitted when <replaceable>chain</replaceable> has been removed from <replaceable>table</replaceable> for <replaceable>ipv</replaceable> being either <literal>ipv4</literal> (iptables) or <literal>ipv6</literal> (ip6tables) or <literal>eb</literal> (ebtables). 
+		Emitted when <replaceable>chain</replaceable> has been removed from <replaceable>table</replaceable> for <replaceable>ipv</replaceable> being either <literal>ipv4</literal> (iptables) or <literal>ipv6</literal> (ip6tables) or <literal>eb</literal> (ebtables).
               </para>
             </listitem>
           </varlistentry>
@@ -3740,7 +3740,7 @@
           </varlistentry>
 	</variablelist>
       </refsect3>
-      
+
       <refsect3 id="FirewallD1.config.ipset.Signals">
         <title>Signals</title>
         <variablelist>

--- a/doc/xml/firewalld.dbus.xml
+++ b/doc/xml/firewalld.dbus.xml
@@ -7,25 +7,15 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2014 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
   Jiri Popelka <jpopelka@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.dbus">

--- a/doc/xml/firewalld.direct.xml
+++ b/doc/xml/firewalld.direct.xml
@@ -283,7 +283,7 @@
 
     <para>
       Denylisting of the networks 192.168.1.0/24 and 192.168.5.0/24 with logging and dropping early in the raw table:
-      
+
       <programlisting>
 &lt;?xml version="1.0" encoding="utf-8"?&gt;
 &lt;direct&gt;
@@ -294,7 +294,7 @@
   &lt;rule ipv="ipv4" table="raw" chain="denylist" priority="1"&gt;-j DROP&lt;/rule&gt;
 &lt;/direct&gt;
       </programlisting>
-      
+
     </para>
   </refsect1>
 

--- a/doc/xml/firewalld.direct.xml
+++ b/doc/xml/firewalld.direct.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.direct">

--- a/doc/xml/firewalld.helper.xml
+++ b/doc/xml/firewalld.helper.xml
@@ -60,7 +60,7 @@
     <para>
       A firewalld helper configuration file provides the information of a helper entry for firewalld. The most important configuration options are ports, family and module.
     </para>
- 
+
     <para>
       This example configuration file shows the structure of a helper configuration file:
 

--- a/doc/xml/firewalld.helper.xml
+++ b/doc/xml/firewalld.helper.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.helper">

--- a/doc/xml/firewalld.icmptype.xml
+++ b/doc/xml/firewalld.icmptype.xml
@@ -60,7 +60,7 @@
     <para>
       A firewalld icmptype configuration file provides the information for an Internet Control Message Protocol (ICMP) type for firewalld.
     </para>
- 
+
     <para>
       This example configuration file shows the structure of an icmptype configuration file:
 

--- a/doc/xml/firewalld.icmptype.xml
+++ b/doc/xml/firewalld.icmptype.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.icmptype">

--- a/doc/xml/firewalld.ipset.xml
+++ b/doc/xml/firewalld.ipset.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.ipset">

--- a/doc/xml/firewalld.lockdown-whitelist.xml
+++ b/doc/xml/firewalld.lockdown-whitelist.xml
@@ -59,7 +59,7 @@
     <para>
       The firewalld lockdown-whitelist configuration file contains the selinux contexts, commands, users and user ids that are white-listed when firewalld lockdown feature is enabled (see <citerefentry><refentrytitle>firewalld.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry> and <citerefentry><refentrytitle>firewall-cmd</refentrytitle><manvolnum>1</manvolnum></citerefentry>).
     </para>
- 
+
     <para>
       This example configuration file shows the structure of an lockdown-whitelist file:
 
@@ -104,7 +104,7 @@
 	      To get the context of a running application use <command>ps -e --context</command> and search for the application that should be white-listed.
 	    </para>
 	    <para>
-	      Warning: If the context of an application is unconfined, then this will open access for more than the desired application. 
+	      Warning: If the context of an application is unconfined, then this will open access for more than the desired application.
 	    </para>
 	  </listitem>
 	</varlistentry>

--- a/doc/xml/firewalld.lockdown-whitelist.xml
+++ b/doc/xml/firewalld.lockdown-whitelist.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.lockdown-whitelist">

--- a/doc/xml/firewalld.policies.xml
+++ b/doc/xml/firewalld.policies.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2020 Red Hat, Inc.
+
   Authors:
   Eric Garver <eric@garver.life>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.policies">

--- a/doc/xml/firewalld.policy.xml
+++ b/doc/xml/firewalld.policy.xml
@@ -9,24 +9,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2020 Red Hat, Inc.
+
   Authors:
   Eric Garver <eric@garver.life>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.policy">

--- a/doc/xml/firewalld.richlanguage.xml
+++ b/doc/xml/firewalld.richlanguage.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.richlanguage">

--- a/doc/xml/firewalld.richlanguage.xml
+++ b/doc/xml/firewalld.richlanguage.xml
@@ -161,7 +161,7 @@ port port="port value" protocol="tcp|udp|sctp|dccp"
 	</programlisting>
       </para>
       <para>
-	The port <replaceable>port value</replaceable> can either be a single port number <replaceable>portid</replaceable> or a port range <replaceable>portid</replaceable>-<replaceable>portid</replaceable>. 
+	The port <replaceable>port value</replaceable> can either be a single port number <replaceable>portid</replaceable> or a port range <replaceable>portid</replaceable>-<replaceable>portid</replaceable>.
       The protocol can either be <literal>tcp</literal>, <literal>udp</literal>, <literal>sctp</literal> or <literal>dccp</literal>.
       </para>
     </refsect2>
@@ -250,7 +250,7 @@ forward-port port="port value" protocol="tcp|udp|sctp|dccp" to-port="port value"
 	Forward port/packets from local port value with protocol "tcp" or "udp" to either another port locally or to another machine or to another port on another machine.
       </para>
       <para>
-	The port value can either be a single port number or a port range <replaceable>portid-portid</replaceable>. The <option>to-addr</option> is an IP address. 
+	The port value can either be a single port number or a port range <replaceable>portid-portid</replaceable>. The <option>to-addr</option> is an IP address.
       The protocol can either be <literal>tcp</literal>, <literal>udp</literal>, <literal>sctp</literal> or <literal>dccp</literal>.
       </para>
       <para>
@@ -269,7 +269,7 @@ source-port port="port value" protocol="tcp|udp|sctp|dccp"
 	</programlisting>
       </para>
       <para>
-	The source-port <replaceable>port value</replaceable> can either be a single port number <replaceable>portid</replaceable> or a port range <replaceable>portid</replaceable>-<replaceable>portid</replaceable>. 
+	The source-port <replaceable>port value</replaceable> can either be a single port number <replaceable>portid</replaceable> or a port range <replaceable>portid</replaceable>-<replaceable>portid</replaceable>.
       The protocol can either be <literal>tcp</literal>, <literal>udp</literal>, <literal>sctp</literal> or <literal>dccp</literal>.
       </para>
     </refsect2>
@@ -308,7 +308,7 @@ nflog [group="group id"] [prefix="prefix text"] [queue-size="threshold"] [limit 
       You can define a prefix text with a maximum length of 127 characters that will be added to the log message as a prefix.
       The <option>queue-size</option> option can be set to increase the queue threshold which can help limit context switching.
       The default value for <option>queue-size</option> is 1, maximum value is 65535.
-	See <citerefentry><refentrytitle>iptables-extensions</refentrytitle><manvolnum>8</manvolnum></citerefentry> and <citerefentry><refentrytitle>nft</refentrytitle><manvolnum>8</manvolnum></citerefentry> for more details. 
+	See <citerefentry><refentrytitle>iptables-extensions</refentrytitle><manvolnum>8</manvolnum></citerefentry> and <citerefentry><refentrytitle>nft</refentrytitle><manvolnum>8</manvolnum></citerefentry> for more details.
       </para>
       <para>
       See Limit section for description of <option>limit</option> tag.

--- a/doc/xml/firewalld.service.xml
+++ b/doc/xml/firewalld.service.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.service">

--- a/doc/xml/firewalld.service.xml
+++ b/doc/xml/firewalld.service.xml
@@ -60,7 +60,7 @@
     <para>
       A firewalld service configuration file provides the information of a service entry for firewalld. The most important configuration options are ports, modules and destination addresses.
     </para>
- 
+
     <para>
       This example configuration file shows the structure of a service configuration file:
 

--- a/doc/xml/firewalld.xml.in
+++ b/doc/xml/firewalld.xml.in
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld">

--- a/doc/xml/firewalld.zone.xml
+++ b/doc/xml/firewalld.zone.xml
@@ -9,24 +9,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.zone">

--- a/doc/xml/firewalld.zones.xml
+++ b/doc/xml/firewalld.zones.xml
@@ -7,24 +7,14 @@
 ]>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refentry id="firewalld.zones">

--- a/doc/xml/notes.xml
+++ b/doc/xml/notes.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   This file is part of firewalld.

--- a/doc/xml/notes.xml
+++ b/doc/xml/notes.xml
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refsect1>

--- a/doc/xml/policy_zone_descriptions.xml
+++ b/doc/xml/policy_zone_descriptions.xml
@@ -264,7 +264,7 @@
     <title>rule</title>
     <para>
         Is an optional element tag and can be used several times to have more
-        than one rich language rule entry. 
+        than one rich language rule entry.
     </para>
     <para>
         The general rule structure:
@@ -284,7 +284,7 @@
         &lt;forward-port port="<replaceable>portid</replaceable>[-<replaceable>portid</replaceable>]" protocol="<literal>tcp</literal>|<literal>udp</literal>|<literal>sctp</literal>|<literal>dccp</literal>" [to-port="<replaceable>portid</replaceable>[-<replaceable>portid</replaceable>]"] [to-addr="<replaceable>address</replaceable>"]/&gt; |
         &lt;source-port port="<replaceable>portid</replaceable>[-<replaceable>portid</replaceable>]" protocol="<literal>tcp</literal>|<literal>udp</literal>|<literal>sctp</literal>|<literal>dccp</literal>"/&gt; |
     ]
-    [ 
+    [
         &lt;log [prefix="<replaceable>prefix text</replaceable>"] [level="<literal>emerg</literal>|<literal>alert</literal>|<literal>crit</literal>|<literal>err</literal>|<literal>warn</literal>|<literal>notice</literal>|<literal>info</literal>|<literal>debug</literal>"]&gt; [&lt;limit value="<replaceable>rate</replaceable>/<replaceable>duration</replaceable>"/&gt;] &lt;/log&gt; |
         &lt;nflog [group="<replaceable>group id</replaceable>"] [prefix="<replaceable>prefix text</replaceable>"] [queue-size="<replaceable>threshold</replaceable>"]&gt; [&lt;limit value="<replaceable>rate</replaceable>/<replaceable>duration</replaceable>"/&gt;] &lt;/nflog&gt;
     ]
@@ -305,7 +305,7 @@
         <programlisting>
 &lt;rule [family="<literal>ipv4</literal>|<literal>ipv6</literal>"] [priority="<replaceable>priority</replaceable>"]&gt;
     &lt;source address="<replaceable>address</replaceable>[/<replaceable>mask</replaceable>]"|mac="<replaceable>MAC</replaceable>"|ipset="<replaceable>ipset</replaceable>" [invert="<replaceable>True</replaceable>"]/&gt;
-    [ 
+    [
         &lt;log [prefix="<replaceable>prefix text</replaceable>"] [level="<literal>emerg</literal>|<literal>alert</literal>|<literal>crit</literal>|<literal>err</literal>|<literal>warn</literal>|<literal>notice</literal>|<literal>info</literal>|<literal>debug</literal>"]&gt; [&lt;limit value="<replaceable>rate</replaceable>/<replaceable>duration</replaceable>"/&gt;] &lt;/log&gt; |
         &lt;nflog [group="<replaceable>group id</replaceable>"] [prefix="<replaceable>prefix text</replaceable>"] [queue-size="<replaceable>threshold</replaceable>"]&gt; [&lt;limit value="<replaceable>rate</replaceable>/<replaceable>duration</replaceable>"/&gt;] &lt;/nflog&gt;
     ]

--- a/doc/xml/policy_zone_descriptions.xml
+++ b/doc/xml/policy_zone_descriptions.xml
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2020 Red Hat, Inc.
+
   Authors:
   Eric Garver <eric@garver.life>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refsect2 id="short">

--- a/doc/xml/policy_zone_descriptions.xml
+++ b/doc/xml/policy_zone_descriptions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   This file is part of firewalld.

--- a/doc/xml/policy_zone_syntax.xml
+++ b/doc/xml/policy_zone_syntax.xml
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2020 Red Hat, Inc.
+
   Authors:
   Eric Garver <eric@garver.life>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
     [ &lt;short&gt;<replaceable>short description</replaceable>&lt;/short&gt; ]

--- a/doc/xml/policy_zone_syntax.xml
+++ b/doc/xml/policy_zone_syntax.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   This file is part of firewalld.

--- a/doc/xml/seealso.xml
+++ b/doc/xml/seealso.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <!--
   This file is part of firewalld.

--- a/doc/xml/seealso.xml
+++ b/doc/xml/seealso.xml
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
   This file is part of firewalld.
 
   Copyright (C) 2010-2013 Red Hat, Inc.
+
   Authors:
   Thomas Woerner <twoerner@redhat.com>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <refsect1>

--- a/doxygen.conf.in
+++ b/doxygen.conf.in
@@ -662,7 +662,7 @@ RECURSIVE              = YES
 # subdirectory from a directory tree whose root is specified with the INPUT tag.
 # Note that relative paths are relative to directory from which doxygen is run.
 
-EXCLUDE                = 
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/firewalld.spec
+++ b/firewalld.spec
@@ -27,7 +27,7 @@ Requires: python3-firewall  = %{version}-%{release}
 Recommends: libcap-ng-python3
 
 %description
-firewalld is a firewall service daemon that provides a dynamic customizable 
+firewalld is a firewall service daemon that provides a dynamic customizable
 firewall with a D-Bus interface.
 
 %package -n python3-firewall
@@ -72,7 +72,7 @@ Requires: NetworkManager-libnm
 Requires: dbus-x11
 
 %description -n firewall-applet
-The firewall panel applet provides a status information of firewalld and also 
+The firewall panel applet provides a status information of firewalld and also
 the firewall settings.
 
 %package -n firewall-config
@@ -86,7 +86,7 @@ Requires: dbus-x11
 Recommends: polkit
 
 %description -n firewall-config
-The firewall configuration application provides an configuration interface for 
+The firewall configuration application provides an configuration interface for
 firewalld.
 
 %prep
@@ -116,7 +116,7 @@ desktop-file-install --delete-original \
 %systemd_preun firewalld.service
 
 %postun
-%systemd_postun_with_restart firewalld.service 
+%systemd_postun_with_restart firewalld.service
 
 
 %post -n firewall-applet

--- a/shell-completion/bash/firewall-cmd
+++ b/shell-completion/bash/firewall-cmd
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
 # Copyright (C) 2013 Red Hat, Inc.
 #
 # Authors:
 # Jiri Popelka <jpopelka@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 # bash completion for firewall-cmd
 

--- a/shell-completion/bash/firewall-cmd
+++ b/shell-completion/bash/firewall-cmd
@@ -1,5 +1,3 @@
-# bash completion for firewall-cmd                         -*- shell-script -*-
-
 # Copyright (C) 2013 Red Hat, Inc.
 #
 # Authors:
@@ -19,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# bash completion for firewall-cmd
 
 # TODO: find a way how to get the following options from firewall-cmd
 

--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -1,24 +1,11 @@
 #!@PYTHON@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2023 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
 # Eric Garver <eric@garver.life>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 try:
     from PyQt6 import QtGui, QtCore, QtWidgets

--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -1,24 +1,11 @@
 #!@PYTHON@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2009-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
 # Jiri Popelka <jpopelka@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from gi.repository import GObject
 import sys

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.6"/>

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1,23 +1,10 @@
 #!@PYTHON@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2015 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import sys
 import string

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -1,24 +1,11 @@
 #!@PYTHON@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2009-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
 # Jiri Popelka <jpopelka@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from gi.repository import GObject
 import sys

--- a/src/firewall/client.py
+++ b/src/firewall/client.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2009-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from gi.repository import GLib
 

--- a/src/firewall/command.py
+++ b/src/firewall/command.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """FirewallCommand class for command line client simplification"""
 

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2007-2016 Red Hat, Inc.
+#
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 # translation
 import locale

--- a/src/firewall/config/dbus.py
+++ b/src/firewall/config/dbus.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011,2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 DBUS_INTERFACE_VERSION = 1
 DBUS_INTERFACE_REVISION = 15

--- a/src/firewall/core/base.py
+++ b/src/firewall/core/base.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Base firewall settings"""
 

--- a/src/firewall/core/ebtables.py
+++ b/src/firewall/core/ebtables.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import os.path
 from firewall.core.prog import runProg

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import os
 import sys

--- a/src/firewall/core/fw_config.py
+++ b/src/firewall/core/fw_config.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import copy
 import os

--- a/src/firewall/core/fw_direct.py
+++ b/src/firewall/core/fw_direct.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from firewall.fw_types import LastUpdatedOrderedDict
 from firewall.core import ipXtables

--- a/src/firewall/core/fw_helper.py
+++ b/src/firewall/core/fw_helper.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """helper backend"""
 

--- a/src/firewall/core/fw_icmptype.py
+++ b/src/firewall/core/fw_icmptype.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from firewall.core.logger import log
 from firewall import errors

--- a/src/firewall/core/fw_ifcfg.py
+++ b/src/firewall/core/fw_ifcfg.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Functions to search for and change ifcfg files"""
 

--- a/src/firewall/core/fw_ipset.py
+++ b/src/firewall/core/fw_ipset.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """ipset backend"""
 

--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Functions for NetworkManager interaction"""
 

--- a/src/firewall/core/fw_policies.py
+++ b/src/firewall/core/fw_policies.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from firewall import config
 from firewall.core.logger import log

--- a/src/firewall/core/fw_service.py
+++ b/src/firewall/core/fw_service.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from firewall import errors
 from firewall.errors import FirewallError

--- a/src/firewall/core/fw_transaction.py
+++ b/src/firewall/core/fw_transaction.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Transaction classes for firewalld"""
 

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import copy
 from firewall.core.base import SHORTCUTS, DEFAULT_ZONE_TARGET, SOURCE_IPSET_TYPES

--- a/src/firewall/core/helper.py
+++ b/src/firewall/core/helper.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """The helper maxnamelen"""
 

--- a/src/firewall/core/icmp.py
+++ b/src/firewall/core/icmp.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 ICMP_TYPES = {
      "echo-reply": "0/0",

--- a/src/firewall/core/io/__init__.py
+++ b/src/firewall/core/io/__init__.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 # fix xmlplus to be compatible with the python xml sax parser and python 3
 # by adding __contains__ to xml.sax.xmlreader.AttributesImpl

--- a/src/firewall/core/io/direct.py
+++ b/src/firewall/core/io/direct.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import xml.sax as sax
 import os

--- a/src/firewall/core/io/firewalld_conf.py
+++ b/src/firewall/core/io/firewalld_conf.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import os.path
 import io

--- a/src/firewall/core/io/functions.py
+++ b/src/firewall/core/io/functions.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2018 Red Hat, Inc.
 #
 # Authors:
 # Eric Garver <egarver@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import os
 

--- a/src/firewall/core/io/helper.py
+++ b/src/firewall/core/io/helper.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import xml.sax as sax
 import os

--- a/src/firewall/core/io/icmptype.py
+++ b/src/firewall/core/io/icmptype.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import xml.sax as sax
 import os

--- a/src/firewall/core/io/ifcfg.py
+++ b/src/firewall/core/io/ifcfg.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """ifcfg file parser"""
 

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Generic io_object handler, io specific check methods."""
 

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """ipset io XML handler, reader, writer"""
 

--- a/src/firewall/core/io/lockdown_whitelist.py
+++ b/src/firewall/core/io/lockdown_whitelist.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import xml.sax as sax
 import os

--- a/src/firewall/core/io/service.py
+++ b/src/firewall/core/io/service.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import xml.sax as sax
 import os

--- a/src/firewall/core/io/zone.py
+++ b/src/firewall/core/io/zone.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import xml.sax as sax
 import os

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import os.path
 import copy

--- a/src/firewall/core/ipset.py
+++ b/src/firewall/core/ipset.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """The ipset command wrapper"""
 

--- a/src/firewall/core/logger.py
+++ b/src/firewall/core/logger.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2005-2007,2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import sys
 import types

--- a/src/firewall/core/modules.py
+++ b/src/firewall/core/modules.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """modules backend"""
 

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -1,22 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2018-2023 Red Hat, Inc.
 #
 # Authors:
 # Eric Garver <eric@garver.life>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
+
 import copy
 import json
 import ipaddress

--- a/src/firewall/core/prog.py
+++ b/src/firewall/core/prog.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import subprocess
 

--- a/src/firewall/core/rich.py
+++ b/src/firewall/core/rich.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2013-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from firewall import functions
 from firewall.core.ipset import check_ipset_name

--- a/src/firewall/core/watcher.py
+++ b/src/firewall/core/watcher.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2012-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 from gi.repository import Gio, GLib
 

--- a/src/firewall/dbus_utils.py
+++ b/src/firewall/dbus_utils.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2011-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import dbus
 import pwd

--- a/src/firewall/errors.py
+++ b/src/firewall/errors.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 ALREADY_ENABLED     =   11
 NOT_ENABLED         =   12

--- a/src/firewall/functions.py
+++ b/src/firewall/functions.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2007,2008,2011,2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import socket
 import os

--- a/src/firewall/fw_types.py
+++ b/src/firewall/fw_types.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2013-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 class LastUpdatedOrderedDict:
     def __init__(self, x=None):

--- a/src/firewall/server/config.py
+++ b/src/firewall/server/config.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 

--- a/src/firewall/server/config_helper.py
+++ b/src/firewall/server/config_helper.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import dbus
 import dbus.service

--- a/src/firewall/server/config_icmptype.py
+++ b/src/firewall/server/config_icmptype.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import dbus
 import dbus.service

--- a/src/firewall/server/config_ipset.py
+++ b/src/firewall/server/config_ipset.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2015-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import dbus
 import dbus.service

--- a/src/firewall/server/config_service.py
+++ b/src/firewall/server/config_service.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import dbus
 import dbus.service

--- a/src/firewall/server/config_zone.py
+++ b/src/firewall/server/config_zone.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import dbus
 import dbus.service

--- a/src/firewall/server/decorators.py
+++ b/src/firewall/server/decorators.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2012-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module contains decorators for use with and without D-Bus"""
 

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import GLib
 

--- a/src/firewall/server/server.py
+++ b/src/firewall/server/server.py
@@ -1,21 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # signal handling and run_server derived from setroubleshoot
 # Copyright (C) 2006,2007,2008,2009 Red Hat, Inc.

--- a/src/firewalld.in
+++ b/src/firewalld.in
@@ -1,21 +1,10 @@
 #!@PYTHON@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2016 Red Hat, Inc.
+#
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # python fork magic derived from setroubleshoot
 # Copyright (C) 2006,2007,2008,2009 Red Hat, Inc.

--- a/src/gtk3_chooserbutton.py
+++ b/src/gtk3_chooserbutton.py
@@ -1,24 +1,11 @@
 #!/usr/bin/python -Es
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2008,2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
 # Florian Festi <ffesti@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 import gi
 gi.require_version('Gtk', '3.0')

--- a/src/gtk3_niceexpander.py
+++ b/src/gtk3_niceexpander.py
@@ -1,23 +1,10 @@
 #!/usr/bin/python -Es
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2016 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 class NiceExpander:
     def __init__(self, expanded_button, unexpanded_button, paned, child):

--- a/src/tests/cli/firewall-cmd.at
+++ b/src/tests/cli/firewall-cmd.at
@@ -4,7 +4,7 @@ m4_ifdef([TESTING_FIREWALL_OFFLINE_CMD], [], [
 
 FWD_START_TEST([basic options])
     AT_KEYWORDS(panic reload gh808)
-    
+
     FWD_CHECK([], 2, ignore, [dnl
 State: running
 
@@ -1481,27 +1481,27 @@ FWD_START_TEST([rich rules priority])
         AUDIT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:1122 AUDIT accept
     ])
     IPTABLES_LIST_RULES([filter], [IN_public_deny], 0, [dnl
-        DROP 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2222 
+        DROP 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2222
     ])
     IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:1122 
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:3333 
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:4444 
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:1122
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:3333
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:4444
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_log], 0, [dnl
         LOG 6 -- ::/0 ::/0 tcp dpt:1111 LOG flags 0 level 4
         AUDIT 6 -- ::/0 ::/0 tcp dpt:1122 AUDIT accept
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_deny], 0, [dnl
-        DROP 6 -- ::/0 ::/0 tcp dpt:2222 
+        DROP 6 -- ::/0 ::/0 tcp dpt:2222
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-        ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:1122 
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:3333 
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:4444 
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+        ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:1122
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:3333
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:4444
     ])
     FWD_RELOAD
 
@@ -1644,7 +1644,7 @@ FWD_START_TEST([rich rules priority])
         DROP 0 -- 10.1.0.0/16 0.0.0.0/0
     ])
     IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
     ])
     IPTABLES_LIST_RULES([filter], [FWD_public_pre], 0, [dnl
     ])
@@ -1671,8 +1671,8 @@ FWD_START_TEST([rich rules priority])
     IP6TABLES_LIST_RULES([filter], [IN_public_pre], 0, [dnl
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-        ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+        ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
     ])
     IP6TABLES_LIST_RULES([filter], [FWD_public_pre], 0, [dnl
     ])
@@ -1751,7 +1751,7 @@ FWD_START_TEST([rich rules priority])
         REJECT 1 -- 0.0.0.0/0 0.0.0.0/0 icmptype 3 reject-with icmp-host-prohibited
     ])
     IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
         ACCEPT 1 -- 0.0.0.0/0 0.0.0.0/0 icmptype 8
     ])
     IPTABLES_LIST_RULES([filter], [FWD_public_pre], 0, [dnl
@@ -1768,8 +1768,8 @@ FWD_START_TEST([rich rules priority])
         REJECT 58 -- ::/0 ::/0 ipv6-icmptype 1 reject-with icmp6-adm-prohibited
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-        ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+        ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
         ACCEPT 58 -- ::/0 ::/0 ipv6-icmptype 128
     ])
     IP6TABLES_LIST_RULES([filter], [FWD_public_pre], 0, [dnl
@@ -1852,43 +1852,43 @@ FWD_START_TEST([rich rules priority])
     IPTABLES_LIST_RULES([filter], [IN_public_pre], 0, [dnl
         LOG 0 -- 10.0.0.0/8 0.0.0.0/0 LOG flags 0 level 4
         LOG 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:1111 LOG flags 0 level 4
-        DROP 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:1111 
+        DROP 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:1111
         ACCEPT 0 -- 10.10.10.0/24 0.0.0.0/0
         LOG 0 -- 10.0.0.0/8 0.0.0.0/0 LOG flags 0 level 4
         DROP 0 -- 10.0.0.0/8 0.0.0.0/0
     ])
     IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
     ])
     IPTABLES_LIST_RULES([filter], [IN_public_deny], 0, [dnl
     ])
     IPTABLES_LIST_RULES([filter], [IN_public_log], 0, [dnl
     ])
     IPTABLES_LIST_RULES([filter], [IN_public_post], 0, [dnl
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:80 
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:443 
-        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:143 
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:80
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:443
+        ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:143
         LOG 0 -- 0.0.0.0/0 0.0.0.0/0 LOG flags 0 level 4 prefix "DROPPED: "
         DROP 0 -- 0.0.0.0/0 0.0.0.0/0
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_pre], 0, [dnl
         LOG 6 -- ::/0 ::/0 tcp dpt:1111 LOG flags 0 level 4
-        DROP 6 -- ::/0 ::/0 tcp dpt:1111 
+        DROP 6 -- ::/0 ::/0 tcp dpt:1111
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-        ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+        ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_deny], 0, [dnl
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_log], 0, [dnl
     ])
     IP6TABLES_LIST_RULES([filter], [IN_public_post], 0, [dnl
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:80 
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:443 
-        ACCEPT 6 -- ::/0 ::/0 tcp dpt:143 
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:80
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:443
+        ACCEPT 6 -- ::/0 ::/0 tcp dpt:143
         LOG 0 -- ::/0 ::/0 LOG flags 0 level 4 prefix "DROPPED: "
         DROP 0 -- ::/0 ::/0
     ])

--- a/src/tests/dbus/direct.at
+++ b/src/tests/dbus/direct.at
@@ -170,7 +170,7 @@ DBUS_INTROSPECT([], [[//signal[@name="ChainAdded"]]], 0, [dnl
         <arg name="table" type="s"></arg>
         <arg name="chain" type="s"></arg>
         <annotation name="org.freedesktop.DBus.Deprecated" value="true"></annotation>
-    </signal>  
+    </signal>
 ])
 
 DBUS_INTROSPECT([], [[//signal[@name="ChainRemoved"]]], 0, [dnl

--- a/src/tests/features/helpers_custom.at
+++ b/src/tests/features/helpers_custom.at
@@ -46,16 +46,16 @@ IPTABLES_LIST_RULES([raw], [PRE_public_allow], 0, [dnl
     CT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121 CT helper ftp
 ])
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121
 ])
 IP6TABLES_LIST_RULES([raw], [PRE_public_allow], 0, [dnl
     CT 6 -- ::/0 ::/0 tcp dpt:2121 CT helper ftp
 ])
 IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:2121 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:2121
 ])
 
 dnl Same thing as above, but with the new "helper" in service.
@@ -100,16 +100,16 @@ IPTABLES_LIST_RULES([raw], [PRE_public_allow], 0, [dnl
     CT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121 CT helper ftp
 ])
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121
 ])
 IP6TABLES_LIST_RULES([raw], [PRE_public_allow], 0, [dnl
     CT 6 -- ::/0 ::/0 tcp dpt:2121 CT helper ftp
 ])
 IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:2121 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:2121
 ])
 
 dnl again, but with both "module" and "helper"
@@ -138,19 +138,19 @@ IPTABLES_LIST_RULES([raw], [PRE_public_allow], 0, [dnl
     CT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121 CT helper ftp
 ])
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:21 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:2121
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:21
 ])
 IP6TABLES_LIST_RULES([raw], [PRE_public_allow], 0, [dnl
     CT 6 -- ::/0 ::/0 tcp dpt:21 CT helper ftp
     CT 6 -- ::/0 ::/0 tcp dpt:2121 CT helper ftp
 ])
 IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:2121 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:21 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:2121
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:21
 ])
 
 FWD_END_TEST

--- a/src/tests/features/ports.at
+++ b/src/tests/features/ports.at
@@ -30,16 +30,16 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:1234 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:1234 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:4321 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:4444 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:1234
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:1234
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:4321
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:4444
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:1234 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:1234 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:4321 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:4444 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:1234
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:1234
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:4321
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:4444
 ])
 FWD_CHECK([--permanent --policy=foobar --remove-port 1234/tcp], 0, [ignore])
 FWD_CHECK([--permanent --policy foobar --query-port 1234/tcp], 1, [ignore])
@@ -72,12 +72,12 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:1234 
-    ACCEPT 132 -- 0.0.0.0/0 0.0.0.0/0 sctp dpt:4444 
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:1234
+    ACCEPT 132 -- 0.0.0.0/0 0.0.0.0/0 sctp dpt:4444
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:1234 
-    ACCEPT 132 -- ::/0 ::/0 sctp dpt:4444 
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:1234
+    ACCEPT 132 -- ::/0 ::/0 sctp dpt:4444
 ])
 FWD_CHECK([--permanent --policy=foobar --remove-port 1234/udp], 0, [ignore])
 FWD_CHECK([--permanent --policy=foobar --remove-rich-rule='rule port port=4444 protocol=sctp accept'], 0, [ignore])

--- a/src/tests/features/protocols.at
+++ b/src/tests/features/protocols.at
@@ -30,16 +30,16 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 132 -- 0.0.0.0/0 0.0.0.0/0 
-    ACCEPT 58 -- 0.0.0.0/0 0.0.0.0/0 
-    ACCEPT 33 -- 0.0.0.0/0 0.0.0.0/0 
-    ACCEPT 47 -- 0.0.0.0/0 0.0.0.0/0 
+    ACCEPT 132 -- 0.0.0.0/0 0.0.0.0/0
+    ACCEPT 58 -- 0.0.0.0/0 0.0.0.0/0
+    ACCEPT 33 -- 0.0.0.0/0 0.0.0.0/0
+    ACCEPT 47 -- 0.0.0.0/0 0.0.0.0/0
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 132 -- ::/0 ::/0 
-    ACCEPT 58 -- ::/0 ::/0 
-    ACCEPT 33 -- ::/0 ::/0 
-    ACCEPT 47 -- ::/0 ::/0 
+    ACCEPT 132 -- ::/0 ::/0
+    ACCEPT 58 -- ::/0 ::/0
+    ACCEPT 33 -- ::/0 ::/0
+    ACCEPT 47 -- ::/0 ::/0
 ])
 FWD_CHECK([--permanent --policy=foobar --remove-protocol ipv6-icmp], 0, [ignore])
 FWD_CHECK([--permanent --policy foobar --query-protocol ipv6-icmp], 1, [ignore])
@@ -72,12 +72,12 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 58 -- 0.0.0.0/0 0.0.0.0/0 
-    ACCEPT 132 -- 0.0.0.0/0 0.0.0.0/0 
+    ACCEPT 58 -- 0.0.0.0/0 0.0.0.0/0
+    ACCEPT 132 -- 0.0.0.0/0 0.0.0.0/0
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 58 -- ::/0 ::/0 
-    ACCEPT 132 -- ::/0 ::/0 
+    ACCEPT 58 -- ::/0 ::/0
+    ACCEPT 132 -- ::/0 ::/0
 ])
 FWD_CHECK([--permanent --policy=foobar --remove-protocol ipv6-icmp], 0, [ignore])
 FWD_CHECK([--permanent --policy=foobar --remove-rich-rule='rule protocol value="sctp" accept'], 0, [ignore])

--- a/src/tests/features/rich_destination_ipset.at
+++ b/src/tests/features/rich_destination_ipset.at
@@ -21,7 +21,7 @@ NFT_LIST_RULES([inet], [filter_IN_public_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
     ACCEPT 0 -- 0.0.0.0/0 0.0.0.0/0 match-set foobar dst
 ])
 

--- a/src/tests/features/service_include.at
+++ b/src/tests/features/service_include.at
@@ -62,14 +62,14 @@ NFT_LIST_RULES([inet], [filter_IN_drop_log], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_drop_allow], 0, [dnl
-    ACCEPT 17 -- 0.0.0.0/0 239.255.255.250 udp dpt:1900 
-    ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:12345 
+    ACCEPT 17 -- 0.0.0.0/0 239.255.255.250 udp dpt:1900
+    ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:12345
 ])
 IP6TABLES_LIST_RULES([filter], [IN_drop_allow], 0, [dnl
-    ACCEPT 17 -- ::/0 ff02::c udp dpt:1900 
-    ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:12345 
+    ACCEPT 17 -- ::/0 ff02::c udp dpt:1900
+    ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:12345
 ])
 IPTABLES_LIST_RULES([filter], [IN_drop_log], 0, [dnl
     LOG 17 -- 0.0.0.0/0 239.255.255.250 udp dpt:1900 LOG flags 0 level 4

--- a/src/tests/features/services.at
+++ b/src/tests/features/services.at
@@ -23,11 +23,11 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-    ACCEPT 6 -- 10.10.10.0/24 0.0.0.0/0 tcp dpt:22 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+    ACCEPT 6 -- 10.10.10.0/24 0.0.0.0/0 tcp dpt:22
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
 ])
 m4_ifdef([TESTING_FIREWALL_OFFLINE_CMD], [
     FWD_CHECK([--permanent --policy=foobar --remove-service-from-policy ssh], 0, [ignore])
@@ -62,11 +62,11 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:21 
-    ACCEPT 6 -- 10.10.10.0/24 0.0.0.0/0 tcp dpt:21 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:21
+    ACCEPT 6 -- 10.10.10.0/24 0.0.0.0/0 tcp dpt:21
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:21 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:21
 ])
 dnl iptables needs the helper rules in the raw table
 IPTABLES_LIST_RULES([raw], [PRE_foobar_allow], 0, [dnl

--- a/src/tests/features/source_ports.at
+++ b/src/tests/features/source_ports.at
@@ -30,16 +30,16 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp spt:1234 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp spt:1234 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp spt:4321 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp spt:4444 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp spt:1234
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp spt:1234
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp spt:4321
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp spt:4444
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp spt:1234 
-    ACCEPT 17 -- ::/0 ::/0 udp spt:1234 
-    ACCEPT 17 -- ::/0 ::/0 udp spt:4321 
-    ACCEPT 17 -- ::/0 ::/0 udp spt:4444 
+    ACCEPT 6 -- ::/0 ::/0 tcp spt:1234
+    ACCEPT 17 -- ::/0 ::/0 udp spt:1234
+    ACCEPT 17 -- ::/0 ::/0 udp spt:4321
+    ACCEPT 17 -- ::/0 ::/0 udp spt:4444
 ])
 FWD_CHECK([--permanent --policy=foobar --remove-source-port 1234/tcp], 0, [ignore])
 FWD_CHECK([--permanent --policy foobar --query-source-port 1234/tcp], 1, [ignore])
@@ -72,12 +72,12 @@ NFT_LIST_RULES([inet], [filter_IN_policy_foobar_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp spt:1234 
-    ACCEPT 132 -- 0.0.0.0/0 0.0.0.0/0 sctp spt:4444 
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp spt:1234
+    ACCEPT 132 -- 0.0.0.0/0 0.0.0.0/0 sctp spt:4444
 ])
 IP6TABLES_LIST_RULES([filter], [IN_foobar_allow], 0, [dnl
-    ACCEPT 17 -- ::/0 ::/0 udp spt:1234 
-    ACCEPT 132 -- ::/0 ::/0 sctp spt:4444 
+    ACCEPT 17 -- ::/0 ::/0 udp spt:1234
+    ACCEPT 132 -- ::/0 ::/0 sctp spt:4444
 ])
 FWD_CHECK([--permanent --policy=foobar --remove-source-port 1234/udp], 0, [ignore])
 FWD_CHECK([--permanent --policy=foobar --remove-rich-rule='rule source-port port=4444 protocol=sctp accept'], 0, [ignore])

--- a/src/tests/features/zone.at
+++ b/src/tests/features/zone.at
@@ -162,7 +162,7 @@ IPTABLES_LIST_RULES([filter], [IN_foobar], 0, [dnl
     IN_foobar_deny 0 -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_allow 0 -- 0.0.0.0/0 0.0.0.0/0
     IN_foobar_post 0 -- 0.0.0.0/0 0.0.0.0/0
-    ACCEPT 1 -- 0.0.0.0/0 0.0.0.0/0                                 
+    ACCEPT 1 -- 0.0.0.0/0 0.0.0.0/0
 ])
 IPTABLES_LIST_RULES([filter], [INPUT_POLICIES], 0, [dnl
     IN_allow-host-ipv6 0 -- 0.0.0.0/0 0.0.0.0/0
@@ -178,7 +178,7 @@ IP6TABLES_LIST_RULES([filter], [IN_foobar], 0, [dnl
     IN_foobar_deny 0 -- ::/0 ::/0
     IN_foobar_allow 0 -- ::/0 ::/0
     IN_foobar_post 0 -- ::/0 ::/0
-    ACCEPT 58 -- ::/0 ::/0                                
+    ACCEPT 58 -- ::/0 ::/0
 ])
 IP6TABLES_LIST_RULES([filter], [INPUT_POLICIES], 0, [dnl
     IN_allow-host-ipv6 0 -- ::/0 ::/0

--- a/src/tests/features/zone_priority.at
+++ b/src/tests/features/zone_priority.at
@@ -757,16 +757,16 @@ zone-2 (active)
   egress-priority: -10000
   icmp-block-inversion: no
   interfaces: dummy-2
-  sources: 
-  services: 
-  ports: 
-  protocols: 
+  sources:
+  services:
+  ports:
+  protocols:
   forward: no
   masquerade: no
-  forward-ports: 
-  source-ports: 
-  icmp-blocks: 
-  rich rules: 
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
 ])])
 FWD_CHECK([--info-zone zone-4 | TRIM_WHITESPACE], 0, [m4_strip([dnl
 zone-4 (active)
@@ -775,16 +775,16 @@ zone-4 (active)
   egress-priority: 1
   icmp-block-inversion: no
   interfaces: dummy-4
-  sources: 
-  services: 
-  ports: 
-  protocols: 
+  sources:
+  services:
+  ports:
+  protocols:
   forward: no
   masquerade: no
-  forward-ports: 
-  source-ports: 
-  icmp-blocks: 
-  rich rules: 
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
 ])])
 
 dnl verify XML

--- a/src/tests/integration/polkit_auth_desktop.at
+++ b/src/tests/integration/polkit_auth_desktop.at
@@ -9,7 +9,7 @@ dnl This test verifies the different policy permissions. It does not verify
 dnl every (dbus API, policy) pair. It is only using a subset of the dbus
 dnl interfaces sufficient to verify the policy actions. It's only verifying
 dnl that policy kit auth is functional.
-dnl 
+dnl
 dnl A prime example of this is that both permanent and runtime config changes
 dnl fall under the "config" polkit action.
 

--- a/src/tests/integration/polkit_auth_server.at
+++ b/src/tests/integration/polkit_auth_server.at
@@ -9,7 +9,7 @@ dnl This test verifies the different policy permissions. It does not verify
 dnl every (dbus API, policy) pair. It is only using a subset of the dbus
 dnl interfaces sufficient to verify the policy actions. It's only verifying
 dnl that policy kit auth is functional.
-dnl 
+dnl
 dnl A prime example of this is that both permanent and runtime config changes
 dnl fall under the "config" polkit action.
 

--- a/src/tests/integration/rhbz1928860.at
+++ b/src/tests/integration/rhbz1928860.at
@@ -16,7 +16,7 @@ NMCLI_CHECK([connection up ovs-interface-port], 0, [ignore])
 
 dnl Omit the actual linux interface because it requires the OVS daemon to be
 dnl running. The bug is reproducible without it.
-dnl 
+dnl
 dnl NMCLI_CHECK([connection add type ovs-interface slave-type ovs-port conn.interface ovs-br master ovs-interface-port con-name ovs-interface ipv4.method disabled ipv6.method disabled], 0, [ignore])
 dnl echo NS_CMD([nmcli connection delete ovs-interface]) >> ./cleanup
 dnl NMCLI_CHECK([connection up ovs-interface], 0, [ignore])

--- a/src/tests/python/firewalld_config.py
+++ b/src/tests/python/firewalld_config.py
@@ -1,24 +1,11 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
 # Jiri Popelka <jpopelka@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 # To use in git tree: PYTHONPATH=.. python firewalld-test.py
 

--- a/src/tests/python/firewalld_direct.py
+++ b/src/tests/python/firewalld_direct.py
@@ -1,24 +1,11 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
 # Jiri Popelka <jpopelka@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 # To use in git tree: PYTHONPATH=.. python firewalld-test.py
 

--- a/src/tests/python/firewalld_misc.py
+++ b/src/tests/python/firewalld_misc.py
@@ -1,24 +1,11 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2010-2012 Red Hat, Inc.
 #
 # Authors:
 # Thomas Woerner <twoerner@redhat.com>
 # Jiri Popelka <jpopelka@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 # To use in git tree: PYTHONPATH=.. python firewalld-test.py
 

--- a/src/tests/python/firewalld_rich.py
+++ b/src/tests/python/firewalld_rich.py
@@ -1,23 +1,10 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2013 Red Hat, Inc.
 #
 # Authors:
 # Jiri Popelka <jpopelka@redhat.com>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 # To use in git tree: PYTHONPATH=.. python firewalld-test.py
 

--- a/src/tests/regression/build_policy_split_wildcard.at
+++ b/src/tests/regression/build_policy_split_wildcard.at
@@ -1,7 +1,7 @@
 FWD_START_TEST([build policy split wildcards])
 AT_KEYWORDS(gh892 policy)
 
-dnl Setting up policy and adding interfaces that will remain for the duration of 
+dnl Setting up policy and adding interfaces that will remain for the duration of
 dnl the tests
 dnl
 FWD_CHECK([--permanent --new-policy=foobar], 0, [ignore])

--- a/src/tests/regression/gh1152.at
+++ b/src/tests/regression/gh1152.at
@@ -550,7 +550,7 @@ public (default)
 ])
 
 FWD_CHECK([--get-active-policies], 0, [dnl
-allow-host-ipv6     
+allow-host-ipv6
   ingress-zones: ANY
   egress-zones: HOST
 ])

--- a/src/tests/regression/gh366.at
+++ b/src/tests/regression/gh366.at
@@ -13,13 +13,13 @@ ip6 daddr ff02::fb udp dport 5353 accept
 }
 ])
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 
+ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353
 ])
 IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
-ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353 
+ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
+ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353
 ])])
 
 FWD_CHECK([-q --zone=public --add-service=mdns])

--- a/src/tests/regression/gh696.at
+++ b/src/tests/regression/gh696.at
@@ -65,12 +65,12 @@ NFT_LIST_RULES([inet], [filter_IN_public_allow], 0, [dnl
 ])
 
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
     ACCEPT 1 -- 0.0.0.0/0 0.0.0.0/0 icmptype 8
 ])
 IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
     ACCEPT 58 -- ::/0 ::/0 ipv6-icmptype 128
 ])
 
@@ -90,12 +90,12 @@ NFT_LIST_RULES([inet], [filter_IN_public_allow], 0, [dnl
 ])
 
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
     ACCEPT 1 -- 0.0.0.0/0 0.0.0.0/0 icmptype 8
 ])
 IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
     ACCEPT 58 -- ::/0 ::/0 ipv6-icmptype 128
 ])
 

--- a/src/tests/regression/gh940.at
+++ b/src/tests/regression/gh940.at
@@ -90,12 +90,12 @@ NFT_LIST_RULES([inet], [filter_IN_policy_log-denied_deny], 0, [dnl
 IPTABLES_LIST_RULES([filter], [IN_log-denied_deny], 0, [dnl
     LOG 1 -- 0.0.0.0/0 0.0.0.0/0 icmptype 8 LOG flags 0 level 4 prefix "log-denied_ICMP_BLOCK: "
     REJECT 1 -- 0.0.0.0/0 0.0.0.0/0 icmptype 8 reject-with icmp-host-prohibited
-    DROP 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:6667 
+    DROP 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:6667
 ])
 IP6TABLES_LIST_RULES([filter], [IN_log-denied_deny], 0, [dnl
     LOG 58 -- ::/0 ::/0 ipv6-icmptype 128 LOG flags 0 level 4 prefix "log-denied_ICMP_BLOCK: "
     REJECT 58 -- ::/0 ::/0 ipv6-icmptype 128 reject-with icmp6-adm-prohibited
-    DROP 6 -- ::/0 ::/0 tcp dpt:6667 
+    DROP 6 -- ::/0 ::/0 tcp dpt:6667
 ])
 
 NFT_LIST_RULES([inet], [filter_IN_policy_log-denied_log], 0, [dnl

--- a/src/tests/regression/rhbz1715977.at
+++ b/src/tests/regression/rhbz1715977.at
@@ -19,18 +19,18 @@ NFT_LIST_RULES([inet], [filter_IN_internal_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_internal_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-    ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:137 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:138 
-    ACCEPT 6 -- 0.0.0.0/0 192.168.122.235 tcp dpt:22 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+    ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:137
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:138
+    ACCEPT 6 -- 0.0.0.0/0 192.168.122.235 tcp dpt:22
 ])
 IP6TABLES_LIST_RULES([filter], [IN_internal_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:137 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:138 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:137
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:138
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
 ])
 
 FWD_CHECK([-q --zone=internal --add-rich-rule='rule family=ipv4 destination address="192.168.111.222/32" source address="10.10.10.0/24" service name="ssh" accept'])
@@ -50,19 +50,19 @@ NFT_LIST_RULES([inet], [filter_IN_internal_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_internal_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-    ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:137 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:138 
-    ACCEPT 6 -- 0.0.0.0/0 192.168.122.235 tcp dpt:22 
-    ACCEPT 6 -- 10.10.10.0/24 192.168.111.222 tcp dpt:22 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+    ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:137
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:138
+    ACCEPT 6 -- 0.0.0.0/0 192.168.122.235 tcp dpt:22
+    ACCEPT 6 -- 10.10.10.0/24 192.168.111.222 tcp dpt:22
 ])
 IP6TABLES_LIST_RULES([filter], [IN_internal_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:137 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:138 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:137
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:138
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
 ])
 
 FWD_CHECK([-q --zone=internal --add-rich-rule='rule family=ipv4 service name="ssdp" accept'])
@@ -83,20 +83,20 @@ NFT_LIST_RULES([inet], [filter_IN_internal_allow], 0, [dnl
     }
 ])
 IPTABLES_LIST_RULES([filter], [IN_internal_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
-    ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:137 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:138 
-    ACCEPT 6 -- 0.0.0.0/0 192.168.122.235 tcp dpt:22 
-    ACCEPT 6 -- 10.10.10.0/24 192.168.111.222 tcp dpt:22 
-    ACCEPT 17 -- 0.0.0.0/0 239.255.255.250 udp dpt:1900 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
+    ACCEPT 17 -- 0.0.0.0/0 224.0.0.251 udp dpt:5353
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:137
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:138
+    ACCEPT 6 -- 0.0.0.0/0 192.168.122.235 tcp dpt:22
+    ACCEPT 6 -- 10.10.10.0/24 192.168.111.222 tcp dpt:22
+    ACCEPT 17 -- 0.0.0.0/0 239.255.255.250 udp dpt:1900
 ])
 IP6TABLES_LIST_RULES([filter], [IN_internal_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:137 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:138 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 ff02::fb udp dpt:5353
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:137
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:138
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
 ])
 
 FWD_CHECK([-q --zone=internal --add-rich-rule='rule family=ipv4 destination address="192.168.122.235/32" service name="mdns" accept'], 122, [ignore], [ignore])

--- a/src/tests/regression/rhbz1839781.at
+++ b/src/tests/regression/rhbz1839781.at
@@ -27,36 +27,36 @@ NFT_LIST_RULES([inet], [filter_IN_trusted_allow], 0, [dnl
 ])
 
 IPTABLES_LIST_RULES([filter], [IN_trusted_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:53 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:53 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:80 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:443 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:67 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:69 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:68 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8140 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:5000 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpts:5646:5647 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:5671 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8000 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8080 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:9090 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:53
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:53
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:80
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:443
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:67
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:69
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:68
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8140
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:5000
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpts:5646:5647
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:5671
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8000
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8080
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:9090
 ])
 IP6TABLES_LIST_RULES([filter], [IN_trusted_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:53 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:53 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:80 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:443 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:67 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:69 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:68 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8140 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:5000 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpts:5646:5647 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:5671 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8000 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8080 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:9090 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:53
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:53
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:80
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:443
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:67
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:69
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:68
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8140
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:5000
+    ACCEPT 6 -- ::/0 ::/0 tcp dpts:5646:5647
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:5671
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8000
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8080
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:9090
 ])
 
 FWD_CHECK([--zone trusted --remove-service RH-Satellite-6], 0, [ignore])
@@ -86,38 +86,38 @@ NFT_LIST_RULES([inet], [filter_IN_trusted_allow], 0, [dnl
 ])
 
 IPTABLES_LIST_RULES([filter], [IN_trusted_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:53 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:53 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:80 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:443 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:67 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:69 
-    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:68 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8140 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:5000 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpts:5646:5647 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:5671 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8000 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8080 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:9090 
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8443 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:53
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:53
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:80
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:443
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:67
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:69
+    ACCEPT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:68
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8140
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:5000
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpts:5646:5647
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:5671
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8000
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8080
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:9090
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:8443
 ])
 IP6TABLES_LIST_RULES([filter], [IN_trusted_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:53 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:53 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:80 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:443 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:67 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:69 
-    ACCEPT 17 -- ::/0 ::/0 udp dpt:68 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8140 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:5000 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpts:5646:5647 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:5671 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8000 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8080 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:9090 
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8443 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:53
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:53
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:80
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:443
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:67
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:69
+    ACCEPT 17 -- ::/0 ::/0 udp dpt:68
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8140
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:5000
+    ACCEPT 6 -- ::/0 ::/0 tcp dpts:5646:5647
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:5671
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8000
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8080
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:9090
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:8443
 ])
 
 FWD_END_TEST

--- a/src/tests/regression/rhbz1855140.at
+++ b/src/tests/regression/rhbz1855140.at
@@ -28,7 +28,7 @@ NFT_LIST_RULES([inet], [filter_IN_public_allow], 0, [dnl
 IPTABLES_LIST_RULES([mangle], [PRE_public_allow], 0, [dnl
 ])
 IPTABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 
+    ACCEPT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22
     ACCEPT 1 -- 0.0.0.0/0 0.0.0.0/0 icmptype 8
     ACCEPT 1 -- 0.0.0.0/0 0.0.0.0/0 icmptype 13
 ])
@@ -36,8 +36,8 @@ IP6TABLES_LIST_RULES([mangle], [PRE_public_allow], 0, [dnl
     MARK 58 -- ::/0 ::/0 ipv6-icmptype 4 code 0 MARK or 0x86
 ])
 IP6TABLES_LIST_RULES([filter], [IN_public_allow], 0, [dnl
-    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22 
-    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546 
+    ACCEPT 6 -- ::/0 ::/0 tcp dpt:22
+    ACCEPT 17 -- ::/0 fe80::/64 udp dpt:546
     ACCEPT 58 -- ::/0 ::/0 ipv6-icmptype 128
     ACCEPT 58 -- ::/0 ::/0 ipv6-icmptype 136
 ])

--- a/src/tests/unit/test_unit_helpers.py
+++ b/src/tests/unit/test_unit_helpers.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 import pytest
 from tests.unit import helpers
 


### PR DESCRIPTION
Includes some manual cleanup for the license comments and the file preambles.
The major part of the changes (to add SPDX license identifiers and drop GPL texts) was done by a script.