### PR TITLE
improvement(build): add ".git-blame-ignore-revs" file for "blame.ignoreRevsFile" git config

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# List of commits that did automated reformatting. You may want to ignore them
+# during git-blame with `--ignore-rev` or `--ignore-revs-file`.
+#
+#   $ git config --add 'blame.ignoreRevsFile' '.git-blame-ignore-revs'
+#
+871a752de8578574ef8be86f32cfc1c9d6abb130


### PR DESCRIPTION
If you want to use git-blame and are bothered by the large diff due to the reformatting with python-black, consider ignoring the reformatting commit by using ".git-blame-ignore-revs" file.

---

this is a follow-up to the reformatting with python black.

The `.git-blame-ignore-revs` file contains a comment that explains how to use it (or its purpose).