### PR TITLE
[th/fw-in-container-no-skip] improvement(fw-in-container): support running nftables test in container

### DIFF
--- a/contrib/fw-in-container/fw-in-container
+++ b/contrib/fw-in-container/fw-in-container
@@ -17,6 +17,8 @@ set -e
 # Options:
 #  --no-cleanup: don't delete the CONTAINERFILE and other artifacts
 #  --stop: only has effect with "run". It will stop the container afterwards.
+#  -S|--setup-host: bump sysctl values of host to run tests inside rootless
+#    container. Requires root.
 #  -- [EXTRA_ARGS]:
 #    - with command "exec", provide a command and arguments to run in the container.
 #      Defaults to "bash".
@@ -101,6 +103,29 @@ trap cleanup EXIT
 
 ###############################################################################
 
+sysctl_bump() {
+    local sysctl="$1"
+    local val="$2"
+    local cur;
+
+    cur="$(cat "$sysctl" 2>/dev/null)" || :
+    if [ -n "$cur" -a "$cur" -ge "$val" ] ; then
+        echo "# Skip: echo $val > $sysctl (current value $cur)"
+        return 0
+    fi
+    echo "    echo $val > $sysctl (previous value $cur)"
+    echo "$val" > "$sysctl"
+}
+
+setup_host() {
+    echo "Setting up host for running as rootless (requires root)."
+    sysctl_bump /proc/sys/net/core/rmem_max $((4000*1024)) || return $?
+    sysctl_bump /proc/sys/net/core/wmem_max $((4000*1024)) || return $?
+    sysctl_bump /proc/sys/net/core/wmem_default $((4000*1024)) || return $?
+}
+
+###############################################################################
+
 tmp_file() {
     cat > "$1"
     CLEANUP_FILES+=( "$1" )
@@ -115,6 +140,9 @@ bind_files() {
 
     ARR+=( -v "$BASEDIR_FW:$BASEDIR_FW" )
     ARR+=( -v "/:/Host" )
+
+    # Make /proc/sys/net/core available, so we can check it.
+    ARR+=( -v "/proc/sys/net/core:/.host/proc/sys/net/core" )
 
     for i in $(seq 1 ${#SYMLINK_TARGET[@]}) ; do
         j=$((i - 1))
@@ -607,6 +635,10 @@ for (( i=1 ; i<="$#" ; )) ; do
         --)
             EXTRA_ARGS=( "${@:$i}" )
             break
+            ;;
+        -S|--setup-host)
+            setup_host
+            exit $?
             ;;
         -h|--help)
             usage

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -751,8 +751,9 @@ m4_define([SKIP_IF_FW_IN_CONTAINER], [
     dnl With contrib/fw-in-container script, we run a rootless (privileged) container.
     dnl We recognize by having "$FW_IN_CONTAINER" set in the environment variables.
     dnl
-    dnl Some test won't pass. Skip them.
-    AT_SKIP_IF([test -n "$FW_IN_CONTAINER"])
+    dnl Some test won't pass, because the socket buffer sizes are limited for rootless.
+    dnl We skip those tests, except, if we detect that the limits are large.
+    AT_SKIP_IF([test -n "$FW_IN_CONTAINER" -a "(" "$(cat /proc/sys/net/core/rmem_max 2>/dev/null || cat /.host/proc/sys/net/core/rmem_max 2>/dev/null || echo 0)" -lt 4096000 -o "$(cat /proc/sys/net/core/wmem_max 2>/dev/null  || cat /.host/proc/sys/net/core/wmem_max 2>/dev/null || echo 0)" -lt 4096000 -o "$(cat /proc/sys/net/core/wmem_default 2>/dev/null  || cat /.host/proc/sys/net/core/wmem_default 2>/dev/null || echo 0)" -lt 4096000")" ])
 ])
 
 m4_define([SKIP_IF_FW_IN_CONTAINER_WITH_NFTABLES], [


### PR DESCRIPTION
fw-in-container is useful for testing and development.

Note that it runs a rootless container. For non-root users, the netlink socket buffer is limited by /proc/sys/net/core/{rmem_max,wmem_max}. This causes various tests inside fw-in-container to fail. The test also cannot just bump that limit, because it's rootless (and because it would be an undesirable modification of the host).

However, it's useful to support running such tests also inside the container. All that we need, is that the user (as root) bumps those host wide limits.

Extend the script to detect that, so that it can run.

If you now want to run those tests, first issue a
```
  echo 4096000 > /proc/sys/net/core/rmem_max
  echo 4096000 > /proc/sys/net/core/wmem_max
  echo 4096000 > /proc/sys/net/core/wmem_default
```
as root. You can get this simply by running:
```
  $ sudo ./contrib/fw-in-container/fw-in-container -S
```