### PR TITLE
Performance: nftables reload

### DIFF
--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -333,13 +333,9 @@ class nftables:
     def _get_rule_key(self, rule):
         for verb in ["add", "insert", "delete"]:
             if verb in rule and "rule" in rule[verb]:
-                rule_key = copy.deepcopy(rule[verb]["rule"])
-                for non_key in ["index", "handle", "position"]:
-                    if non_key in rule_key:
-                        del rule_key[non_key]
                 # str(rule_key) is insufficient because dictionary order is
                 # not stable.. so abuse the JSON library
-                rule_key = json.dumps(rule_key, sort_keys=True)
+                rule_key = json.dumps(rule[verb]["rule"], sort_keys=True)
                 return rule_key
         # Not a rule (it's a table, chain, etc)
         return None

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -348,6 +348,7 @@ class nftables:
         _valid_verbs = ["add", "insert", "delete", "flush", "replace"]
         _valid_add_verbs = ["add", "insert", "replace"]
         _deduplicated_rules = []
+        _deduplicated_rules_keys = []
         _executed_rules = []
         rich_rule_priority_counts = copy.deepcopy(self.rich_rule_priority_counts)
         policy_dispatch_index_cache = copy.deepcopy(self.policy_dispatch_index_cache)
@@ -407,8 +408,9 @@ class nftables:
                 )
 
             _deduplicated_rules.append(rule)
+            _deduplicated_rules_keys.append(rule_key)
 
-            _rule = copy.deepcopy(rule)
+            _rule = rule
             if rule_key:
                 # filter empty rule expressions. Rich rules add quite a bit of
                 # them, but it makes the rest of the code simpler. libnftables
@@ -464,8 +466,8 @@ class nftables:
 
         index = 0
         for rule in _deduplicated_rules:
+            rule_key = _deduplicated_rules_keys[index]
             index += 1  # +1 due to metainfo
-            rule_key = self._get_rule_key(rule)
 
             if not rule_key:
                 continue

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -410,38 +410,37 @@ class nftables:
             _deduplicated_rules.append(rule)
             _deduplicated_rules_keys.append(rule_key)
 
-            _rule = rule
             if rule_key:
                 # filter empty rule expressions. Rich rules add quite a bit of
                 # them, but it makes the rest of the code simpler. libnftables
                 # does not tolerate them.
-                _rule[verb]["rule"]["expr"] = list(
-                    filter(None, _rule[verb]["rule"]["expr"])
+                rule[verb]["rule"]["expr"] = list(
+                    filter(None, rule[verb]["rule"]["expr"])
                 )
 
                 if self._fw._nftables_counters:
                     # -1 inserts just before the verdict
-                    _rule[verb]["rule"]["expr"].insert(-1, {"counter": None})
+                    rule[verb]["rule"]["expr"].insert(-1, {"counter": None})
 
                 self._set_rule_replace_priority(
-                    _rule, rich_rule_priority_counts, "%%RICH_RULE_PRIORITY%%"
+                    rule, rich_rule_priority_counts, "%%RICH_RULE_PRIORITY%%"
                 )
-                self._set_rule_sort_policy_dispatch(_rule, policy_dispatch_index_cache)
+                self._set_rule_sort_policy_dispatch(rule, policy_dispatch_index_cache)
 
                 # delete using rule handle
                 if verb == "delete":
-                    _rule = {
+                    rule = {
                         "delete": {
                             "rule": {
-                                "family": _rule["delete"]["rule"]["family"],
-                                "table": _rule["delete"]["rule"]["table"],
-                                "chain": _rule["delete"]["rule"]["chain"],
+                                "family": rule["delete"]["rule"]["family"],
+                                "table": rule["delete"]["rule"]["table"],
+                                "chain": rule["delete"]["rule"]["chain"],
                                 "handle": self.rule_to_handle[rule_key],
                             }
                         }
                     }
 
-            _executed_rules.append(_rule)
+            _executed_rules.append(rule)
 
         json_blob = {
             "nftables": [{"metainfo": {"json_schema_version": 1}}] + _executed_rules


### PR DESCRIPTION
Preface: I'm not a Python expert, so I'm hoping you can test to make sure my suggestions are not breaking something. My tests produced identical JSON output, but my tests are not exhaustive.

### Speed up set_rules() using marshal
This one instance of deepcopy() uses 85% of the processing time and deepcopy() is about 15 times slows than marshal in my tests.

### Other potential speedups
Switch `_deduplicated_rules` from a list to a dict and use the rule_key as the key. Avoids another call to `_get_rule_key()` and avoids duplicating rules.
```diff
-        for rule in _deduplicated_rules:
+        for rule_key in _deduplicated_rules:
             index += 1  # +1 due to metainfo
-            rule_key = self._get_rule_key(rule)
+            rule = _deduplicated_rules[rule_key]
```

Pre-calculate ipset information and pass it through build_set_add_rules()
```diff
-    def _set_entry_fragment(self, name, entry):
+    def _set_entry_fragment(self, obj, type_format, entry):
         # convert something like
         #    1.2.3.4,sctp:8080 (type hash:ip,port)
         # to
         #    ["1.2.3.4", "sctp", "8080"]
-        obj = self._fw.ipset.get_ipset(name)
-        type_format = obj.type.split(":")[1].split(",")
         entry_tokens = entry.split(",")
         if len(type_format) != len(entry_tokens):
```
```diff
+        ipset = self._fw.ipset.get_ipset(set_name)
+        type_format = obj.type.split(":")[1].split(",")
+
         # avoid large memory usage by chunking the entries
         chunk = 0
         for entry in entries:
-            rules.extend(self.build_set_add_rules(set_name, entry))
+            rules.extend(self.build_set_add_rules(ipset, type_format, entry))
```

Move the marshal/deepcopy outside of the rules loop (I'm not as confident about this one, because I don't fully understand the need for a deepcopy in the first place if we're not reusing the objects)
```diff
-        for rule in rules:
+        _rules = marshal.loads(marshal.dumps(rules))
+        for _rule in _rules:
```

If you would like any of these additional changes added to this pull request, please let me know or feel free to add the edits directly to my branch.