### PR TITLE
Add submission service for SMTP over port 587

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -323,6 +323,7 @@ CONFIG_FILES = \
 	services/steam-streaming.xml \
 	services/stellaris.xml \
 	services/stronghold-crusader.xml \
+	services/submission.xml \
 	services/supertuxkart.xml \
 	services/svdrp.xml \
 	services/svn.xml \

--- a/config/services/smtp-submission.xml
+++ b/config/services/smtp-submission.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>Mail (SMTP-Submission)</short>
-  <description>SMTP-Submission allows remote users to submit mail over port 587.</description>
-  <port protocol="tcp" port="587"/>
+  <description>This service is deprecated. Please use the "submission" service.</description>
+  <include service="submission"/>
 </service>

--- a/config/services/submission.xml
+++ b/config/services/submission.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Mail Submission</short>
+  <description>Submission allows remote client users to submit mail using SMTP over port 587.</description>
+  <port protocol="tcp" port="587"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -248,6 +248,7 @@ config/services/statsrv.xml
 config/services/steam-streaming.xml
 config/services/stellaris.xml
 config/services/stronghold-crusader.xml
+config/services/submission.xml
 config/services/supertuxkart.xml
 config/services/svdrp.xml
 config/services/svn.xml


### PR DESCRIPTION
* This commit adds the correct service name for SMTP mail submission for clients/users using tcp/587 and udp/587 ports.
* It resolves the naming confusion between the service name on firewalld and the defaults on `/etc/services`:
https://access.redhat.com/articles/1761
* It adheres to the defined rules in RFC6409, which can be on: https://www.rfc-editor.org/rfc/rfc6409.html
* It aligns with the service name and port reservations listed by IANA:
https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?&page=11

This PR does not removes the misleading `smtp-submission` service name to avoid breaking already existing software that relies on the old service name.