### PR TITLE
[th/doc-no-link-to-fedoraproject.org] drop references to firewalld wiki on fedoraproject.org

### DIFF
--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -2667,10 +2667,6 @@ For interfaces that are not under control of NetworkManager, firewalld tries to 
 
   <refsect1>
     <title>Examples</title>
-      <para>
-	For more examples see <ulink url="http://fedoraproject.org/wiki/FirewallD"></ulink>
-      </para>
-
     <refsect2>
       <title>Example 1</title>
       <para>

--- a/doc/xml/notes.xml
+++ b/doc/xml/notes.xml
@@ -32,14 +32,6 @@
 	</para>
       </listitem>
     </varlistentry>
-    <varlistentry>
-      <term>More documentation with examples:</term>
-      <listitem>
-	<para>
-	  <ulink url="http://fedoraproject.org/wiki/FirewallD"></ulink>
-	</para>
-      </listitem>
-    </varlistentry>
   </variablelist>
 </refsect1>
 


### PR DESCRIPTION
This wiki is outdated. We should improve our website (if anything is missing) and link to that.

https://lists.fedorahosted.org/archives/list/firewalld-users@lists.fedorahosted.org/thread/LW2MU7VPP5NFCRO3CMTRTYE2L3NIZLIZ/#LW2MU7VPP5NFCRO3CMTRTYE2L3NIZLIZ

https://github.com/firewalld/firewalld/issues/1183