### PR TITLE
fix(forward-port): log rich rule forwarded ports

### DIFF
--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -4126,8 +4126,6 @@ class FirewallConfig:
             elif combolabel == _("forward-port"):
                 self.richRuleDialogActionCheck.set_sensitive(False)
                 self.richRuleDialogActionBox.set_sensitive(False)
-                self.richRuleDialogLogCheck.set_sensitive(False)
-                self.richRuleDialogLogGrid.set_sensitive(False)
                 self.richRuleDialogAuditCheck.set_sensitive(False)
                 self.richRuleDialogAuditBox.set_sensitive(False)
             elif combolabel == _("icmp-block"):

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1610,33 +1610,28 @@ class ip4tables:
         if toport and toport != "":
             to += ":%s" % portStr(toport, "-")
 
+        rules = []
         rule_fragment = []
+        port_fragment = ["-p", protocol, "--dport", portStr(port)]
         if rich_rule:
             chain_suffix = self._rich_rule_chain_suffix(rich_rule)
             rule_fragment = self._rich_rule_priority_fragment(rich_rule)
             rule_fragment += self._rich_rule_destination_fragment(rich_rule.destination)
             rule_fragment += self._rich_rule_source_fragment(rich_rule.source)
+
+            rules.append(
+                self._rich_rule_log(
+                    policy, rich_rule, enable, "nat", rule_fragment + port_fragment
+                )
+            )
         else:
             chain_suffix = "allow"
 
-        rules = []
-        if rich_rule:
-            rules.append(
-                self._rich_rule_log(policy, rich_rule, enable, "nat", rule_fragment)
-            )
         rules.append(
             ["-t", "nat", add_del, "%s_%s" % (_policy, chain_suffix)]
             + rule_fragment
-            + [
-                "-p",
-                protocol,
-                "--dport",
-                portStr(port),
-                "-j",
-                "DNAT",
-                "--to-destination",
-                to,
-            ]
+            + port_fragment
+            + ["-j", "DNAT", "--to-destination", to]
         )
 
         return rules

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -2287,6 +2287,12 @@ class nftables:
             }
         )
 
+        rules = []
+        if rich_rule:
+            rules.append(
+                self._rich_rule_log(policy, rich_rule, enable, table, expr_fragments)
+            )
+
         if toaddr:
             if check_single_address("ipv6", toaddr):
                 toaddr = normalizeIP6(toaddr)
@@ -2306,7 +2312,9 @@ class nftables:
             "expr": expr_fragments,
         }
         rule.update(self._rich_rule_priority_fragment(rich_rule))
-        return [{add_del: {"rule": rule}}]
+        rules.append({add_del: {"rule": rule}})
+
+        return rules
 
     def _icmp_types_to_nft_fragments(self, ipv, icmp_type):
         if icmp_type in ICMP_TYPES_FRAGMENTS[ipv]:

--- a/src/tests/features/forward_ports.at
+++ b/src/tests/features/forward_ports.at
@@ -274,3 +274,49 @@ FWD_CHECK([            --policy foobar --remove-ingress-zone HOST], 0, [ignore])
 FWD_CHECK([            --policy foobar --remove-egress-zone localhost], 0, [ignore])
 
 FWD_END_TEST([-e '/ERROR: INVALID_FORWARD/d' -e '/ERROR: INVALID_ZONE/d'])
+
+
+FWD_START_TEST([forward ports - logging and limiting])
+AT_KEYWORDS(forward_port rich logging limit)
+
+FWD_CHECK([--add-rich-rule='rule family=ipv4 forward-port port=33 protocol=tcp to-port=33 to-addr=10.10.10.10 log prefix="forward-port: " level="info" limit value="1/m"'], 0, ignore)
+FWD_CHECK([--query-rich-rule='rule family=ipv4 forward-port port=33 protocol=tcp to-port=33 to-addr=10.10.10.10 log prefix="forward-port: " level="info" limit value="1/m"'], 0, ignore)
+IF_HOST_SUPPORTS_IPV6_RULES([
+FWD_CHECK([--add-rich-rule='rule family=ipv6 forward-port port=44 protocol=udp to-port=4444 to-addr=1234::4321 nflog prefix="forward-port: " queue-size=10 limit value="1/m"'], 0, ignore)
+FWD_CHECK([--query-rich-rule='rule family=ipv6 forward-port port=44 protocol=udp to-port=4444 to-addr=1234::4321 nflog prefix="forward-port: " queue-size=10 limit value="1/m"'], 0, ignore)
+])
+
+NFT_LIST_RULES([inet], [nat_PRE_public_log], 0, [dnl
+    table inet firewalld {
+        chain nat_PRE_public_log {
+            meta nfproto ipv4 tcp dport 33 limit rate 1/minute log prefix "forward-port: " level info
+            meta nfproto ipv6 udp dport 44 limit rate 1/minute log prefix "forward-port: " group 0 queue-threshold 10
+        }
+    }
+])
+
+NFT_LIST_RULES([inet], [nat_PRE_public_allow], 0, [dnl
+    table inet firewalld {
+        chain nat_PRE_public_allow {
+            meta nfproto ipv4 tcp dport 33 dnat ip to 10.10.10.10:33
+            meta nfproto ipv6 udp dport 44 dnat ip6 to [[1234::4321]:4444]
+        }
+    }
+])
+
+
+IPTABLES_LIST_RULES([nat], [PRE_public_log], 0, [dnl
+    LOG 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:33 limit: avg 1/min burst 5 LOG flags 0 level 6 prefix "forward-port: "
+])
+IP6TABLES_LIST_RULES([nat], [PRE_public_log], 0, [dnl
+    NFLOG 17 -- ::/0 ::/0 udp dpt:44 limit: avg 1/min burst 5 nflog-prefix "forward-port: " nflog-threshold 10
+])
+
+IPTABLES_LIST_RULES([nat], [PRE_public_allow], 0, [dnl
+    DNAT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:33 to:10.10.10.10:33
+])
+IP6TABLES_LIST_RULES([nat], [PRE_public_allow], 0, [dnl
+    DNAT 17 -- ::/0 ::/0 udp dpt:44 [to:[1234::4321]:4444]
+])
+
+FWD_END_TEST


### PR DESCRIPTION
This pull request fixes issues with logging of forwarded traffic.

- c769089: enable option in gui to log rich rule forwarded ports.
  - Note: nflog logging still not available.
- 4962d49: log just forwarded ports, not all traffic.
- e5c807f: enable logging of forwarded ports on nftables backend.
- 1adf9d7: verify logging of forwarded ports.

Closes #1263