### PR TITLE
[th/pkg-upgrade-no-restart] improvement(spec): don't restart firewalld on package upgrade

### DIFF
--- a/firewalld.spec
+++ b/firewalld.spec
@@ -116,7 +116,7 @@ desktop-file-install --delete-original \
 %systemd_preun firewalld.service
 
 %postun
-%systemd_postun_with_restart firewalld.service
+%systemd_postun firewalld.service
 
 
 %post -n firewall-applet


### PR DESCRIPTION
Restarting the firewalld daemon is not as seamless, as it maybe should be. In particular, it can reconfigure the firewall or temporarily drop important rules. That should be improved, but until restart is really seamless, it is harmful to do during package update.

The proper way install new package is offline upgrade and reboot. If the user knows better, they can upgrade packages without reboot. But then they must handle the restart of the affected packages, in a way that is safe and useful to them.

https://issues.redhat.com/browse/RHEL-19610