### PR TITLE
[th/with-transaction] cleanup `use_transaction` handling

### DIFF
--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -616,7 +616,7 @@ class Firewall:
             self.zone.apply_zones(use_transaction=transaction)
 
             log.debug1("Applying used policies")
-            self.policy.apply_policies(use_transaction=transaction)
+            self.policy.apply_policies(transaction)
 
     def _start_apply_direct_rules(self):
         with self.with_transaction() as transaction:

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -572,7 +572,6 @@ class Firewall:
             self.ipset.backends() and self.ipset.has_ipsets()
         ):
             transaction.execute(True)
-            transaction.clear()
 
         # complete reload: unload modules also
         if reload and complete_reload:
@@ -581,7 +580,6 @@ class Firewall:
 
         self.apply_default_tables(use_transaction=transaction)
         transaction.execute(True)
-        transaction.clear()
 
         # apply settings for loaded ipsets while reloading here
         if (self.ipset.backends()) and self.ipset.has_ipsets():
@@ -602,7 +600,6 @@ class Firewall:
         self.policy.apply_policies(use_transaction=transaction)
 
         transaction.execute(True)
-        transaction.clear()
 
     def _start_apply_direct_rules(self):
         transaction = FirewallTransaction(self)
@@ -616,14 +613,12 @@ class Firewall:
             # the cause if the transaction fails.
             try:
                 transaction.execute(True)
-                transaction.clear()
             except FirewallError as e:
                 raise FirewallError(e.code, "Direct: %s" % (e.msg if e.msg else ""))
             except Exception:
                 raise
 
         transaction.execute(True)
-        transaction.clear()
 
     def _start_check(self):
         # check minimum required zones

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -597,7 +597,7 @@ class Firewall:
                 log.debug1("Unloading firewall modules")
                 self.modules_backend.unload_firewall_modules()
 
-            self.apply_default_tables(use_transaction=transaction)
+            self.apply_default_tables(transaction)
             transaction.execute(True)
 
             # apply settings for loaded ipsets while reloading here
@@ -1025,10 +1025,9 @@ class Firewall:
             backends.append(self.nftables_backend)
         return backends
 
-    def apply_default_tables(self, use_transaction=None):
-        with self.with_transaction(use_transaction) as transaction:
-            for backend in self.enabled_backends():
-                transaction.add_rules(backend, backend.build_default_tables())
+    def apply_default_tables(self, transaction):
+        for backend in self.enabled_backends():
+            transaction.add_rules(backend, backend.build_default_tables())
 
     def apply_default_rules(self, use_transaction=None):
 

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -613,7 +613,7 @@ class Firewall:
             self.zone._interface(True, self._default_zone, "+", transaction)
 
             log.debug1("Applying used zones")
-            self.zone.apply_zones(use_transaction=transaction)
+            self.zone.apply_zones(transaction)
 
             log.debug1("Applying used policies")
             self.policy.apply_policies(transaction)

--- a/src/firewall/core/fw_direct.py
+++ b/src/firewall/core/fw_direct.py
@@ -534,7 +534,9 @@ class FirewallDirect:
             if ipv in ["ipv4", "ipv6"]:
                 table, chain = backend.passthrough_parse_table_chain(args)
                 if table and chain:
-                    self._fw.zone.create_zone_base_by_chain(ipv, table, chain)
+                    self._fw.zone.create_zone_base_by_chain(
+                        ipv, table, chain, transaction
+                    )
             _args = args
         else:
             _args = backend.reverse_passthrough(args)

--- a/src/firewall/core/fw_direct.py
+++ b/src/firewall/core/fw_direct.py
@@ -64,20 +64,18 @@ class FirewallDirect:
             return True
         return False
 
-    def apply_direct(self, use_transaction=None):
-        with self._fw.with_transaction(use_transaction) as transaction:
-
-            # Apply permanent configuration and save the obj to be able to
-            # remove permanent configuration settings within get_runtime_config
-            # for use in firewalld reload.
-            self.set_config(
-                (
-                    self._obj.get_all_chains(),
-                    self._obj.get_all_rules(),
-                    self._obj.get_all_passthroughs(),
-                ),
-                transaction,
-            )
+    def apply_direct(self, transaction):
+        # Apply permanent configuration and save the obj to be able to
+        # remove permanent configuration settings within get_runtime_config
+        # for use in firewalld reload.
+        self.set_config(
+            (
+                self._obj.get_all_chains(),
+                self._obj.get_all_rules(),
+                self._obj.get_all_passthroughs(),
+            ),
+            transaction,
+        )
 
     def get_runtime_config(self):
         # Return only runtime changes

--- a/src/firewall/core/fw_policy.py
+++ b/src/firewall/core/fw_policy.py
@@ -276,9 +276,7 @@ class FirewallPolicy:
         self.check_ingress_zone(zone)
         return zone
 
-    def add_ingress_zone(
-        self, policy, zone, timeout=0, sender=None, use_transaction=None
-    ):
+    def add_ingress_zone(self, policy, zone, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -290,7 +288,7 @@ class FirewallPolicy:
                 errors.ALREADY_ENABLED, "'%s' already in '%s'" % (zone, _policy)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._ingress_zone(True, _policy, zone, transaction)
@@ -304,7 +302,7 @@ class FirewallPolicy:
     def __register_ingress_zone(self, _obj, zone_id, timeout, sender):
         _obj.ingress_zones.append(zone_id)
 
-    def remove_ingress_zone(self, policy, zone, use_transaction=None):
+    def remove_ingress_zone(self, policy, zone):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -315,7 +313,7 @@ class FirewallPolicy:
                 errors.NOT_ENABLED, "'%s' not in '%s'" % (zone, _policy)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 if len(_obj.ingress_zones) <= 1:
@@ -349,9 +347,7 @@ class FirewallPolicy:
         self.check_egress_zone(zone)
         return zone
 
-    def add_egress_zone(
-        self, policy, zone, timeout=0, sender=None, use_transaction=None
-    ):
+    def add_egress_zone(self, policy, zone, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -363,7 +359,7 @@ class FirewallPolicy:
                 errors.ALREADY_ENABLED, "'%s' already in '%s'" % (zone, _policy)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._egress_zone(True, _policy, zone, transaction)
@@ -377,7 +373,7 @@ class FirewallPolicy:
     def __register_egress_zone(self, _obj, zone_id, timeout, sender):
         _obj.egress_zones.append(zone_id)
 
-    def remove_egress_zone(self, policy, zone, use_transaction=None):
+    def remove_egress_zone(self, policy, zone):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -388,7 +384,7 @@ class FirewallPolicy:
                 errors.NOT_ENABLED, "'%s' not in '%s'" % (zone, _policy)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 if len(_obj.egress_zones) <= 1:
@@ -440,7 +436,7 @@ class FirewallPolicy:
     def __rule(self, enable, policy, rule, transaction):
         self._rule_prepare(enable, policy, rule, transaction)
 
-    def add_rule(self, policy, rule, timeout=0, sender=None, use_transaction=None):
+    def add_rule(self, policy, rule, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -453,7 +449,7 @@ class FirewallPolicy:
                 errors.ALREADY_ENABLED, "'%s' already in '%s'" % (rule, _name)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self.__rule(True, _policy, rule, transaction)
@@ -466,7 +462,7 @@ class FirewallPolicy:
     def __register_rule(self, _obj, rule_id, timeout, sender):
         _obj.rules_str.append(rule_id)
 
-    def remove_rule(self, policy, rule, use_transaction=None):
+    def remove_rule(self, policy, rule):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -476,7 +472,7 @@ class FirewallPolicy:
             _name = _obj.derived_from_zone if _obj.derived_from_zone else _policy
             raise FirewallError(errors.NOT_ENABLED, "'%s' not in '%s'" % (rule, _name))
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self.__rule(False, _policy, rule, transaction)
@@ -504,9 +500,7 @@ class FirewallPolicy:
         self.check_service(service)
         return service
 
-    def add_service(
-        self, policy, service, timeout=0, sender=None, use_transaction=None
-    ):
+    def add_service(self, policy, service, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -519,7 +513,7 @@ class FirewallPolicy:
                 errors.ALREADY_ENABLED, "'%s' already in '%s'" % (service, _name)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._service(True, _policy, service, transaction)
@@ -532,7 +526,7 @@ class FirewallPolicy:
     def __register_service(self, _obj, service_id, timeout, sender):
         _obj.services.append(service_id)
 
-    def remove_service(self, policy, service, use_transaction=None):
+    def remove_service(self, policy, service):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -544,7 +538,7 @@ class FirewallPolicy:
                 errors.NOT_ENABLED, "'%s' not in '%s'" % (service, _name)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._service(False, _policy, service, transaction)
@@ -606,9 +600,7 @@ class FirewallPolicy:
         self.check_port(port, protocol)
         return (portStr(port, "-"), protocol)
 
-    def add_port(
-        self, policy, port, protocol, timeout=0, sender=None, use_transaction=None
-    ):
+    def add_port(self, policy, port, protocol, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -627,7 +619,7 @@ class FirewallPolicy:
             port, [_port for (_port, _protocol) in existing_port_ids]
         )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 for range in added_ranges:
@@ -652,7 +644,7 @@ class FirewallPolicy:
     def __register_port(self, _obj, port_id, timeout, sender):
         _obj.ports.append(port_id)
 
-    def remove_port(self, policy, port, protocol, use_transaction=None):
+    def remove_port(self, policy, port, protocol):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -671,7 +663,7 @@ class FirewallPolicy:
             port, [_port for (_port, _protocol) in existing_port_ids]
         )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 for range in added_ranges:
@@ -725,9 +717,7 @@ class FirewallPolicy:
         self.check_protocol(protocol)
         return protocol
 
-    def add_protocol(
-        self, policy, protocol, timeout=0, sender=None, use_transaction=None
-    ):
+    def add_protocol(self, policy, protocol, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -740,7 +730,7 @@ class FirewallPolicy:
                 errors.ALREADY_ENABLED, "'%s' already in '%s'" % (protocol, _name)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._protocol(True, _policy, protocol, transaction)
@@ -753,7 +743,7 @@ class FirewallPolicy:
     def __register_protocol(self, _obj, protocol_id, timeout, sender):
         _obj.protocols.append(protocol_id)
 
-    def remove_protocol(self, policy, protocol, use_transaction=None):
+    def remove_protocol(self, policy, protocol):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -765,7 +755,7 @@ class FirewallPolicy:
                 errors.NOT_ENABLED, "'%s' not in '%s'" % (protocol, _name)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._protocol(False, _policy, protocol, transaction)
@@ -790,9 +780,7 @@ class FirewallPolicy:
         self.check_port(port, protocol)
         return (portStr(port, "-"), protocol)
 
-    def add_source_port(
-        self, policy, port, protocol, timeout=0, sender=None, use_transaction=None
-    ):
+    def add_source_port(self, policy, port, protocol, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -811,7 +799,7 @@ class FirewallPolicy:
             port, [_port for (_port, _protocol) in existing_port_ids]
         )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 for range in added_ranges:
@@ -836,7 +824,7 @@ class FirewallPolicy:
     def __register_source_port(self, _obj, port_id, timeout, sender):
         _obj.source_ports.append(port_id)
 
-    def remove_source_port(self, policy, port, protocol, use_transaction=None):
+    def remove_source_port(self, policy, port, protocol):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -855,7 +843,7 @@ class FirewallPolicy:
             port, [_port for (_port, _protocol) in existing_port_ids]
         )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 for range in added_ranges:
@@ -893,7 +881,7 @@ class FirewallPolicy:
 
     # MASQUERADE
 
-    def add_masquerade(self, policy, timeout=0, sender=None, use_transaction=None):
+    def add_masquerade(self, policy, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -905,7 +893,7 @@ class FirewallPolicy:
                 errors.ALREADY_ENABLED, "masquerade already enabled in '%s'" % _name
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._masquerade(True, _policy, transaction)
@@ -918,7 +906,7 @@ class FirewallPolicy:
     def __register_masquerade(self, _obj, timeout, sender):
         _obj.masquerade = True
 
-    def remove_masquerade(self, policy, use_transaction=None):
+    def remove_masquerade(self, policy):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -929,7 +917,7 @@ class FirewallPolicy:
                 errors.NOT_ENABLED, "masquerade not enabled in '%s'" % _name
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._masquerade(False, _policy, transaction)
@@ -975,7 +963,6 @@ class FirewallPolicy:
         toaddr=None,
         timeout=0,
         sender=None,
-        use_transaction=None,
     ):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
@@ -991,7 +978,7 @@ class FirewallPolicy:
                 % (port, protocol, toport, toaddr, _name),
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._forward_port(
@@ -1006,9 +993,7 @@ class FirewallPolicy:
     def __register_forward_port(self, _obj, forward_id, timeout, sender):
         _obj.forward_ports.append(forward_id)
 
-    def remove_forward_port(
-        self, policy, port, protocol, toport=None, toaddr=None, use_transaction=None
-    ):
+    def remove_forward_port(self, policy, port, protocol, toport=None, toaddr=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -1021,7 +1006,7 @@ class FirewallPolicy:
                 "'%s:%s:%s:%s' not in '%s'" % (port, protocol, toport, toaddr, _name),
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._forward_port(
@@ -1052,9 +1037,7 @@ class FirewallPolicy:
         self.check_icmp_block(icmp)
         return icmp
 
-    def add_icmp_block(
-        self, policy, icmp, timeout=0, sender=None, use_transaction=None
-    ):
+    def add_icmp_block(self, policy, icmp, timeout=0, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -1067,7 +1050,7 @@ class FirewallPolicy:
                 errors.ALREADY_ENABLED, "'%s' already in '%s'" % (icmp, _name)
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._icmp_block(True, _policy, icmp, transaction)
@@ -1080,7 +1063,7 @@ class FirewallPolicy:
     def __register_icmp_block(self, _obj, icmp_id, timeout, sender):
         _obj.icmp_blocks.append(icmp_id)
 
-    def remove_icmp_block(self, policy, icmp, use_transaction=None):
+    def remove_icmp_block(self, policy, icmp):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -1090,7 +1073,7 @@ class FirewallPolicy:
             _name = _obj.derived_from_zone if _obj.derived_from_zone else _policy
             raise FirewallError(errors.NOT_ENABLED, "'%s' not in '%s'" % (icmp, _name))
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._icmp_block(False, _policy, icmp, transaction)
@@ -1111,7 +1094,7 @@ class FirewallPolicy:
 
     # ICMP BLOCK INVERSION
 
-    def add_icmp_block_inversion(self, policy, sender=None, use_transaction=None):
+    def add_icmp_block_inversion(self, policy, sender=None):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -1123,7 +1106,7 @@ class FirewallPolicy:
                 "icmp-block-inversion already enabled in '%s'" % _name,
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 # undo icmp blocks
@@ -1162,7 +1145,7 @@ class FirewallPolicy:
                 for args in _obj.icmp_blocks:
                     self._icmp_block(True, _policy, args, transaction)
 
-    def remove_icmp_block_inversion(self, policy, use_transaction=None):
+    def remove_icmp_block_inversion(self, policy):
         _policy = self._fw.check_policy(policy)
         self._fw.check_panic()
         _obj = self._policies[_policy]
@@ -1173,7 +1156,7 @@ class FirewallPolicy:
                 errors.NOT_ENABLED, "icmp-block-inversion not enabled in '%s'" % _name
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 # undo icmp blocks

--- a/src/firewall/core/fw_transaction.py
+++ b/src/firewall/core/fw_transaction.py
@@ -68,7 +68,7 @@ class FirewallTransaction:
         for module in modules:
             self.remove_module(module)
 
-    def execute(self, enable):
+    def execute(self, enable, clear=True):
         log.debug4("%s.execute(%s)" % (type(self), enable))
 
         rules = self.rules
@@ -118,6 +118,9 @@ class FirewallTransaction:
 
         # post
         self.post()
+
+        if clear:
+            self.clear()
 
     def pre(self):
         log.debug4("%s.pre()" % type(self))

--- a/src/firewall/core/fw_transaction.py
+++ b/src/firewall/core/fw_transaction.py
@@ -69,6 +69,15 @@ class FirewallTransaction:
             self.remove_module(module)
 
     def execute(self, enable, clear=True):
+        if (
+            not self.rules
+            and not self.pre_funcs
+            and not self.post_funcs
+            and not self.fail_funcs
+        ):
+            # empty transaction. Don't do anything.
+            return
+
         log.debug4("%s.execute(%s)" % (type(self), enable))
 
         rules = self.rules

--- a/src/firewall/core/fw_transaction.py
+++ b/src/firewall/core/fw_transaction.py
@@ -25,9 +25,9 @@ class FirewallTransaction:
 
     def clear(self):
         self.rules.clear()
-        del self.pre_funcs[:]
-        del self.post_funcs[:]
-        del self.fail_funcs[:]
+        self.pre_funcs.clear()
+        self.post_funcs.clear()
+        self.fail_funcs.clear()
 
     def add_rule(self, backend, rule):
         self.rules.setdefault(backend.name, []).append(rule)

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -410,9 +410,7 @@ class FirewallZone:
         self.check_interface(interface)
         return interface
 
-    def add_interface(
-        self, zone, interface, sender=None, use_transaction=None, allow_apply=True
-    ):
+    def add_interface(self, zone, interface, sender=None, allow_apply=True):
         self._fw.check_panic()
         _zone = self._fw.check_zone(zone)
         _obj = self._zones[_zone]
@@ -432,7 +430,7 @@ class FirewallZone:
 
         log.debug1("Setting zone of interface '%s' to '%s'" % (interface, _zone))
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if not _obj.applied and allow_apply:
                 self.apply_zone_settings(zone, transaction)
@@ -468,7 +466,7 @@ class FirewallZone:
 
         return _zone
 
-    def remove_interface(self, zone, interface, use_transaction=None):
+    def remove_interface(self, zone, interface):
         self._fw.check_panic()
         zoi = self.get_zone_of_interface(interface)
         if zoi is None:
@@ -482,7 +480,7 @@ class FirewallZone:
                 "remove_interface(%s, %s): zoi='%s'" % (zone, interface, zoi),
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             _obj = self._zones[_zone]
             interface_id = self.__interface_id(interface)
@@ -526,9 +524,7 @@ class FirewallZone:
         self.check_source(source, applied=applied)
         return source
 
-    def add_source(
-        self, zone, source, sender=None, use_transaction=None, allow_apply=True
-    ):
+    def add_source(self, zone, source, sender=None, allow_apply=True):
         self._fw.check_panic()
         _zone = self._fw.check_zone(zone)
         _obj = self._zones[_zone]
@@ -548,7 +544,7 @@ class FirewallZone:
                 errors.ZONE_CONFLICT, "'%s' already bound to a zone" % source
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if not _obj.applied and allow_apply:
                 self.apply_zone_settings(zone, transaction)
@@ -583,7 +579,7 @@ class FirewallZone:
 
         return _zone
 
-    def remove_source(self, zone, source, use_transaction=None):
+    def remove_source(self, zone, source):
         self._fw.check_panic()
         if check_mac(source):
             source = source.upper()
@@ -599,7 +595,7 @@ class FirewallZone:
                 "remove_source(%s, %s): zos='%s'" % (zone, source, zos),
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             _obj = self._zones[_zone]
             ipv = self.check_source(source)
@@ -1271,7 +1267,7 @@ class FirewallZone:
                 )
                 transaction.add_rules(backend, rules)
 
-    def add_forward(self, zone, timeout=0, sender=None, use_transaction=None):
+    def add_forward(self, zone, timeout=0, sender=None):
         _zone = self._fw.check_zone(zone)
         self._fw.check_timeout(timeout)
         self._fw.check_panic()
@@ -1282,7 +1278,7 @@ class FirewallZone:
                 errors.ALREADY_ENABLED, "forward already enabled in '%s'" % _zone
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._forward(True, _zone, transaction)
@@ -1295,7 +1291,7 @@ class FirewallZone:
     def __register_forward(self, _obj, timeout, sender):
         _obj.forward = True
 
-    def remove_forward(self, zone, use_transaction=None):
+    def remove_forward(self, zone):
         _zone = self._fw.check_zone(zone)
         self._fw.check_panic()
         _obj = self._zones[_zone]
@@ -1305,7 +1301,7 @@ class FirewallZone:
                 errors.NOT_ENABLED, "forward not enabled in '%s'" % _zone
             )
 
-        with self.with_transaction(use_transaction) as transaction:
+        with self.with_transaction() as transaction:
 
             if _obj.applied:
                 self._forward(False, _zone, transaction)

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -241,16 +241,15 @@ class FirewallZone:
 
         return (self.policy_name_from_zones(fromZone, toZone), _chain)
 
-    def create_zone_base_by_chain(self, ipv, table, chain, use_transaction=None):
+    def create_zone_base_by_chain(self, ipv, table, chain, transaction):
         # Create zone base chains if the chain is reserved for a zone
         if ipv in ["ipv4", "ipv6"]:
             x = self.policy_from_chain(chain)
             if x is not None:
                 (policy, _chain) = self.policy_from_chain(chain)
-                with self.with_transaction(use_transaction) as transaction:
-                    self._fw.policy.gen_chain_rules(
-                        policy, True, table, _chain, transaction
-                    )
+                self._fw.policy.gen_chain_rules(
+                    policy, True, table, _chain, transaction
+                )
 
     def _zone_settings(self, enable, zone, transaction):
         for key in ["interfaces", "sources", "forward", "icmp_block_inversion"]:

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -290,9 +290,7 @@ class FirewallZone:
 
             for policy in self._zone_policies[_zone]:
                 log.debug1("Applying policy (%s) derived from zone '%s'", policy, zone)
-                self._fw.policy.apply_policy_settings(
-                    policy, use_transaction=transaction
-                )
+                self._fw.policy.apply_policy_settings(policy, transaction)
 
             self._zone_settings(True, _zone, transaction)
 
@@ -305,9 +303,7 @@ class FirewallZone:
         with self.with_transaction(use_transaction) as transaction:
 
             for policy in self._zone_policies[_zone]:
-                self._fw.policy.unapply_policy_settings(
-                    policy, use_transaction=transaction
-                )
+                self._fw.policy.unapply_policy_settings(policy, transaction)
 
             self._zone_settings(False, _zone, transaction)
 

--- a/src/firewall/core/fw_zone.py
+++ b/src/firewall/core/fw_zone.py
@@ -410,7 +410,7 @@ class FirewallZone:
         self.check_interface(interface)
         return interface
 
-    def add_interface(self, zone, interface, sender=None, allow_apply=True):
+    def add_interface(self, zone, interface, sender=None):
         self._fw.check_panic()
         _zone = self._fw.check_zone(zone)
         _obj = self._zones[_zone]
@@ -432,12 +432,11 @@ class FirewallZone:
 
         with self.with_transaction() as transaction:
 
-            if not _obj.applied and allow_apply:
+            if not _obj.applied:
                 self.apply_zone_settings(zone, transaction)
                 transaction.add_fail(self.set_zone_applied, _zone, False)
 
-            if allow_apply:
-                self._interface(True, _zone, interface, transaction)
+            self._interface(True, _zone, interface, transaction)
 
             self.__register_interface(_obj, interface_id, zone, sender)
             transaction.add_fail(self.__unregister_interface, _obj, interface_id)
@@ -524,7 +523,7 @@ class FirewallZone:
         self.check_source(source, applied=applied)
         return source
 
-    def add_source(self, zone, source, sender=None, allow_apply=True):
+    def add_source(self, zone, source, sender=None):
         self._fw.check_panic()
         _zone = self._fw.check_zone(zone)
         _obj = self._zones[_zone]
@@ -532,8 +531,8 @@ class FirewallZone:
         if check_mac(source):
             source = source.upper()
 
-        ipv = self.check_source(source, applied=allow_apply)
-        source_id = self.__source_id(source, applied=allow_apply)
+        ipv = self.check_source(source, applied=True)
+        source_id = self.__source_id(source, applied=True)
 
         if source_id in _obj.sources:
             raise FirewallError(
@@ -546,12 +545,11 @@ class FirewallZone:
 
         with self.with_transaction() as transaction:
 
-            if not _obj.applied and allow_apply:
+            if not _obj.applied:
                 self.apply_zone_settings(zone, transaction)
                 transaction.add_fail(self.set_zone_applied, _zone, False)
 
-            if allow_apply:
-                self._source(True, _zone, ipv, source_id, transaction)
+            self._source(True, _zone, ipv, source_id, transaction)
 
             self.__register_source(_obj, source_id, zone, sender)
             transaction.add_fail(self.__unregister_source, _obj, source_id)


### PR DESCRIPTION
I think most functions that have a `use_transaction` argument, should not optimally take a transaction. Instead, their callers should always provide one.

But that is not immediately obvious to fix, without potential changes in behavior (which may be correct). For example, there are calls like `transaction.add_pre(self._fw.flush_direct_backends)`, where the flush is not done with a transaction. Maybe it should be.

Anyway. Add and use a context manager for the "use_transaction" pattern, to simplify the code.