### PR TITLE
improvement(build): rename the "master" branch to "main"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,11 +43,11 @@ update-po:
 	$(MAKE) -C po update-po ${PACKAGE_NAME}.pot
 	cp po/${PACKAGE_NAME}.pot po/${PACKAGE_NAME}.weblate.pot
 
-# This merges translations from the upstream master branch.
+# This merges translations from the upstream main branch.
 # It's only meant to be used from the stable branches. Translations
-# contributions are only done against master.
+# contributions are only done against main.
 merge-po: update-po
-	git fetch -q https://github.com/firewalld/firewalld master; \
+	git fetch -q https://github.com/firewalld/firewalld main; \
 	for po in $(top_srcdir)/po/*.po; do \
 		mv $${po} $${po}.old; \
 		git checkout -q FETCH_HEAD $${po}; \

--- a/config/firewall-config.appdata.xml.in
+++ b/config/firewall-config.appdata.xml.in
@@ -20,7 +20,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/firewalld/firewalld/master/doc/firewall-config.png</image>
+      <image>https://raw.githubusercontent.com/firewalld/firewalld/main/doc/firewall-config.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">http://firewalld.org</url>


### PR DESCRIPTION
The default firewalld branch will be renamed from "master" to "main". This is part of the conscious language effort. Many projects did such a change, and with time, "main" is (becoming?) the most popular name for the default branch.

There are little actual changes necessary, except pushing the "main" branch, deleting the "master" branch and fixing a bit of fall-out.

This commit changes a few references of "master" in the source tree.

See-also: https://github.com/github/renaming/#renaming-the-default-branch-from-master