### PR TITLE
[th/import-export-structure] make IMPORT_EXPORT_STRUCTURE a dictionary

### DIFF
--- a/src/firewall/core/fw_config.py
+++ b/src/firewall/core/fw_config.py
@@ -629,10 +629,7 @@ class FirewallConfig:
         return obj.export_config_dict()
 
     def set_service_config(self, obj, conf):
-        conf_dict = {}
-        for i, value in enumerate(conf):
-            conf_dict[obj.IMPORT_EXPORT_STRUCTURE[i][0]] = value
-
+        conf_dict = obj.get_dict_from_tuple(conf)
         return self.set_service_config_dict(obj, conf_dict)
 
     def set_service_config_dict(self, obj, conf):
@@ -653,10 +650,9 @@ class FirewallConfig:
         if name in self._services or name in self._builtin_services:
             raise FirewallError(errors.NAME_CONFLICT, "new_service(): '%s'" % name)
 
-        conf_dict = {}
-        for i, value in enumerate(conf):
-            conf_dict[Service.IMPORT_EXPORT_STRUCTURE[i][0]] = value
-
+        conf_dict = IO_Object.get_dict_from_tuple_static(
+            Service.IMPORT_EXPORT_STRUCTURE, conf
+        )
         return self.new_service_dict(name, conf_dict)
 
     def new_service_dict(self, name, conf):
@@ -827,10 +823,7 @@ class FirewallConfig:
         return obj.export_config_dict()
 
     def set_zone_config(self, obj, conf):
-        conf_dict = {}
-        for i, value in enumerate(conf):
-            conf_dict[obj.IMPORT_EXPORT_STRUCTURE[i][0]] = value
-
+        conf_dict = obj.get_dict_from_tuple(conf)
         return self.set_zone_config_dict(obj, conf_dict)
 
     def set_zone_config_dict(self, obj, conf):
@@ -851,10 +844,9 @@ class FirewallConfig:
         if name in self._zones or name in self._builtin_zones:
             raise FirewallError(errors.NAME_CONFLICT, "new_zone(): '%s'" % name)
 
-        conf_dict = {}
-        for i, value in enumerate(conf):
-            conf_dict[Zone.IMPORT_EXPORT_STRUCTURE[i][0]] = value
-
+        conf_dict = IO_Object.get_dict_from_tuple_static(
+            Zone.IMPORT_EXPORT_STRUCTURE, conf
+        )
         return self.new_zone_dict(name, conf_dict)
 
     def new_zone_dict(self, name, conf):

--- a/src/firewall/core/fw_config.py
+++ b/src/firewall/core/fw_config.py
@@ -623,18 +623,7 @@ class FirewallConfig:
         return self._builtin_services[obj.name]
 
     def get_service_config(self, obj):
-        conf_dict = obj.export_config_dict()
-        conf_list = []
-        for i in range(8):  # tuple based dbus API has 8 elements
-            if obj.IMPORT_EXPORT_STRUCTURE[i][0] not in conf_dict:
-                # old API needs the empty elements as well. Grab it from the
-                # object otherwise we don't know the type.
-                conf_list.append(
-                    copy.deepcopy(getattr(obj, obj.IMPORT_EXPORT_STRUCTURE[i][0]))
-                )
-            else:
-                conf_list.append(conf_dict[obj.IMPORT_EXPORT_STRUCTURE[i][0]])
-        return tuple(conf_list)
+        return obj.export_config_tuple(length=8)
 
     def get_service_config_dict(self, obj):
         return obj.export_config_dict()
@@ -832,18 +821,7 @@ class FirewallConfig:
         return self._builtin_zones[obj.name]
 
     def get_zone_config(self, obj):
-        conf_dict = obj.export_config_dict()
-        conf_list = []
-        for i in range(16):  # tuple based dbus API has 16 elements
-            if obj.IMPORT_EXPORT_STRUCTURE[i][0] not in conf_dict:
-                # old API needs the empty elements as well. Grab it from the
-                # object otherwise we don't know the type.
-                conf_list.append(
-                    copy.deepcopy(getattr(obj, obj.IMPORT_EXPORT_STRUCTURE[i][0]))
-                )
-            else:
-                conf_list.append(conf_dict[obj.IMPORT_EXPORT_STRUCTURE[i][0]])
-        return tuple(conf_list)
+        return obj.export_config_tuple(length=16)
 
     def get_zone_config_dict(self, obj):
         return obj.export_config_dict()

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -329,18 +329,9 @@ class FirewallZone:
         :return: exported config updated with runtime settings
         """
         obj = self.get_zone(zone)
-        conf_dict = self.get_config_with_settings_dict(zone)
-        conf_list = []
-        for i in range(16):  # tuple based API has 16 elements
-            if obj.IMPORT_EXPORT_STRUCTURE[i][0] not in conf_dict:
-                # old API needs the empty elements as well. Grab it from the
-                # class otherwise we don't know the type.
-                conf_list.append(
-                    copy.deepcopy(getattr(obj, obj.IMPORT_EXPORT_STRUCTURE[i][0]))
-                )
-            else:
-                conf_list.append(conf_dict[obj.IMPORT_EXPORT_STRUCTURE[i][0]])
-        return tuple(conf_list)
+        return obj.export_config_tuple(
+            conf_dict=self.get_config_with_settings_dict(zone), length=16
+        )
 
     def get_config_with_settings_dict(self, zone):
         """

--- a/src/firewall/core/io/direct.py
+++ b/src/firewall/core/io/direct.py
@@ -103,14 +103,14 @@ class direct_ContentHandler(IO_Object_ContentHandler):
 class Direct(IO_Object):
     """Direct class"""
 
-    IMPORT_EXPORT_STRUCTURE = (
+    IMPORT_EXPORT_STRUCTURE = {
         # chain: [ ipv, table, [ chain ] ]
-        ("chains", [("", "", "")]),  # a(sss)
+        "chains": [("", "", "")],  # a(sss)
         # rule: [ ipv, table, chain, [ priority, [ arg ] ] ]
-        ("rules", [("", "", "", 0, [""])]),  # a(sssias)
+        "rules": [("", "", "", 0, [""])],  # a(sssias)
         # passthrough: [ ipv, [ [ arg ] ] ]
-        ("passthroughs", [("", [""])]),  # a(sas)
-    )
+        "passthroughs": [("", [""])],  # a(sas)
+    }
     DBUS_SIGNATURE = "(a(sss)a(sssias)a(sas))"
     PARSER_REQUIRED_ELEMENT_ATTRS = {
         "direct": None,
@@ -153,14 +153,14 @@ class Direct(IO_Object):
     def import_config(self, conf, all_io_objects):
         self.cleanup()
         self.check_config(conf)
-        for i, (element, dummy) in enumerate(self.IMPORT_EXPORT_STRUCTURE):
+        for i, element in enumerate(self.IMPORT_EXPORT_STRUCTURE):
             if element == "chains":
                 for x in conf[i]:
                     self.add_chain(*x)
-            if element == "rules":
+            elif element == "rules":
                 for x in conf[i]:
                     self.add_rule(*x)
-            if element == "passthroughs":
+            elif element == "passthroughs":
                 for x in conf[i]:
                     self.add_passthrough(*x)
 

--- a/src/firewall/core/io/helper.py
+++ b/src/firewall/core/io/helper.py
@@ -24,14 +24,14 @@ from firewall.errors import FirewallError
 
 
 class Helper(IO_Object):
-    IMPORT_EXPORT_STRUCTURE = (
-        ("version", ""),  # s
-        ("short", ""),  # s
-        ("description", ""),  # s
-        ("family", ""),  # s
-        ("module", ""),  # s
-        ("ports", [("", "")]),  # a(ss)
-    )
+    IMPORT_EXPORT_STRUCTURE = {
+        "version": "",  # s
+        "short": "",  # s
+        "description": "",  # s
+        "family": "",  # s
+        "module": "",  # s
+        "ports": [("", "")],  # a(ss)
+    }
     DBUS_SIGNATURE = "(sssssa(ss))"
     ADDITIONAL_ALNUM_CHARS = ["-", "."]
     PARSER_REQUIRED_ELEMENT_ATTRS = {

--- a/src/firewall/core/io/icmptype.py
+++ b/src/firewall/core/io/icmptype.py
@@ -22,12 +22,12 @@ from firewall.errors import FirewallError
 
 
 class IcmpType(IO_Object):
-    IMPORT_EXPORT_STRUCTURE = (
-        ("version", ""),  # s
-        ("short", ""),  # s
-        ("description", ""),  # s
-        ("destination", [""]),  # as
-    )
+    IMPORT_EXPORT_STRUCTURE = {
+        "version": "",  # s
+        "short": "",  # s
+        "description": "",  # s
+        "destination": [""],  # as
+    }
     DBUS_SIGNATURE = "(sssas)"
     ADDITIONAL_ALNUM_CHARS = ["_", "-"]
     PARSER_REQUIRED_ELEMENT_ATTRS = {

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -51,6 +51,24 @@ class IO_Object:
                 conf[key] = copy.deepcopy(getattr(self, key))
         return conf
 
+    def export_config_tuple(self, conf_dict=None, length=None):
+        if conf_dict is None:
+            conf_dict = self.export_config_dict()
+
+        if length is None:
+            length = len(self.IMPORT_EXPORT_STRUCTURE)
+
+        conf_list = []
+        for i in range(length):
+            key = self.IMPORT_EXPORT_STRUCTURE[i][0]
+            if key not in conf_dict:
+                # old API needs the empty elements as well. Grab it from the
+                # object otherwise we don't know the type.
+                conf_list.append(copy.deepcopy(getattr(self, key)))
+            else:
+                conf_list.append(conf_dict[key])
+        return tuple(conf_list)
+
     def import_config(self, conf, all_io_objects):
         self.check_config(conf, all_io_objects)
         for i, (element, dummy) in enumerate(self.IMPORT_EXPORT_STRUCTURE):

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -39,6 +39,16 @@ class IO_Object:
             ret.append(copy.deepcopy(getattr(self, x[0])))
         return tuple(ret)
 
+    @staticmethod
+    def get_dict_from_tuple_static(IMPORT_EXPORT_STRUCTURE, conf):
+        conf_dict = {}
+        for i, value in enumerate(conf):
+            conf_dict[IMPORT_EXPORT_STRUCTURE[i][0]] = value
+        return conf_dict
+
+    def get_dict_from_tuple(obj, conf):
+        return IO_Object.get_dict_from_tuple_static(obj.IMPORT_EXPORT_STRUCTURE, conf)
+
     def export_config_dict(self):
         conf = {}
         type_formats = dict([(x[0], x[1]) for x in self.IMPORT_EXPORT_STRUCTURE])

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -41,14 +41,14 @@ from firewall.errors import FirewallError
 
 
 class IPSet(IO_Object):
-    IMPORT_EXPORT_STRUCTURE = (
-        ("version", ""),  # s
-        ("short", ""),  # s
-        ("description", ""),  # s
-        ("type", ""),  # s
-        ("options", {"": ""}),  # a{ss}
-        ("entries", [""]),  # as
-    )
+    IMPORT_EXPORT_STRUCTURE = {
+        "version": "",  # s
+        "short": "",  # s
+        "description": "",  # s
+        "type": "",  # s
+        "options": {"": ""},  # a{ss}
+        "entries": [""],  # as
+    }
     DBUS_SIGNATURE = "(ssssa{ss}as)"
     ADDITIONAL_ALNUM_CHARS = ["_", "-", ":", "."]
     PARSER_REQUIRED_ELEMENT_ATTRS = {

--- a/src/firewall/core/io/lockdown_whitelist.py
+++ b/src/firewall/core/io/lockdown_whitelist.py
@@ -74,12 +74,12 @@ class lockdown_whitelist_ContentHandler(IO_Object_ContentHandler):
 class LockdownWhitelist(IO_Object):
     """LockdownWhitelist class"""
 
-    IMPORT_EXPORT_STRUCTURE = (
-        ("commands", [""]),  # as
-        ("contexts", [""]),  # as
-        ("users", [""]),  # as
-        ("uids", [0]),  # ai
-    )
+    IMPORT_EXPORT_STRUCTURE = {
+        "commands": [""],  # as
+        "contexts": [""],  # as
+        "users": [""],  # as
+        "uids": [0],  # ai
+    }
     DBUS_SIGNATURE = "(asasasai)"
     ADDITIONAL_ALNUM_CHARS = ["_"]
     PARSER_REQUIRED_ELEMENT_ATTRS = {

--- a/src/firewall/core/io/policy.py
+++ b/src/firewall/core/io/policy.py
@@ -828,23 +828,23 @@ class Policy(IO_Object):
     priority_default = DEFAULT_POLICY_PRIORITY
     priority_reserved = [0]
 
-    IMPORT_EXPORT_STRUCTURE = (
-        ("version", ""),  # s
-        ("short", ""),  # s
-        ("description", ""),  # s
-        ("target", ""),  # s
-        ("services", [""]),  # as
-        ("ports", [("", "")]),  # a(ss)
-        ("icmp_blocks", [""]),  # as
-        ("masquerade", False),  # b
-        ("forward_ports", [("", "", "", "")]),  # a(ssss)
-        ("rich_rules", [""]),  # as
-        ("protocols", [""]),  # as
-        ("source_ports", [("", "")]),  # a(ss)
-        ("priority", 0),  # i
-        ("ingress_zones", [""]),  # as
-        ("egress_zones", [""]),  # as
-    )
+    IMPORT_EXPORT_STRUCTURE = {
+        "version": "",  # s
+        "short": "",  # s
+        "description": "",  # s
+        "target": "",  # s
+        "services": [""],  # as
+        "ports": [("", "")],  # a(ss)
+        "icmp_blocks": [""],  # as
+        "masquerade": False,  # b
+        "forward_ports": [("", "", "", "")],  # a(ssss)
+        "rich_rules": [""],  # as
+        "protocols": [""],  # as
+        "source_ports": [("", "")],  # a(ss)
+        "priority": 0,  # i
+        "ingress_zones": [""],  # as
+        "egress_zones": [""],  # as
+    }
     ADDITIONAL_ALNUM_CHARS = ["_", "-", "/"]
     PARSER_REQUIRED_ELEMENT_ATTRS = {
         "short": None,

--- a/src/firewall/core/io/service.py
+++ b/src/firewall/core/io/service.py
@@ -26,18 +26,18 @@ from firewall.errors import FirewallError
 
 
 class Service(IO_Object):
-    IMPORT_EXPORT_STRUCTURE = (
-        ("version", ""),
-        ("short", ""),
-        ("description", ""),
-        ("ports", [("", "")]),
-        ("modules", [""]),
-        ("destination", {"": ""}),
-        ("protocols", [""]),
-        ("source_ports", [("", "")]),
-        ("includes", [""]),
-        ("helpers", [""]),
-    )
+    IMPORT_EXPORT_STRUCTURE = {
+        "version": "",
+        "short": "",
+        "description": "",
+        "ports": [("", "")],
+        "modules": [""],
+        "destination": {"": ""},
+        "protocols": [""],
+        "source_ports": [("", "")],
+        "includes": [""],
+        "helpers": [""],
+    }
     ADDITIONAL_ALNUM_CHARS = ["_", "-"]
     PARSER_REQUIRED_ELEMENT_ATTRS = {
         "short": None,

--- a/src/firewall/core/io/zone.py
+++ b/src/firewall/core/io/zone.py
@@ -44,27 +44,27 @@ class Zone(IO_Object):
     priority_max = 32767
     priority_default = DEFAULT_ZONE_PRIORITY
 
-    IMPORT_EXPORT_STRUCTURE = (
-        ("version", ""),  # s
-        ("short", ""),  # s
-        ("description", ""),  # s
-        ("UNUSED", False),  # b
-        ("target", ""),  # s
-        ("services", [""]),  # as
-        ("ports", [("", "")]),  # a(ss)
-        ("icmp_blocks", [""]),  # as
-        ("masquerade", False),  # b
-        ("forward_ports", [("", "", "", "")]),  # a(ssss)
-        ("interfaces", [""]),  # as
-        ("sources", [""]),  # as
-        ("rules_str", [""]),  # as
-        ("protocols", [""]),  # as
-        ("source_ports", [("", "")]),  # a(ss)
-        ("icmp_block_inversion", False),  # b
-        ("forward", True),  # b
-        ("ingress_priority", 0),  # i
-        ("egress_priority", 0),  # i
-    )
+    IMPORT_EXPORT_STRUCTURE = {
+        "version": "",  # s
+        "short": "",  # s
+        "description": "",  # s
+        "UNUSED": False,  # b
+        "target": "",  # s
+        "services": [""],  # as
+        "ports": [("", "")],  # a(ss)
+        "icmp_blocks": [""],  # as
+        "masquerade": False,  # b
+        "forward_ports": [("", "", "", "")],  # a(ssss)
+        "interfaces": [""],  # as
+        "sources": [""],  # as
+        "rules_str": [""],  # as
+        "protocols": [""],  # as
+        "source_ports": [("", "")],  # a(ss)
+        "icmp_block_inversion": False,  # b
+        "forward": True,  # b
+        "ingress_priority": 0,  # i
+        "egress_priority": 0,  # i
+    }
     ADDITIONAL_ALNUM_CHARS = ["_", "-", "/"]
     PARSER_REQUIRED_ELEMENT_ATTRS = {
         "short": None,
@@ -114,7 +114,7 @@ class Zone(IO_Object):
 
     @staticmethod
     def index_of(element):
-        for i, (el, dummy) in enumerate(Zone.IMPORT_EXPORT_STRUCTURE):
+        for i, el in enumerate(Zone.IMPORT_EXPORT_STRUCTURE):
             if el == element:
                 return i
         raise FirewallError(errors.UNKNOWN_ERROR, "index_of()")

--- a/src/firewall/errors.py
+++ b/src/firewall/errors.py
@@ -135,3 +135,15 @@ FirewallError.errors = {
 FirewallError.codes = {
     FirewallError.errors[code]: code for code in FirewallError.errors
 }
+
+###############################################################################
+
+
+class BugError(Exception):
+    """Indicates that there is a bug in the code. You probably don't
+    want to catch this, but fix the bug."""
+
+    def __init__(self, msg=None):
+        if msg is None:
+            msg = "should not be reached"
+        super().__init__(f"BUG: {msg}")

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -1050,18 +1050,7 @@ class FirewallD(DbusServiceObject):
         service = dbus_to_python(service, str)
         log.debug1("getServiceSettings(%s)", service)
         obj = self.fw.service.get_service(service)
-        conf_dict = obj.export_config_dict()
-        conf_list = []
-        for i in range(8):  # tuple based dbus API has 8 elements
-            if obj.IMPORT_EXPORT_STRUCTURE[i][0] not in conf_dict:
-                # old API needs the empty elements as well. Grab it from the
-                # object otherwise we don't know the type.
-                conf_list.append(
-                    copy.deepcopy(getattr(obj, obj.IMPORT_EXPORT_STRUCTURE[i][0]))
-                )
-            else:
-                conf_list.append(conf_dict[obj.IMPORT_EXPORT_STRUCTURE[i][0]])
-        return tuple(conf_list)
+        return obj.export_config_tuple(length=8)
 
     @dbus_polkit_require_auth(config.dbus.PK_ACTION_CONFIG_INFO)
     @dbus_service_method(


### PR DESCRIPTION
`IMPORT_EXPORT_STRUCTURE` is a tuple of (string,variant)-tuples.

Most callers are interested in the keys, and want to lookup. The tuple is cumbersome to use. Use a dictionary instead.

In the past, a dictionary was not suitable, because it did not preserver order. We require pyton 3.7, where dictionaries preserve order (and are iterated in the order of insertion).