### PR TITLE
feat(service): add WS-Discovery host

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -357,6 +357,7 @@ CONFIG_FILES = \
 	services/wbem-https.xml \
 	services/wireguard.xml \
 	services/ws-discovery-client.xml \
+	services/ws-discovery-host.xml \
 	services/ws-discovery-tcp.xml \
 	services/ws-discovery-udp.xml \
 	services/ws-discovery.xml \

--- a/config/services/ws-discovery-host.xml
+++ b/config/services/ws-discovery-host.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>ws-discovery</short>
+  <description>Web Service Discovery Host</description>
+  <include service="ws-discovery-udp"/>
+  <port protocol="tcp" port="5357"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -282,6 +282,7 @@ config/services/wbem-https.xml
 config/services/wbem-http.xml
 config/services/wireguard.xml
 config/services/ws-discovery-client.xml
+config/services/ws-discovery-host.xml
 config/services/ws-discovery-tcp.xml
 config/services/ws-discovery-udp.xml
 config/services/ws-discovery.xml


### PR DESCRIPTION
Add a generic service definition for a WS-Discovery host implementation,
which, e.g., allows to discover Samba file sharing services via Windows.
As per https://learn.microsoft.com/en-us/windows/win32/wsdapi/additional-ws-discovery-functionality,
TCP port 5357 is used by the service and respective implementations (see
below).

The file re-uses the already existing UDP multicast service definition.

The service file is taken from openSUSE (see
https://build.opensuse.org/package/view_file/openSUSE:Leap:15.5/wsdd/wsdd.xml),
which did not validate against the firewalld serivce schema. Thus, the
include statement was moved. The original author of the openSUSE
package, suggested to upstream a generic service definition that is
agnostic to a specific implementation, like wsdd
(https://github.com/christgau/wsdd) or wsdd2
(https://github.com/Netgear/wsdd2).

See also: https://github.com/christgau/wsdd/pull/186

Co-authored-by: Herbert Graeber <herbert@graeber-clan.de>
