### PR TITLE
[th/python-inval-escape-seq] fix(firewall-config): fix invalid escape sequence in Python source for regex

### DIFF
--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1873,7 +1873,7 @@ class FirewallConfig:
                 if desc:
                     import re
 
-                    desc = re.sub("\s+", " ", desc)
+                    desc = re.sub(r"\s+", " ", desc)
 
         self.zoneStore.append([zone, weight, desc])
 


### PR DESCRIPTION
```
  $ flake8
  <unknown>:1876: SyntaxWarning: invalid escape sequence '\s'
  ./src/firewall-config.in:1876:36: W605 invalid escape sequence '\s'
```

Fixes: d81485cdf4c1 ('improvement(firewall-config): show zone description as tooltip')