### PR TITLE
[th/fw-in-container-polkit-rules] improvement(fw-in-container): don'tdo anything in "40-firewalld.rules" polkit rule

### DIFF
--- a/contrib/fw-in-container/data/data-etc-polkit-1-rules-d-40-firewalld.rules
+++ b/contrib/fw-in-container/data/data-etc-polkit-1-rules-d-40-firewalld.rules
@@ -2,8 +2,8 @@ polkit.addRule(function(action, subject) {
     if (action.id.indexOf("org.fedoraproject.FirewallD1.") != 0) {
         return polkit.Result.NOT_HANDLED;
     }
+    return polkit.Result.NOT_HANDLED;
     return polkit.Result.YES;
     return polkit.Result.NO;
     return polkit.Result.AUTH_SELF;
-    return polkit.Result.NOT_HANDLED;
 });


### PR DESCRIPTION
Messing with the polkit rules means that `make check-integration` will fail. It should pass by default in fw-in-container.

Now the "40-firewalld.rules" file does nothing. It's still useful to have, because whenever I want to edit the polkit rules for manual testing, it is cumbersome to find the right location for the file and the proper syntax. The "40-firewalld.rules" file helps with that.