### PR TITLE
chore(tests): reformat "test_firewalld_conf.py" with black==23.7.0

### DIFF
--- a/src/tests/unit/test_firewalld_conf.py
+++ b/src/tests/unit/test_firewalld_conf.py
@@ -6,7 +6,6 @@ import firewall.config
 
 def test_reload_policy():
     def t(value, expected_valid=True, **kw):
-
         expected = {
             "INPUT": "DROP",
             "FORWARD": "DROP",


### PR DESCRIPTION
The officially used version of python-black is the one from the github action check, currently black==22.12.0.

On Fedora 39, we get black==23.7.0, which changes behaviors in some regard. This is a common issue, where newer/different versions of the formatter will give different results.

In this case, when we reformat the code base with black==23.7.0, then the result will also be correctly formatted according to black=22.12.0.

Do this reformatting, so that on Fedora 39 a run of black does not introduce any changes -- even if the used black version is not the officially suggested one.

This is for convenience of users of black 23.