### PR TITLE
Add iperf{2,3} services

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -204,6 +204,8 @@ CONFIG_FILES = \
 	services/ident.xml \
 	services/imaps.xml \
 	services/imap.xml \
+	services/iperf2.xml \
+	services/iperf3.xml \
 	services/ipfs.xml \
 	services/ipp-client.xml \
 	services/ipp.xml \

--- a/config/services/iperf2.xml
+++ b/config/services/iperf2.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>iperf2</short>
+  <description>iperf2 is a TCP and UDP network bandwidth measurement tool. Enable this option if you want to run an iperf2 server on its default port.</description>
+  <port protocol="tcp" port="5001"/>
+  <port protocol="udp" port="5001"/>
+</service>

--- a/config/services/iperf3.xml
+++ b/config/services/iperf3.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>iperf3</short>
+  <description>iperf3 is a TCP, UDP, and SCTP network bandwidth measurement tool. Enable this option if you want to run an iperf3 server on its default port.</description>
+  <port protocol="tcp" port="5201"/>
+  <port protocol="udp" port="5201"/>
+  <port protocol="sctp" port="5201"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -128,6 +128,8 @@ config/services/http.xml
 config/services/ident.xml
 config/services/imaps.xml
 config/services/imap.xml
+config/services/iperf2.xml
+config/services/iperf3.xml
 config/services/ipfs.xml
 config/services/ipp-client.xml
 config/services/ipp.xml


### PR DESCRIPTION
Add service definitions for `iperf2` and `iperf3`.

- [ ] Should `iperf2` simply be called `iperf` instead? Personally I think `iperf2` is clearer, but all major distros package `iperf2` as simply `iperf`. So I'm a bit torn.