### PR TITLE
[th/xml-schema] restore XSD XML schemas for validating config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Directory Structure
 | config/           | Configuration files                                   |
 | config/icmptypes/ | Predefined ICMP types                                 |
 | config/services/  | Predefined services                                   |
+| config/xmlschema/ | XML Schema checks for config files                    |
 | config/zones/     | Predefined zones                                      |
 | config/ipsets/    | Predefined ipsets                                     |
 | doc/              | Documentation                                         |

--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -28,6 +28,14 @@ dist_dbus_policy_DATA = FirewallD.conf
 gsettings_in_file = org.fedoraproject.FirewallConfig.gschema.xml.in
 gsettings_SCHEMAS = $(gsettings_in_file:.xml.in=.xml)
 
+xmlschemadir = $(prefixlibdir)/xmlschema
+dist_xmlschema_DATA = \
+	xmlschema/icmptype.xsd \
+	xmlschema/ipset.xsd \
+	xmlschema/service.xsd \
+	xmlschema/zone.xsd
+dist_xmlschema_SCRIPTS = xmlschema/check.sh
+
 BUILT_SOURCES = \
 	$(desktop_DATA) \
 	$(appdata_DATA) \
@@ -374,6 +382,7 @@ EXTRA_DIST = \
 	$(polkit1_action_FILES) \
 	$(gsettings_in_file) \
 	$(CONFIG_FILES) \
+	$(dist_xmlschema_DATA) \
 	lockdown-whitelist.xml.in \
 	firewalld.init \
 	firewalld.logrotate.in \

--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -375,6 +375,17 @@ CONFIG_FILES = \
 	zones/trusted.xml \
 	zones/work.xml
 
+CONFIG_FILES_TESTS = \
+	tests/policies/libvirt-routed-in.xml \
+	tests/policies/libvirt-routed-out.xml \
+	tests/policies/libvirt-to-host.xml \
+	tests/zones/FedoraServer.xml \
+	tests/zones/FedoraWorkstation.xml \
+	tests/zones/libvirt-routed.xml \
+	tests/zones/libvirt.xml \
+	tests/zones/nm-shared.xml \
+	$(NULL)
+
 EXTRA_DIST = \
 	$(desktop_FILES) \
 	$(appdata_FILES) \
@@ -382,6 +393,7 @@ EXTRA_DIST = \
 	$(polkit1_action_FILES) \
 	$(gsettings_in_file) \
 	$(CONFIG_FILES) \
+	$(CONFIG_FILES_TESTS) \
 	$(dist_xmlschema_DATA) \
 	lockdown-whitelist.xml.in \
 	firewalld.init \

--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -541,8 +541,12 @@ install-data-hook:
 		rm -f org.fedoraproject.FirewallD1.policy && \
 		$(LN_S) org.fedoraproject.FirewallD1.server.policy.choice org.fedoraproject.FirewallD1.policy
 
+check-local-xmlschema:
+	./xmlschema/check.sh
+	./xmlschema/check.sh -d ./tests/
+
 # make sure CONFIG_FILES are also in POTFILES
-check-local:
+check-local: check-local-xmlschema
 	@for file in $(filter-out helpers/% %/README.md,$(CONFIG_FILES)); do \
 		if ! grep "$${file}" ${top_srcdir}/po/POTFILES.in > /dev/null; then \
 			echo "$${file} should be in ${abs_top_srcdir}/po/POTFILES.in"; \

--- a/config/services/cratedb.xml
+++ b/config/services/cratedb.xml
@@ -2,7 +2,7 @@
 <service>
   <short>CrateDB</short>
   <description>CrateDB is a distributed SQL database management system that integrates a fully searchable document oriented data store.</description>
+  <include service="postgresql"/>
   <port protocol="tcp" port="4200"/>
   <port protocol="tcp" port="4300"/>
-  <include service="postgresql"/>
 </service>

--- a/config/services/minidlna.xml
+++ b/config/services/minidlna.xml
@@ -2,6 +2,6 @@
 <service>
   <short>MiniDLNA</short>
   <description>MiniDLNA is a simple media server software with the aim to be fully compliant with DLNA/UPNP-AV clients. Enable this service if you run minidlna service.</description>
-  <port protocol="tcp" port="8200"/>
   <include service="ssdp"/>
+  <port protocol="tcp" port="8200"/>
 </service>

--- a/config/services/plex.xml
+++ b/config/services/plex.xml
@@ -2,12 +2,14 @@
 <service>
   <short>PLEX</short>
   <description>Plex Media Server (PMS) is the back-end media server component of Plex. It organizes content from personal media libraries and streams it to the network.</description>
-  <port protocol="tcp" port="32400"/><port protocol="udp" port="32400"/> <!-- Plex media server access (required)> -->
-  <port protocol="tcp" port="32469"/><include service="ssdp"/> <!-- Plex DLNA -->
-  <port protocol="tcp" port="3005"/><!-- plex home theater control (plex companion) -->
-  <port protocol="tcp" port="8324"/><!-- Roku control (plex companion) -->
-  <port protocol="udp" port="32410"/><!-- gdm discovery -->
-  <port protocol="udp" port="32412"/><!-- gdm discovery -->
-  <port protocol="udp" port="32413"/><!-- gdm discovery -->
-  <port protocol="udp" port="32414"/><!-- gdm discovery -->
+  <include service="ssdp"/> <!-- Plex DLNA -->
+  <port protocol="tcp" port="32400"/>
+  <port protocol="udp" port="32400"/> <!-- Plex media server access (required)> -->
+  <port protocol="tcp" port="32469"/>
+  <port protocol="tcp" port="3005"/>  <!-- plex home theater control (plex companion) -->
+  <port protocol="tcp" port="8324"/>  <!-- Roku control (plex companion) -->
+  <port protocol="udp" port="32410"/> <!-- gdm discovery -->
+  <port protocol="udp" port="32412"/> <!-- gdm discovery -->
+  <port protocol="udp" port="32413"/> <!-- gdm discovery -->
+  <port protocol="udp" port="32414"/> <!-- gdm discovery -->
 </service>

--- a/config/tests/policies/libvirt-routed-in.xml
+++ b/config/tests/policies/libvirt-routed-in.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policy target="ACCEPT">
+  <short>libvirt-routed-in</short>
+
+  <description>
+    This policy is used to allow routed traffic to the virtual machines.
+  </description>
+
+  <ingress-zone name="ANY" />
+  <egress-zone name="libvirt-routed" />
+</policy>

--- a/config/tests/policies/libvirt-routed-out.xml
+++ b/config/tests/policies/libvirt-routed-out.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policy target="ACCEPT">
+  <short>libvirt-routed-out</short>
+
+  <description>
+    This policy is used to allow routed virtual machine traffic to the rest of
+    the network.
+  </description>
+
+  <ingress-zone name="libvirt-routed" />
+  <egress-zone name="ANY" />
+</policy>

--- a/config/tests/policies/libvirt-to-host.xml
+++ b/config/tests/policies/libvirt-to-host.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policy target="REJECT">
+  <short>libvirt-to-host</short>
+
+  <description>
+    This policy is used to filter traffic from virtual machines to the
+    host.
+  </description>
+
+  <ingress-zone name="libvirt-routed" />
+  <egress-zone name="HOST" />
+
+  <protocol value='icmp'/>
+  <protocol value='ipv6-icmp'/>
+  <service name='dhcp'/>
+  <service name='dhcpv6'/>
+  <service name='dns'/>
+  <service name='ssh'/>
+  <service name='tftp'/>
+</policy>

--- a/config/tests/zones/FedoraServer.xml
+++ b/config/tests/zones/FedoraServer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<zone>
+  <short>Public</short>
+  <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+  <service name="ssh"/>
+  <service name="dhcpv6-client"/>
+  <service name="cockpit"/>
+  <forward/>
+</zone>

--- a/config/tests/zones/FedoraWorkstation.xml
+++ b/config/tests/zones/FedoraWorkstation.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<zone>
+  <short>Fedora Workstation</short>
+  <description>Unsolicited incoming network packets are rejected from port 1 to 1024, except for select network services. Incoming packets that are related to outgoing network connections are accepted. Outgoing network connections are allowed.</description>
+  <service name="dhcpv6-client"/>
+  <service name="ssh"/>
+  <service name="samba-client"/>
+  <port protocol="udp" port="1025-65535"/>
+  <port protocol="tcp" port="1025-65535"/>
+  <forward/>
+</zone>

--- a/config/tests/zones/libvirt-routed.xml
+++ b/config/tests/zones/libvirt-routed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<zone>
+  <short>libvirt-routed</short>
+
+  <description>
+    This zone is intended to be used only by routed libvirt virtual networks -
+    libvirt will add the bridge devices for all new virtual networks to this
+    zone by default.
+  </description>
+</zone>

--- a/config/tests/zones/libvirt.xml
+++ b/config/tests/zones/libvirt.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<zone target="ACCEPT">
+  <short>libvirt</short>
+
+  <description>
+    The default policy of "ACCEPT" allows all packets to/from
+    interfaces in the zone to be forwarded, while the (*low priority*)
+    reject rule blocks any traffic destined for the host, except those
+    services explicitly listed (that list can be modified as required
+    by the local admin). This zone is intended to be used only by
+    libvirt virtual networks - libvirt will add the bridge devices for
+    all new virtual networks to this zone by default.
+  </description>
+
+<rule priority='32767'>
+  <reject/>
+</rule>
+<protocol value='icmp'/>
+<protocol value='ipv6-icmp'/>
+<service name='dhcp'/>
+<service name='dhcpv6'/>
+<service name='dns'/>
+<service name='ssh'/>
+<service name='tftp'/>
+</zone>

--- a/config/tests/zones/nm-shared.xml
+++ b/config/tests/zones/nm-shared.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<zone target="ACCEPT">
+  <short>NetworkManager Shared</short>
+
+  <description>
+    This zone is used internally by NetworkManager when activating a
+    profile that uses connection sharing and doesn't have an explicit
+    firewall zone set.
+    Block all traffic to the local machine except ICMP, ICMPv6, DHCP
+    and DNS. Allow all forwarded traffic.
+    Note that future package updates may change the definition of the
+    zone unless you overwrite it with your own definition.
+  </description>
+
+  <rule priority='32767'>
+    <reject/>
+  </rule>
+
+  <protocol value='icmp'/>
+  <protocol value='ipv6-icmp'/>
+  <service name="dhcp"/>
+  <service name="dns"/>
+  <service name="ssh"/>
+</zone>

--- a/config/xmlschema/check.sh
+++ b/config/xmlschema/check.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# requires libxml2 packages for xmllint
+XMLLINT=/usr/bin/xmllint
+PACKAGE=libxml2
+
+prog=$(basename $0)
+BASEDIR=$(realpath $(dirname $0))
+
+checkdir=$(pwd)
+while getopts "d:h" arg; do
+    case $arg in
+	d)
+	    checkdir=$OPTARG
+	    ;;
+	h)
+	    cat <<EOF
+Usage: $prog [options]
+
+Checks zone, service and icmptype firewalld config files to be valid.
+Use this script either in the directory containing the zones, services and
+icmptypes directories containing the files to be checked, or use the -d option
+to specify a directory.
+
+Options:
+  -h              Print this help
+  -d <directory>  Check files in this directory
+
+EOF
+	    exit 0
+	    ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ ! -f "$XMLLINT" ]; then
+    echo "$XMLLINT is not installed, please install the $PACKAGE package."
+    exit -1
+fi
+
+if [ ! -d "$checkdir" ]; then
+    echo "Directory '${checkdir}' does not exist"
+    exit -2
+fi
+
+# Stop execution if something failed
+set -e
+
+for keyword in zone service icmptype ipset; do
+    if [ -d "${checkdir}/${keyword}s" ]; then
+	echo "Checking ${keyword}s"
+	cd "${checkdir}/${keyword}s"
+	ls -f *.xml 2>/dev/null | while read -r file; do
+	    echo -n "  "
+	    $XMLLINT --noout --schema "$BASEDIR"/${keyword}.xsd "${file}"
+	done
+    else
+	echo "Directory '${checkdir}/${keyword}s' does not exist"
+    fi
+done

--- a/config/xmlschema/check.sh
+++ b/config/xmlschema/check.sh
@@ -56,11 +56,12 @@ set -e
 for keyword in zone service icmptype ipset; do
     if [ -d "${checkdir}/${keyword}s" ]; then
 	echo "Checking ${keyword}s"
-	cd "${checkdir}/${keyword}s"
+	pushd "${checkdir}/${keyword}s"
 	ls -f *.xml 2>/dev/null | while read -r file; do
 	    echo -n "  "
 	    $XMLLINT --noout --schema "$BASEDIR"/${keyword}.xsd "${file}"
 	done
+	popd
     else
 	echo "Directory '${checkdir}/${keyword}s' does not exist"
     fi

--- a/config/xmlschema/helper.xsd
+++ b/config/xmlschema/helper.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           lementFormDefault="qualified">
+
+<xs:element name="helper">
+  <xs:complexType>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:choice>
+    <xs:attribute name="module" type="xs:string"/>
+    <xs:attribute name="family" type="familyrestrict"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:simpleType name="familyrestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="ipv4|ipv6"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="porttype">
+  <xs:attribute name="protocol" type="xs:string" use="required"/>
+  <xs:attribute name="port" type="xs:string" use="optional"/>
+</xs:complexType>
+
+</xs:schema>

--- a/config/xmlschema/icmptype.xsd
+++ b/config/xmlschema/icmptype.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+elementFormDefault="qualified">
+
+<xs:element name="icmptype">
+  <xs:complexType>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="short" type="xs:string" minOccurs="0"/>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="destination" type="desttype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:choice>
+    <xs:attribute name="version" type="xs:string"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="desttype">
+  <xs:attribute name="ipv4" type="booltype"/>
+  <xs:attribute name="ipv6" type="booltype"/>
+</xs:complexType>
+
+<xs:simpleType name="booltype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[Yy]es|[Nn]o|[Tt]rue|[Ff]alse"/>
+  </xs:restriction>
+</xs:simpleType>
+
+</xs:schema>
+
+

--- a/config/xmlschema/ipset.xsd
+++ b/config/xmlschema/ipset.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	   lementFormDefault="qualified">
+
+<xs:element name="ipset">
+  <xs:complexType>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="short" type="xs:string" minOccurs="0"/>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="option" type="optiontype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="entry" type="entrytype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:choice>
+    <xs:attribute name="version" type="xs:string"/>
+    <xs:attribute name="type" type="xs:string"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="optiontype">
+  <xs:attribute name="name" type="xs:string" use="required"/>
+  <xs:attribute name="value" type="xs:string" use="optional"/>
+</xs:complexType>
+
+<xs:simpleType name="entrytype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="(([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?)|([0-9A-Fa-f:]{3,39}(/[0-9]{1,3})?)|(([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2})"/>
+  </xs:restriction>
+</xs:simpleType>
+
+</xs:schema>
+
+

--- a/config/xmlschema/policy.xsd
+++ b/config/xmlschema/policy.xsd
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+elementFormDefault="qualified">
+
+<xs:element name="policy">
+  <xs:complexType>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="short" type="xs:string" minOccurs="0"/>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="ingress-zone" type="nametype" minOccurs="0"/>
+      <xs:element name="egress-zone" type="nametype" minOccurs="0"/>
+      <xs:element name="protocol" type="valuetype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="service" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="rule" type="ruletype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:choice>
+    <xs:attribute name="target" type="policytargettype"/>
+    <xs:attribute name="priority" type="prioritytype"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="nametype">
+  <xs:attribute name="name" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="valuetype">
+  <xs:attribute name="value" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:simpleType name="familyrestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="ipv4|ipv6"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="porttype">
+  <xs:attribute name="port" type="porttyperestrict" use="required"/>
+  <xs:attribute name="protocol" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:simpleType name="porttyperestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="([0-9]+(\-[0-9]+)?)?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="prioritytype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="-?[0-9]+"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="fwporttype">
+  <xs:attribute name="port" type="porttyperestrict" use="required"/>
+  <xs:attribute name="protocol" type="xs:string" use="required"/>
+  <xs:attribute name="to-port" type="porttyperestrict"/>
+  <xs:attribute name="to-addr" type="ipaddrtype"/>
+</xs:complexType>
+
+<xs:simpleType name="ipaddrtype">
+  <xs:restriction base="xs:string">
+    <!-- IPv4 or IPv6 address (very rough) -->
+    <xs:pattern value="([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?|[0-9A-Fa-f:]{3,39}(/[0-9]{1,3})?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="policytargettype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="CONTINUE|ACCEPT|DROP|REJECT"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="emptytype">
+</xs:complexType>
+
+<xs:complexType name="ruletype">
+  <xs:choice maxOccurs="unbounded">
+    <xs:element name="source" type="sourcetype" minOccurs="0"/>
+    <xs:element name="destination" type="destinationtype" minOccurs="0"/>
+    <xs:choice>
+      <xs:element name="protocol" type="protocoltype"/>
+      <xs:element name="service" type="nametype"/>
+      <xs:element name="port" type="porttype"/>
+      <xs:element name="source-port" type="porttype"/>
+      <xs:element name="icmp-block" type="nametype"/>
+      <xs:element name="icmp-type" type="nametype"/>
+      <xs:element name="icmp-block-inversion" type="emptytype"/>
+      <xs:element name="masquerade" type="emptytype"/>
+      <xs:element name="forward-port" type="fwporttype"/>
+    </xs:choice>
+    <xs:element name="log" type="logtype" minOccurs="0"/>
+    <xs:element name="audit" type="targettype" minOccurs="0"/>
+    <xs:choice>
+      <xs:element name="accept" type="targettype"/>
+      <xs:element name="drop" type="targettype"/>
+      <xs:element name="reject" type="rejecttype"/>
+      <xs:sequence></xs:sequence>
+    </xs:choice>
+  </xs:choice>
+  <xs:attribute name="family" type="familyrestrict"/>
+  <xs:attribute name="priority" type="prioritytype"/>
+</xs:complexType>
+
+<xs:complexType name="sourcetype">
+  <xs:attribute name="ipset" type="xs:string"/>
+  <xs:attribute name="address" type="ipaddrtype"/>
+  <xs:attribute name="invert" type="booltype"/>
+</xs:complexType>
+
+<xs:complexType name="destinationtype">
+  <xs:attribute name="address" type="ipaddrtype" use="required"/>
+  <xs:attribute name="invert" type="booltype"/>
+</xs:complexType>
+
+<xs:simpleType name="booltype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[Yy]es|[Nn]o|[Tt]rue|[Ff]alse"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="protocoltype">
+  <xs:attribute name="value" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="logtype">
+  <xs:sequence>
+    <xs:element name="limit" type="limittype" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute name="prefix" type="xs:string"/>
+  <xs:attribute name="level" type="logtypelevelrestrict"/>
+</xs:complexType>
+
+<xs:simpleType name="logtypelevelrestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="emerg|alert|crit|error|warning|notice|info|debug"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="audittyperestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="ACCEPT|DROP|REJECT"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="targettype">
+  <xs:sequence>
+    <xs:element name="limit" type="limittype" minOccurs="0"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="limittype">
+  <xs:attribute name="value" type="limitvaluerestrict" use="required"/>
+</xs:complexType>
+
+<xs:simpleType name="limitvaluerestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[0-9]+/[a-z]+"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="rejecttype">
+  <xs:sequence>
+    <xs:element name="limit" type="limittype" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute name="type" type="xs:string"/>
+</xs:complexType>
+
+</xs:schema>

--- a/config/xmlschema/service.xsd
+++ b/config/xmlschema/service.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+elementFormDefault="qualified">
+
+<xs:element name="service">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element name="short" type="xs:string" minOccurs="0"/>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="source-port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="protocol" type="prototype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="module" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="destination" type="desttype" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="version" type="xs:string"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="nametype">
+  <xs:attribute name="name" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="prototype">
+  <xs:attribute name="value" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="porttype">
+  <xs:attribute name="port" type="porttyperestrict" use="required"/>
+  <xs:attribute name="protocol" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:simpleType name="porttyperestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="([0-9]+(\-[0-9]+)?)?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="desttype">
+  <xs:attribute name="ipv4" type="ipv4addrtype"/>
+  <xs:attribute name="ipv6" type="ipv6addrtype"/>
+</xs:complexType>
+
+<xs:simpleType name="ipv4addrtype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="ipv6addrtype">
+  <xs:restriction base="xs:string">
+    <!-- very rough RE -->
+    <xs:pattern value="[0-9A-Fa-f:]{3,39}(/[0-9]{1,3})?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+</xs:schema>
+
+

--- a/config/xmlschema/service.xsd
+++ b/config/xmlschema/service.xsd
@@ -7,11 +7,13 @@ elementFormDefault="qualified">
     <xs:sequence>
       <xs:element name="short" type="xs:string" minOccurs="0"/>
       <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="include" type="includetype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="source-port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="protocol" type="prototype" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="module" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="destination" type="desttype" minOccurs="0"/>
+      <xs:element name="module" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="helper" type="helpertype" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="version" type="xs:string"/>
   </xs:complexType>
@@ -53,6 +55,14 @@ elementFormDefault="qualified">
     <xs:pattern value="[0-9A-Fa-f:]{3,39}(/[0-9]{1,3})?"/>
   </xs:restriction>
 </xs:simpleType>
+
+<xs:complexType name="includetype">
+  <xs:attribute name="service" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="helpertype">
+  <xs:attribute name="name" type="xs:string" use="required"/>
+</xs:complexType>
 
 </xs:schema>
 

--- a/config/xmlschema/zone.xsd
+++ b/config/xmlschema/zone.xsd
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+elementFormDefault="qualified">
+
+<xs:element name="zone">
+  <xs:complexType>
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="short" type="xs:string" minOccurs="0"/>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="interface" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="source" type="sourceaddresstype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="service" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="source-port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="icmp-block" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="icmp-block-inversion" type="emptytype" minOccurs="0"/>
+      <xs:element name="masquerade" type="emptytype" minOccurs="0"/>
+      <xs:element name="forward-port" type="fwporttype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="rule" type="ruletype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:choice>
+    <xs:attribute name="version" type="xs:string"/>
+    <xs:attribute name="target" type="zonetargettype"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:complexType name="nametype">
+  <xs:attribute name="name" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="sourceaddresstype">
+  <xs:attribute name="ipset" type="xs:string"/>
+  <xs:attribute name="address" type="ipaddrtype"/>
+</xs:complexType>
+
+<xs:simpleType name="familyrestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="ipv4|ipv6"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="porttype">
+  <xs:attribute name="port" type="porttyperestrict" use="required"/>
+  <xs:attribute name="protocol" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:simpleType name="porttyperestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="([0-9]+(\-[0-9]+)?)?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="fwporttype">
+  <xs:attribute name="port" type="porttyperestrict" use="required"/>
+  <xs:attribute name="protocol" type="xs:string" use="required"/>
+  <xs:attribute name="to-port" type="porttyperestrict"/>
+  <xs:attribute name="to-addr" type="ipaddrtype"/>
+</xs:complexType>
+
+<xs:simpleType name="ipaddrtype">
+  <xs:restriction base="xs:string">
+    <!-- IPv4 or IPv6 address (very rough) -->
+    <xs:pattern value="([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?|[0-9A-Fa-f:]{3,39}(/[0-9]{1,3})?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="zonetargettype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="ACCEPT|DROP|%%REJECT%%"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="emptytype">
+</xs:complexType>
+
+<xs:complexType name="ruletype">
+  <xs:choice maxOccurs="unbounded">
+    <xs:element name="source" type="sourcetype" minOccurs="0"/>
+    <xs:element name="destination" type="destinationtype" minOccurs="0"/>
+    <xs:choice>
+      <xs:element name="protocol" type="protocoltype"/>
+      <xs:element name="service" type="nametype"/>
+      <xs:element name="port" type="porttype"/>
+      <xs:element name="source-port" type="porttype"/>
+      <xs:element name="icmp-block" type="nametype"/>
+      <xs:element name="icmp-block-inversion" type="emptytype"/>
+      <xs:element name="masquerade" type="emptytype"/>
+      <xs:element name="forward-port" type="fwporttype"/>
+    </xs:choice>
+    <xs:element name="log" type="logtype" minOccurs="0"/>
+    <xs:element name="audit" type="targettype" minOccurs="0"/>
+    <xs:choice>
+      <xs:element name="accept" type="targettype"/>
+      <xs:element name="drop" type="targettype"/>
+      <xs:element name="reject" type="rejecttype"/>
+      <xs:sequence></xs:sequence>
+    </xs:choice>
+  </xs:choice>
+  <xs:attribute name="family" type="familyrestrict"/>
+</xs:complexType>
+
+<xs:complexType name="sourcetype">
+  <xs:attribute name="ipset" type="xs:string"/>
+  <xs:attribute name="address" type="ipaddrtype"/>
+  <xs:attribute name="invert" type="booltype"/>
+</xs:complexType>
+
+<xs:complexType name="destinationtype">
+  <xs:attribute name="address" type="ipaddrtype" use="required"/>
+  <xs:attribute name="invert" type="booltype"/>
+</xs:complexType>
+
+<xs:simpleType name="booltype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[Yy]es|[Nn]o|[Tt]rue|[Ff]alse"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="protocoltype">
+  <xs:attribute name="value" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="logtype">
+  <xs:sequence>
+    <xs:element name="limit" type="limittype" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute name="prefix" type="xs:string"/>
+  <xs:attribute name="level" type="logtypelevelrestrict"/>
+</xs:complexType>
+
+<xs:simpleType name="logtypelevelrestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="emerg|alert|crit|error|warning|notice|info|debug"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="audittyperestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="ACCEPT|DROP|REJECT"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="targettype">
+  <xs:sequence>
+    <xs:element name="limit" type="limittype" minOccurs="0"/>
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="limittype">
+  <xs:attribute name="value" type="limitvaluerestrict" use="required"/>
+</xs:complexType>
+
+<xs:simpleType name="limitvaluerestrict">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[0-9]+/[a-z]+"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:complexType name="rejecttype">
+  <xs:sequence>
+    <xs:element name="limit" type="limittype" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute name="type" type="xs:string"/>
+</xs:complexType>
+
+</xs:schema>
+
+

--- a/config/xmlschema/zone.xsd
+++ b/config/xmlschema/zone.xsd
@@ -9,12 +9,14 @@ elementFormDefault="qualified">
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:element name="interface" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="source" type="sourceaddresstype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="protocol" type="valuetype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="service" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="source-port" type="porttype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="icmp-block" type="nametype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="icmp-block-inversion" type="emptytype" minOccurs="0"/>
       <xs:element name="masquerade" type="emptytype" minOccurs="0"/>
+      <xs:element name="forward" type="emptytype" minOccurs="0"/>
       <xs:element name="forward-port" type="fwporttype" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="rule" type="ruletype" minOccurs="0" maxOccurs="unbounded"/>
     </xs:choice>
@@ -25,6 +27,10 @@ elementFormDefault="qualified">
 
 <xs:complexType name="nametype">
   <xs:attribute name="name" type="xs:string" use="required"/>
+</xs:complexType>
+
+<xs:complexType name="valuetype">
+  <xs:attribute name="value" type="xs:string" use="required"/>
 </xs:complexType>
 
 <xs:complexType name="sourceaddresstype">
@@ -46,6 +52,12 @@ elementFormDefault="qualified">
 <xs:simpleType name="porttyperestrict">
   <xs:restriction base="xs:string">
     <xs:pattern value="([0-9]+(\-[0-9]+)?)?"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="prioritytype">
+  <xs:restriction base="xs:string">
+    <xs:pattern value="[0-9]+"/>
   </xs:restriction>
 </xs:simpleType>
 
@@ -96,6 +108,7 @@ elementFormDefault="qualified">
     </xs:choice>
   </xs:choice>
   <xs:attribute name="family" type="familyrestrict"/>
+  <xs:attribute name="priority" type="prioritytype"/>
 </xs:complexType>
 
 <xs:complexType name="sourcetype">

--- a/firewalld.spec
+++ b/firewalld.spec
@@ -163,6 +163,8 @@ fi
 %{_prefix}/lib/firewalld/services/*.xml
 %{_prefix}/lib/firewalld/zones/*.xml
 %{_prefix}/lib/firewalld/helpers/*.xml
+%{_prefix}/lib/firewalld/xmlschema/check.sh
+%{_prefix}/lib/firewalld/xmlschema/*.xsd
 %attr(0750,root,root) %dir %{_sysconfdir}/firewalld
 %config(noreplace) %{_sysconfdir}/firewalld/firewalld.conf
 %config(noreplace) %{_sysconfdir}/firewalld/lockdown-whitelist.xml
@@ -216,6 +218,7 @@ fi
 %dir %{_prefix}/lib/firewalld/policies
 %dir %{_prefix}/lib/firewalld/services
 %dir %{_prefix}/lib/firewalld/zones
+%dir %{_prefix}/lib/firewalld/xmlschema
 %{_rpmconfigdir}/macros.d/macros.firewalld
 
 %files -n firewalld-test


### PR DESCRIPTION
While firewalld command line tools now have an option `--check-config`,
it's still useful to have a scheme for our XML files.
    
Revert the removal of the XSD schemas.
    
This replaces/obsoletes pull request [1], because I think we should
restore the previous schema, instead of writing a new one.
    
This reverts the removal from commit 81d3d6a7d84bc34a18ddd4ab6153f0dafb2fa17e.

[1] https://github.com/firewalld/firewalld/pull/492

Fixes: https://github.com/firewalld/firewalld/issues/488