### PR TITLE
test(check-container): fix running of polkit tests

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -74,9 +74,18 @@ check-container-debian-sid-image: check-container-%-image:
 	echo "RUN apt-get install -y autoconf automake pkg-config intltool libglib2.0-dev \
 	                             xsltproc docbook-xsl docbook-xml iproute2 iptables ipset ebtables \
 	                             nftables libxml2-utils libdbus-1-dev libgirepository1.0-dev \
-	                             python3-dbus python3-gi python3-nftables \
-	                             procps network-manager gir1.2-nm-1.0 time" && \
-	echo "COPY . /tmp/firewalld"; \
+	                             python3-dbus python3-gi python3-nftables sudo \
+	                             procps network-manager gir1.2-nm-1.0 time policykit-1 systemd" && \
+	echo "ENV container docker" && \
+	echo "VOLUME [ \"/sys/fs/cgroup\" ]" && \
+	echo "CMD [\"/usr/sbin/init\"]" && \
+	echo "RUN mkdir -p /run/dbus" && \
+	echo "COPY . /root/firewalld" && \
+	echo "WORKDIR /root/firewalld" && \
+	echo "RUN ./autogen.sh" && \
+	echo "RUN ./configure --sysconfdir=/etc PYTHON=\"/usr/bin/python3\" am_cv_python_pythondir=/usr/lib/python3/dist-packages" && \
+	echo "RUN make" && \
+	echo "RUN make install" ; \
 	} | $(PODMAN) build -t firewalld-testsuite-$* -f - . )
 
 check-container-fedora-rawhide-image: check-container-%-image:
@@ -88,9 +97,18 @@ check-container-fedora-rawhide-image: check-container-%-image:
 	                 iptables iptables-nft libtool libxml2 libxslt make nftables \
 	                 python3-nftables python3-gobject-base python3-dbus \
 	                 diffutils procps-ng iproute which dbus-daemon \
-	                 NetworkManager NetworkManager-ovs time" && \
+	                 NetworkManager NetworkManager-ovs time polkit systemd sudo" && \
 	echo "RUN alternatives --set ebtables /usr/sbin/ebtables-nft" && \
-	echo "COPY . /tmp/firewalld"; \
+	echo "ENV container docker" && \
+	echo "VOLUME [ \"/sys/fs/cgroup\" ]" && \
+	echo "CMD [\"/usr/sbin/init\"]" && \
+	echo "RUN mkdir -p /run/dbus" && \
+	echo "COPY . /root/firewalld" && \
+	echo "WORKDIR /root/firewalld" && \
+	echo "RUN ./autogen.sh" && \
+	echo "RUN ./configure PYTHON=\"/usr/bin/python3\"" && \
+	echo "RUN make" && \
+	echo "RUN make install" ; \
 	} | $(PODMAN) build -t firewalld-testsuite-$* -f - . )
 
 check-container-centos8-stream-image: check-container-%-image:
@@ -102,8 +120,17 @@ check-container-centos8-stream-image: check-container-%-image:
 	                 iptables iptables-ebtables nftables libtool libxml2 \
 	                 libxslt make nftables python3-nftables python3-dbus \
 	                 python3-gobject-base diffutils procps-ng iproute which dbus-daemon \
-	                 NetworkManager NetworkManager-ovs time" && \
-	echo "COPY . /tmp/firewalld"; \
+	                 NetworkManager NetworkManager-ovs time polkit systemd sudo" && \
+	echo "ENV container docker" && \
+	echo "VOLUME [ \"/sys/fs/cgroup\" ]" && \
+	echo "CMD [\"/usr/sbin/init\"]" && \
+	echo "RUN mkdir -p /run/dbus" && \
+	echo "COPY . /root/firewalld" && \
+	echo "WORKDIR /root/firewalld" && \
+	echo "RUN ./autogen.sh" && \
+	echo "RUN ./configure PYTHON=\"/usr/libexec/platform-python\"" && \
+	echo "RUN make" && \
+	echo "RUN make install" ; \
 	} | $(PODMAN) build -t firewalld-testsuite-$* -f - . )
 
 check-container-centos9-stream-image: check-container-%-image:
@@ -115,24 +142,30 @@ check-container-centos9-stream-image: check-container-%-image:
 	                 iptables-nft nftables libtool libxml2 \
 	                 libxslt make nftables python3-nftables python3-dbus \
 	                 python3-gobject-base diffutils procps-ng iproute which dbus-daemon \
-	                 NetworkManager NetworkManager-ovs time" && \
-	echo "COPY . /tmp/firewalld"; \
+	                 NetworkManager NetworkManager-ovs time polkit systemd sudo" && \
+	echo "ENV container docker" && \
+	echo "VOLUME [ \"/sys/fs/cgroup\" ]" && \
+	echo "CMD [\"/usr/sbin/init\"]" && \
+	echo "RUN mkdir -p /run/dbus" && \
+	echo "COPY . /root/firewalld" && \
+	echo "WORKDIR /root/firewalld" && \
+	echo "RUN ./autogen.sh" && \
+	echo "RUN ./configure PYTHON=\"/usr/libexec/platform-python\"" && \
+	echo "RUN make" && \
+	echo "RUN make install" ; \
 	} | $(PODMAN) build -t firewalld-testsuite-$* -f - . )
 
-check-container-debian-sid: PYTHON=/usr/bin/python3
-check-container-fedora-rawhide: PYTHON=/usr/bin/python3
-check-container-centos8-stream: PYTHON=/usr/libexec/platform-python
-check-container-centos9-stream: PYTHON=/usr/libexec/platform-python
 $(CONTAINER_TARGETS): check-container-%: check-container-%-image
-	$(PODMAN) run -i --rm --privileged firewalld-testsuite-$* bash -c " \
-	cd /tmp/firewalld && \
-	./autogen.sh && \
-	./configure PYTHON=\"${PYTHON}\" && \
-	make && \
-	{ make -C src/tests check-local TESTSUITEFLAGS=\"$(TESTSUITEFLAGS)\" || \
-	  make -C src/tests check-local TESTSUITEFLAGS=\"--recheck --errexit --verbose\" ; } && \
-	make -C src/tests check-integration TESTSUITEFLAGS=\"$(TESTSUITEFLAGS)\" "
-	$(PODMAN) rmi firewalld-testsuite-$*
+	$(PODMAN) run --replace --detach --privileged --name firewalld-testsuite-$*-run firewalld-testsuite-$*
+	$(PODMAN) exec firewalld-testsuite-$*-run rm /usr/lib/firewalld/zones/nm-shared.xml
+	$(PODMAN) exec -it firewalld-testsuite-$*-run sh -c " \
+	{ make -C src/tests installcheck-local TESTSUITEFLAGS=\"$(TESTSUITEFLAGS)\" || \
+	  make -C src/tests installcheck-local TESTSUITEFLAGS=\"--recheck --errexit --verbose\" ; }"
+	$(PODMAN) exec firewalld-testsuite-$*-run systemctl stop NetworkManager
+	$(PODMAN) exec -it firewalld-testsuite-$*-run make -C src/tests installcheck-integration TESTSUITEFLAGS="$(TESTSUITEFLAGS)"
+	$(PODMAN) container stop firewalld-testsuite-$*-run
+	$(PODMAN) container rm firewalld-testsuite-$*-run
+	$(PODMAN) image rm firewalld-testsuite-$*
 
 check-container: $(CONTAINER_TARGETS)
 

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -165,10 +165,11 @@ m4_define([FWD_START_TEST], [
         dnl create a namespace and dbus-daemon
         m4_ifdef([TESTING_INTEGRATION], [], [
             m4_define([CURRENT_DBUS_ADDRESS], [unix:abstract=firewalld-testsuite-dbus-system-socket-${at_group_normalized}])
+
+            m4_define([CURRENT_TEST_NS], [fwd-test-${at_group_normalized}])
+            echo "ip netns delete CURRENT_TEST_NS" >> ./cleanup_late
+            AT_CHECK([ip netns add CURRENT_TEST_NS])
         ])
-        m4_define([CURRENT_TEST_NS], [fwd-test-${at_group_normalized}])
-        echo "ip netns delete CURRENT_TEST_NS" >> ./cleanup_late
-        AT_CHECK([ip netns add CURRENT_TEST_NS])
         m4_if(iptables, FIREWALL_BACKEND, [
             CHECK_IPTABLES
         ])
@@ -245,7 +246,7 @@ m4_define([FWD_START_TEST], [
             </busconfig>
 ])
         m4_ifdef([TESTING_INTEGRATION], [
-            AT_SKIP_IF([NS_CMD([pgrep firewalld >/dev/null 2>&1])])
+            AT_SKIP_IF([pgrep firewalld >/dev/null 2>&1])
 
             dnl dbus has a firewalld spec
             AT_SKIP_IF([! test -r /usr/share/dbus-1/system.d/FirewallD.conf])
@@ -278,7 +279,7 @@ m4_define([FWD_END_TEST], [
                        [grep '^[0-9-]*[ ]\+[0-9:]*[ ]\+\(ERROR\|WARNING\)']])
         fi
         m4_ifdef([CURRENT_DBUS_ADDRESS], [m4_undefine([CURRENT_DBUS_ADDRESS])])
-        m4_undefine([CURRENT_TEST_NS])
+        m4_ifdef([CURRENT_TEST_NS], [m4_undefine([CURRENT_TEST_NS])])
     ])
     AT_CLEANUP
 ])
@@ -360,8 +361,9 @@ m4_define([m4_strip],
                      [^ ?\(.*\) ?$], [\1])])
 
 m4_define([NS_CMD], [dnl
-    m4_ifdef([TESTING_INTEGRATION], [], [env DBUS_SYSTEM_BUS_ADDRESS="CURRENT_DBUS_ADDRESS"]) dnl command continues to next line
-    ip netns exec CURRENT_TEST_NS $1 dnl
+    m4_ifdef([TESTING_INTEGRATION], [$1], [dnl
+        env DBUS_SYSTEM_BUS_ADDRESS="CURRENT_DBUS_ADDRESS" ip netns exec CURRENT_TEST_NS $1 dnl
+    ]) dnl
 ])
 
 m4_define([NS_CHECK], [


### PR DESCRIPTION
In order to run polkit tests inside the container we must start systemd,
dbus-broker, and polkit. In order to do this we have to rework how the
container is built and start them with init.