### PR TITLE
feat: add a service for MNPD protocol

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -250,6 +250,7 @@ CONFIG_FILES = \
 	services/minecraft.xml \
 	services/memcache.xml \
 	services/minidlna.xml \
+	services/mndp.xml \
 	services/mongodb.xml \
 	services/mosh.xml \
 	services/mountd.xml \

--- a/config/services/mndp.xml
+++ b/config/services/mndp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>MNDP</short>
+  <description>MikroTik Neighbor Discovery protocol allows to "find" other devices compatible with MNDP.</description>
+  <port protocol="udp" port="5678"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -175,6 +175,7 @@ config/services/mdns.xml
 config/services/memcache.xml
 config/services/minecraft.xml
 config/services/minidlna.xml
+config/services/mndp.xml
 config/services/mongodb.xml
 config/services/mosh.xml
 config/services/mountd.xml


### PR DESCRIPTION
It's used by winbox to find devices over network using MNPD or CDP protocol.