### PR TITLE
[th/reformat-black23] style: reformat with black 23.7.0-2.fc39

### DIFF
--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -2482,7 +2482,7 @@ if a.permanent:
                 cmd.print_msg(joinArgs(rule))
             sys.exit(0)
         elif a.get_all_passthroughs:
-            for (ipv, rule) in direct.getAllPassthroughs():
+            for ipv, rule in direct.getAllPassthroughs():
                 cmd.print_msg("%s %s" % (ipv, joinArgs(rule)))
             sys.exit(0)
 
@@ -2510,7 +2510,7 @@ if a.permanent:
             sys.exit(0)
         elif a.get_all_chains:
             chains = direct.getAllChains()
-            for (ipv, table, chain) in chains:
+            for ipv, table, chain in chains:
                 cmd.print_msg("%s %s %s" % (ipv, table, chain))
             sys.exit(0)
         elif a.add_rule:
@@ -2582,12 +2582,12 @@ if a.permanent:
             rules = direct.getRules(
                 cmd.check_ipv(a.get_rules[0]), a.get_rules[1], a.get_rules[2]
             )
-            for (priority, rule) in rules:
+            for priority, rule in rules:
                 cmd.print_msg("%d %s" % (priority, joinArgs(rule)))
             sys.exit(0)
         elif a.get_all_rules:
             rules = direct.getAllRules()
-            for (ipv, table, chain, priority, rule) in rules:
+            for ipv, table, chain, priority, rule in rules:
                 cmd.print_msg(
                     "%s %s %s %d %s" % (ipv, table, chain, priority, joinArgs(rule))
                 )
@@ -3339,7 +3339,7 @@ elif a.direct:
             cmd.print_msg(joinArgs(rule))
         sys.exit(0)
     elif a.get_all_passthroughs:
-        for (ipv, rule) in fw.getAllPassthroughs():
+        for ipv, rule in fw.getAllPassthroughs():
             cmd.print_msg("%s %s" % (ipv, joinArgs(rule)))
         sys.exit(0)
     elif a.add_chain:
@@ -3360,7 +3360,7 @@ elif a.direct:
         )
     elif a.get_all_chains:
         chains = fw.getAllChains()
-        for (ipv, table, chain) in chains:
+        for ipv, table, chain in chains:
             cmd.print_msg("%s %s %s" % (ipv, table, chain))
         sys.exit(0)
     elif a.add_rule:
@@ -3431,12 +3431,12 @@ elif a.direct:
         rules = fw.getRules(
             cmd.check_ipv(a.get_rules[0]), a.get_rules[1], a.get_rules[2]
         )
-        for (priority, rule) in rules:
+        for priority, rule in rules:
             cmd.print_msg("%d %s" % (priority, joinArgs(rule)))
         sys.exit(0)
     elif a.get_all_rules:
         rules = fw.getAllRules()
-        for (ipv, table, chain, priority, rule) in rules:
+        for ipv, table, chain, priority, rule in rules:
             cmd.print_msg(
                 "%s %s %s %d %s" % (ipv, table, chain, priority, joinArgs(rule))
             )

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -5273,7 +5273,6 @@ class FirewallConfig:
             if not self.fw.queryForwardPort(
                 selected_zone, port, proto, to_port, to_addr
             ):
-
                 self.fw.addForwardPort(selected_zone, port, proto, to_port, to_addr)
                 if not add:
                     self.fw.removeForwardPort(
@@ -7364,11 +7363,11 @@ class FirewallConfig:
 
         for x in chains:
             self.directChainStore.append(x)
-        for (ipv, table, chain, priority, args) in rules:
+        for ipv, table, chain, priority, args in rules:
             self.directRuleStore.append(
                 (ipv, table, chain, priority, functions.joinArgs(args))
             )
-        for (ipv, args) in passthroughs:
+        for ipv, args in passthroughs:
             self.directPassthroughStore.append((ipv, functions.joinArgs(args)))
 
     def load_lockdown_whitelist(self):

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -36,6 +36,7 @@ from firewall.core.io.icmptype import icmptype_reader
 from firewall.core.io.helper import helper_reader
 from firewall.command import FirewallCommand
 
+
 # check for root user
 def assert_root():
     if os.getuid() != 0:
@@ -2690,7 +2691,7 @@ try:
             sys.exit(0)
         elif a.get_all_chains:
             chains = obj.get_all_chains()
-            for (ipv, table) in chains:
+            for ipv, table in chains:
                 for chain in chains[(ipv, table)]:
                     cmd.print_msg("%s %s %s" % (ipv, table, chain))
             sys.exit(0)
@@ -2764,13 +2765,13 @@ try:
             rules = obj.get_rules(
                 cmd.check_ipv(a.get_rules[0]), a.get_rules[1], a.get_rules[2]
             )
-            for (priority, rule) in rules:
+            for priority, rule in rules:
                 cmd.print_msg("%d %s" % (priority, joinArgs(rule)))
             sys.exit(0)
         elif a.get_all_rules:
             rules = obj.get_all_rules()
-            for (ipv, table, chain) in rules:
-                for (priority, rule) in rules[(ipv, table, chain)]:
+            for ipv, table, chain in rules:
+                for priority, rule in rules[(ipv, table, chain)]:
                     cmd.print_msg(
                         "%s %s %s %d %s" % (ipv, table, chain, priority, joinArgs(rule))
                     )

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -218,7 +218,7 @@ class Firewall:
         order = ["ipsets", "helpers", "icmptypes", "services", "zones", "policies"]
         for io_obj_type in order:
             io_objs = all_io_objects[io_obj_type]
-            for (name, io_obj) in io_objs.items():
+            for name, io_obj in io_objs.items():
                 io_obj.check_config_dict(io_obj.export_config_dict(), all_io_objects)
 
     def _start_check_tables(self):
@@ -1298,7 +1298,6 @@ class Firewall:
             # add interfaces to zones again
             for zone in self.zone.get_zones():
                 if zone in _zone_interfaces:
-
                     for interface_id in _zone_interfaces[zone]:
                         self.zone.change_zone_of_interface(zone, interface_id)
 

--- a/src/firewall/core/fw_config.py
+++ b/src/firewall/core/fw_config.py
@@ -160,7 +160,7 @@ class FirewallConfig:
         order = ["ipsets", "helpers", "icmptypes", "services", "zones", "policies"]
         for io_obj_type in order:
             io_objs = all_io_objects[io_obj_type]
-            for (name, io_obj) in io_objs.items():
+            for name, io_obj in io_objs.items():
                 io_obj.check_config_dict(io_obj.export_config_dict(), all_io_objects)
 
     # access check

--- a/src/firewall/core/fw_direct.py
+++ b/src/firewall/core/fw_direct.py
@@ -107,7 +107,7 @@ class FirewallDirect:
 
         for chain_id in self._rules:
             (ipv, table, chain) = chain_id
-            for (priority, args) in self._rules[chain_id]:
+            for priority, args in self._rules[chain_id]:
                 if not self._obj.query_rule(ipv, table, chain, priority, args):
                     if chain_id not in rules:
                         rules[chain_id] = LastUpdatedOrderedDict()
@@ -143,7 +143,7 @@ class FirewallDirect:
 
         for chain_id in _rules:
             (ipv, table, chain) = chain_id
-            for (priority, args) in _rules[chain_id]:
+            for priority, args in _rules[chain_id]:
                 if not self.query_rule(ipv, table, chain, priority, args):
                     try:
                         self.add_rule(
@@ -310,7 +310,7 @@ class FirewallDirect:
         r = []
         for key in self._rules:
             (ipv, table, chain) = key
-            for (priority, args) in self._rules[key]:
+            for priority, args in self._rules[key]:
                 r.append((ipv, table, chain, priority, list(args)))
         return r
 

--- a/src/firewall/core/fw_policy.py
+++ b/src/firewall/core/fw_policy.py
@@ -125,7 +125,7 @@ class FirewallPolicy:
 
         if enable:
             # build the base chain layout of the policy
-            for (table, chain) in (
+            for table, chain in (
                 self._get_table_chains_for_policy_dispatch(policy)
                 if not obj.derived_from_zone
                 else self._get_table_chains_for_zone_dispatch(policy)
@@ -184,7 +184,7 @@ class FirewallPolicy:
                     )
 
         if not enable:
-            for (table, chain) in (
+            for table, chain in (
                 self._get_table_chains_for_policy_dispatch(policy)
                 if not obj.derived_from_zone
                 else self._get_table_chains_for_zone_dispatch(policy)
@@ -755,7 +755,7 @@ class FirewallPolicy:
             _obj.ports.remove(port_id)
 
     def query_port(self, policy, port, protocol):
-        for (_port, _protocol) in self.get_policy(policy).ports:
+        for _port, _protocol in self.get_policy(policy).ports:
             if portInPortRange(port, _port) and protocol == _protocol:
                 return True
 
@@ -963,7 +963,7 @@ class FirewallPolicy:
             _obj.source_ports.remove(port_id)
 
     def query_source_port(self, policy, port, protocol):
-        for (_port, _protocol) in self.get_policy(policy).source_ports:
+        for _port, _protocol in self.get_policy(policy).source_ports:
             if portInPortRange(port, _port) and protocol == _protocol:
                 return True
 
@@ -1366,7 +1366,7 @@ class FirewallPolicy:
         )
 
     def _register_chains(self, policy, create, tables):
-        for (table, chain) in tables:
+        for table, chain in tables:
             if create:
                 self._chains.setdefault(policy, []).append((table, chain))
             else:
@@ -1495,7 +1495,7 @@ class FirewallPolicy:
                             if len(helper.ports) < 1:
                                 modules.append(module)
                             else:
-                                for (port, proto) in helper.ports:
+                                for port, proto in helper.ports:
                                     rules = backend.build_policy_helper_ports_rules(
                                         enable,
                                         policy,
@@ -1509,7 +1509,7 @@ class FirewallPolicy:
                         transaction.add_modules(modules)
 
                     # create rules
-                    for (port, proto) in svc.ports:
+                    for port, proto in svc.ports:
                         rules = backend.build_policy_ports_rules(
                             enable, policy, proto, port, destination, rule
                         )
@@ -1522,7 +1522,7 @@ class FirewallPolicy:
                         transaction.add_rules(backend, rules)
 
                     # create rules
-                    for (port, proto) in svc.source_ports:
+                    for port, proto in svc.source_ports:
                         rules = backend.build_policy_source_ports_rules(
                             enable, policy, proto, port, destination, rule
                         )
@@ -1676,7 +1676,7 @@ class FirewallPolicy:
                 if (backend, None) not in backends_ipv:
                     backends_ipv.append((backend, None))
 
-        for (backend, destination) in backends_ipv:
+        for backend, destination in backends_ipv:
             for helper in helpers:
                 module = helper.module
                 _module_short_name = get_nf_conntrack_short_name(module)
@@ -1688,7 +1688,7 @@ class FirewallPolicy:
                 if len(helper.ports) < 1:
                     transaction.add_module(module)
                 else:
-                    for (port, proto) in helper.ports:
+                    for port, proto in helper.ports:
                         rules = backend.build_policy_helper_ports_rules(
                             enable,
                             policy,
@@ -1700,7 +1700,7 @@ class FirewallPolicy:
                         )
                         transaction.add_rules(backend, rules)
 
-            for (port, proto) in svc.ports:
+            for port, proto in svc.ports:
                 rules = backend.build_policy_ports_rules(
                     enable, policy, proto, port, destination
                 )
@@ -1712,7 +1712,7 @@ class FirewallPolicy:
                 )
                 transaction.add_rules(backend, rules)
 
-            for (port, proto) in svc.source_ports:
+            for port, proto in svc.source_ports:
                 rules = backend.build_policy_source_ports_rules(
                     enable, policy, proto, port, destination
                 )
@@ -1834,7 +1834,7 @@ class FirewallPolicy:
             if not backend.policies_supported:
                 continue
 
-            for (table, chain) in (
+            for table, chain in (
                 self._get_table_chains_for_policy_dispatch(policy)
                 if not p_obj.derived_from_zone
                 else self._get_table_chains_for_zone_dispatch(policy)

--- a/src/firewall/core/fw_transaction.py
+++ b/src/firewall/core/fw_transaction.py
@@ -107,7 +107,7 @@ class FirewallTransaction:
 
         if error:
             # call failure functions
-            for (func, args) in self.fail_funcs:
+            for func, args in self.fail_funcs:
                 try:
                     func(*args)
                 except Exception as msg:
@@ -122,11 +122,11 @@ class FirewallTransaction:
     def pre(self):
         log.debug4("%s.pre()" % type(self))
 
-        for (func, args) in self.pre_funcs:
+        for func, args in self.pre_funcs:
             func(*args)
 
     def post(self):
         log.debug4("%s.post()" % type(self))
 
-        for (func, args) in self.post_funcs:
+        for func, args in self.post_funcs:
             func(*args)

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -239,7 +239,6 @@ class FirewallZone:
         return (self.policy_name_from_zones(fromZone, toZone), _chain)
 
     def create_zone_base_by_chain(self, ipv, table, chain, use_transaction=None):
-
         # Create zone base chains if the chain is reserved for a zone
         if ipv in ["ipv4", "ipv6"]:
             x = self.policy_from_chain(chain)

--- a/src/firewall/core/io/direct.py
+++ b/src/firewall/core/io/direct.py
@@ -176,7 +176,7 @@ class Direct(IO_Object):
         print("rules")
         for key in self.rules:
             print("  (%s, %s, %s):" % (key[0], key[1], key[2]))
-            for (priority, args) in self.rules[key]:
+            for priority, args in self.rules[key]:
                 print("    (%d, ('%s'))" % (priority, "','".join(args)))
         print("passthroughs")
         for key in self.passthroughs:
@@ -399,7 +399,7 @@ class Direct(IO_Object):
         # rules
         for key in self.rules:
             (ipv, table, chain) = key
-            for (priority, args) in self.rules[key]:
+            for priority, args in self.rules[key]:
                 if len(args) < 1:
                     continue
                 handler.ignorableWhitespace("  ")

--- a/src/firewall/core/io/firewalld_conf.py
+++ b/src/firewall/core/io/firewalld_conf.py
@@ -58,7 +58,7 @@ class firewalld_conf:
 
     def __str__(self):
         s = ""
-        for (key, value) in self._config.items():
+        for key, value in self._config.items():
             if s:
                 s += "\n"
             s += "%s=%s" % (key, value)
@@ -343,7 +343,7 @@ class firewalld_conf:
 
         # write remaining key/value pairs
         if len(self._config) > 0:
-            for (key, value) in self._config.items():
+            for key, value in self._config.items():
                 if key in done:
                     continue
                 if key in [

--- a/src/firewall/core/io/ifcfg.py
+++ b/src/firewall/core/io/ifcfg.py
@@ -40,7 +40,7 @@ class ifcfg:
 
     def __str__(self):
         s = ""
-        for (key, value) in self._config.items():
+        for key, value in self._config.items():
             if s:
                 s += "\n"
             s += "%s=%s" % (key, value)
@@ -152,7 +152,7 @@ class ifcfg:
 
         # write remaining key/value pairs
         if len(self._config) > 0:
-            for (key, value) in self._config.items():
+            for key, value in self._config.items():
                 if key in done:
                     continue
                 if not empty:

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -144,7 +144,7 @@ class IO_Object:
         elif isinstance(structure, dict):
             # only one key value pair in structure
             (skey, svalue) = list(structure.items())[0]
-            for (key, value) in conf.items():
+            for key, value in conf.items():
                 if not isinstance(key, type(skey)):
                     raise FirewallError(
                         errors.INVALID_TYPE,
@@ -261,7 +261,7 @@ class IO_Object_XMLGenerator(saxutils.XMLGenerator):
     def simpleElement(self, name, attrs):
         """slightly modified startElement()"""
         self._write("<" + name)
-        for (name, value) in attrs.items():
+        for name, value in attrs.items():
             self._write(" %s=%s" % (name, saxutils.quoteattr(value)))
         self._write("/>")
 

--- a/src/firewall/core/logger.py
+++ b/src/firewall/core/logger.py
@@ -18,6 +18,7 @@ import os
 
 # ---------------------------------------------------------------------------
 
+
 # abstract class for logging targets
 class LogTarget:
     """Abstract class for logging targets."""
@@ -36,6 +37,7 @@ class LogTarget:
 
 
 # ---------------------------------------------------------------------------
+
 
 # private class for stdout
 class _StdoutLog(LogTarget):
@@ -57,6 +59,7 @@ class _StdoutLog(LogTarget):
 
 # ---------------------------------------------------------------------------
 
+
 # private class for stderr
 class _StderrLog(_StdoutLog):
     def __init__(self):
@@ -65,6 +68,7 @@ class _StderrLog(_StdoutLog):
 
 
 # ---------------------------------------------------------------------------
+
 
 # private class for syslog
 class _SyslogLog(LogTarget):
@@ -317,7 +321,7 @@ class Logger:
         for level in range(self.FATAL, self.DEBUG_MAX + 1):
             if level not in self._logging:
                 continue
-            for (dummy, target, dummy) in self._logging[level]:
+            for dummy, target, dummy in self._logging[level]:
                 target.close()
 
     def getInfoLogLevel(self, domain="*"):
@@ -541,7 +545,7 @@ class Logger:
         for level in range(_range[0], _range[1]):
             if level not in _logging:
                 continue
-            for (domain, dummy, dummy) in _logging[level]:
+            for domain, dummy, dummy in _logging[level]:
                 if domain not in _domains:
                     _domains.setdefault(level, []).append(domain)
 
@@ -615,7 +619,7 @@ class Logger:
             _logging = self._logging
 
         # do we need to log?
-        for (domain, dummy, dummy) in _logging[level]:
+        for domain, dummy, dummy in _logging[level]:
             if (
                 domain == "*"
                 or point_domain.startswith(domain)
@@ -647,7 +651,7 @@ class Logger:
                 return None
 
         # class in module
-        for (dummy, obj) in module.__dict__.items():
+        for dummy, obj in module.__dict__.items():
             if isinstance(obj, types.ClassType):
                 if hasattr(obj, code.co_name):
                     value = getattr(obj, code.co_name)
@@ -705,7 +709,7 @@ class Logger:
 
         used_targets = []
         # log to target(s)
-        for (domain, target, _format) in _logging[level]:
+        for domain, target, _format in _logging[level]:
             if target in used_targets:
                 continue
             if (

--- a/src/firewall/server/config_zone.py
+++ b/src/firewall/server/config_zone.py
@@ -534,7 +534,7 @@ class FirewallDConfigZone(DbusServiceObject):
         port = dbus_to_python(port, str)
         protocol = dbus_to_python(protocol, str)
         log.debug1("%s.queryPort('%s', '%s')", self._log_prefix, port, protocol)
-        for (_port, _protocol) in self.getSettings()[6]:
+        for _port, _protocol in self.getSettings()[6]:
             if portInPortRange(port, _port) and protocol == _protocol:
                 return True
 
@@ -672,7 +672,7 @@ class FirewallDConfigZone(DbusServiceObject):
         port = dbus_to_python(port, str)
         protocol = dbus_to_python(protocol, str)
         log.debug1("%s.querySourcePort('%s', '%s')", self._log_prefix, port, protocol)
-        for (_port, _protocol) in self.getSettings()[14]:
+        for _port, _protocol in self.getSettings()[14]:
             if portInPortRange(port, _port) and protocol == _protocol:
                 return True
 

--- a/src/firewall/server/decorators.py
+++ b/src/firewall/server/decorators.py
@@ -153,7 +153,6 @@ class dbus_polkit_require_auth:
     def __call__(self, func):
         @functools.wraps(func)
         def _impl(*args, **kwargs):
-
             if not type(self)._bus:
                 type(self)._bus = dbus.SystemBus()
 

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -2468,7 +2468,7 @@ class FirewallD(DbusServiceObject):
         chain = dbus_to_python(chain, str)
         log.debug1("direct.removeRules('%s', '%s', '%s')" % (ipv, table, chain))
         self.accessCheck(sender)
-        for (priority, args) in self.fw.direct.get_rules(ipv, table, chain):
+        for priority, args in self.fw.direct.get_rules(ipv, table, chain):
             self.fw.direct.remove_rule(ipv, table, chain, priority, args)
             self.RuleRemoved(ipv, table, chain, priority, args)
 

--- a/src/gtk3_chooserbutton.py
+++ b/src/gtk3_chooserbutton.py
@@ -127,7 +127,6 @@ class ChooserButton:
 
 class ToolChooserButton:
     def __init__(self, button, default_label=""):
-
         self.button = button
         self.default_label = default_label
 

--- a/src/tests/unit/test_dbus_utils.py
+++ b/src/tests/unit/test_dbus_utils.py
@@ -7,7 +7,6 @@ import firewall.dbus_utils
 
 
 def test_dbus_to_python():
-
     assert firewall.dbus_utils.dbus_to_python_args(
         [dbus.String("a"), dbus.String("b")], str, str
     ) == ("a", "b")


### PR DESCRIPTION
Fedora 39 is out and ships black 23.7.0-2.fc39. There were some changes in the formatting ([1]), which means that changes are introduced when using black 23.

The officially blessed black version is still black=22.12.0, which you can get via pip. This is also the version that the github action uses for checking the formatting.

The good news is, once files are reformatted with black 23, this is fine for both black 23 and black=22.12.0.

Do the reformatting, so that you can use black 23 just as well.

[1] https://black.readthedocs.io/en/stable/change_log.html#id38

---

After merge, the commit ID should also be recorded in `.git-blame-ignore-revs` file.