### PR TITLE
Update Warpinator service config to include required DNS (5353/udp) rule

### DIFF
--- a/config/services/warpinator.xml
+++ b/config/services/warpinator.xml
@@ -5,4 +5,5 @@
   <port protocol="tcp" port="42000"/>
   <port protocol="udp" port="42000"/>
   <port protocol="tcp" port="42001"/>
+  <port protocol="udp" port="5353"/>
 </service>


### PR DESCRIPTION
Hi, 

According to: https://github.com/linuxmint/warpinator#secure-mode

_If you are planning to use the Flatpak version to connect to other machines using Flatpak, you need to open UDP port 5353 as well as those mentioned above._ 

This change addresses that requirement. 

Thanks,
xsub