### PR TITLE
[th/rich-rule-check-service] fix(rich): validate service name of rich rule

### DIFF
--- a/src/firewall/core/io/policy.py
+++ b/src/firewall/core/io/policy.py
@@ -570,6 +570,14 @@ def common_check_config(obj, config, item, all_config, all_io_objects):
                             log.debug1("{} (unsupported)".format(ex))
                         else:
                             raise ex
+            elif isinstance(obj_rich.element, rich.Rich_Service):
+                if obj_rich.element.name not in all_io_objects["services"]:
+                    raise FirewallError(
+                        errors.INVALID_SERVICE,
+                        "{} '{}': '{}' not among existing services".format(
+                            obj_type, obj.name, obj_rich.element.name
+                        ),
+                    )
 
 
 def common_writer(obj, handler):

--- a/src/tests/features/rich_rules.at
+++ b/src/tests/features/rich_rules.at
@@ -46,6 +46,10 @@ FWD_CHECK([--permanent --policy foobar --add-rich-rule='rule family=ipv4 priorit
 FWD_CHECK([--permanent --policy foobar --add-rich-rule='rule family=ipv4 priority=0  source address=10.10.10.13 drop'], 0, ignore)
 FWD_CHECK([--permanent --policy foobar --add-rich-rule='rule family=ipv4 priority=-1 source address=10.10.10.14 accept'], 0, ignore)
 FWD_CHECK([--permanent --policy foobar --add-rich-rule='rule family=ipv4 priority=1  source address=10.10.10.15 accept'], 0, ignore)
+
+dnl Invalid service name is rejected.
+FWD_CHECK([--permanent --policy foobar --add-rich-rule='rule priority="-100" family="ipv4" source address="10.0.0.10" service name="bogusservice" accept'], 101, ignore, ignore)
+
 FWD_RELOAD
 NFT_LIST_RULES([inet], [filter_IN_policy_foobar_pre], 0, [dnl
     table inet firewalld {
@@ -319,4 +323,5 @@ IP6TABLES_LIST_RULES([filter], [IN_foobar_post], 0, [dnl
     ACCEPT 0 -- ::/0 ::/0
 ])
 
-FWD_END_TEST([-e '/ERROR: INVALID_ZONE:/d'])
+FWD_END_TEST([-e '/ERROR: INVALID_ZONE:/d' dnl
+              -e "/ERROR: INVALID_SERVICE: Policy 'foobar': 'bogusservice' not among existing services/d"])


### PR DESCRIPTION
Previously, validation of valid service names was not done. That meant:
```
  $ firewall-cmd --add-rich-rule='rule priority="-100" family="ipv4" source address="10.0.0.10" service name="listen" accept' --permanent
  success
  $ firewall-cmd --reload
  Error: INVALID_SERVICE: listen
```
which left firewalld in a bad state.

Now:
```
  $ firewall-cmd --add-rich-rule='rule priority="-100" family="ipv4" source address="10.0.0.10" service name="listen" accept' --permanent
  Error: INVALID_SERVICE: Zone 'public': 'listen' not among existing services
```
It's still not all golden. If you now have to happen an XML file with an unknown service on disk, on restart we get tracebacks and a degraded state.
```
  $ firewall-cmd --add-rich-rule='rule priority="-100" family="ipv4" source address="10.0.0.10" service name="listen" accept' --permanent
  Error: RUNNING_BUT_FAILED: Changing permanent configuration is not allowed while firewalld is in FAILED state. The permanent configuration must be fixed and then firewalld restarted. Try `firewall-offline-cmd --check-config`.
  $ firewall-offline-cmd --check-config
  Configuration error: INVALID_SERVICE: Zone 'public': 'listen' not among existing services
```
But that is a general problem, which probably should be handled better. For example, by not failing badly and making the best of what we have. This while possibly loosing configuration by normalizing errors away, but still exposing the configuration problem to the user. Anyway, this is not new. What is new is that this error condition now triggers the failure.

https://issues.redhat.com/browse/RHEL-5790