### PR TITLE
[th/ipaddr-parse-pt1] add new function for parsing IP addresses

### DIFF
--- a/src/firewall/functions.py
+++ b/src/firewall/functions.py
@@ -84,6 +84,12 @@ def addr_family_bitsize(family):
 ###############################################################################
 
 
+IPAddrZero4 = b"\0\0\0\0"
+
+
+###############################################################################
+
+
 def getPortID(port):
     """Check and Get port id from port string or port id using socket.getservbyname
 

--- a/src/tests/unit/helpers.py
+++ b/src/tests/unit/helpers.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os
+import socket
+
+###############################################################################
 
 
 def str_to_bool(val, default_val=False):
@@ -20,6 +23,8 @@ def str_to_bool(val, default_val=False):
     raise ValueError(f"Unexpcted value for str_to_bool({repr(val)})")
 
 
+###############################################################################
+
 _srcdir = os.path.realpath(os.path.dirname(__file__) + "../../../..")
 
 
@@ -28,3 +33,25 @@ def srcdir(*a, exists=True):
     if exists:
         assert os.path.exists(f)
     return f
+
+
+###############################################################################
+
+
+def ipaddr_to_bin(addr):
+    assert addr
+    assert isinstance(addr, str)
+    family = socket.AF_INET if "." in addr else socket.AF_INET6
+    return socket.inet_pton(family, addr)
+
+
+def ipaddr_from_bin(addr):
+    assert addr
+    assert isinstance(addr, bytes)
+    if len(addr) == 4:
+        family = socket.AF_INET
+    elif len(addr) == 16:
+        family = socket.AF_INET6
+    else:
+        assert False
+    return socket.inet_ntop(family, addr)

--- a/src/tests/unit/helpers.py
+++ b/src/tests/unit/helpers.py
@@ -55,3 +55,35 @@ def ipaddr_from_bin(addr):
     else:
         assert False
     return socket.inet_ntop(family, addr)
+
+
+###############################################################################
+
+
+def getservbyname(name, expected=None, maybe_missing=False):
+    assert name
+    assert isinstance(name, str)
+
+    try:
+        p = socket.getservbyname(name)
+    except socket.error:
+        if not maybe_missing:
+            raise
+        return None
+
+    assert isinstance(p, int)
+    assert p > 0
+
+    if expected is not None:
+        assert p == expected
+
+    return p
+
+
+def getprotobyname(name):
+    assert name
+    assert isinstance(name, str)
+    try:
+        return socket.getprotobyname(name)
+    except socket.error:
+        return None

--- a/src/tests/unit/helpers.py
+++ b/src/tests/unit/helpers.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os
+import re
 import socket
 
 ###############################################################################
@@ -87,3 +88,21 @@ def getprotobyname(name):
         return socket.getprotobyname(name)
     except socket.error:
         return None
+
+
+###############################################################################
+
+
+def assert_firewall_error(obj, code=None, msg=None):
+    import firewall.errors
+
+    assert isinstance(obj, firewall.errors.FirewallError)
+    if msg is None:
+        pass
+    elif isinstance(msg, str):
+        assert obj.msg == msg
+    else:
+        assert isinstance(msg, re.Pattern)
+        assert msg.search(obj.msg)
+    if code is not None:
+        assert obj.code == code

--- a/src/tests/unit/test_functions.py
+++ b/src/tests/unit/test_functions.py
@@ -191,3 +191,12 @@ def test_addr_family():
 
 def test_addr_parse():
     assert firewall.functions.IPAddrZero4 == helpers.ipaddr_to_bin("0.0.0.0")
+
+
+def test_entrytype():
+    with pytest.raises(TypeError):
+        assert firewall.functions.EntryType.check("fooo", types=None)
+
+    with pytest.raises(ValueError):
+        firewall.functions.EntryType.parse("fooo", types=())
+    assert not firewall.functions.EntryType.check("fooo", types=())

--- a/src/tests/unit/test_functions.py
+++ b/src/tests/unit/test_functions.py
@@ -127,3 +127,35 @@ def test_checkIP():
     assert firewall.functions.normalizeIP6("[[[[[::[") == "::"
     assert firewall.functions.normalizeIP6("[[[[[1::2[") == "1::2"
     assert firewall.functions.normalizeIP6("[[[[[bogus[") == "bogus"
+
+
+def test_checkInterface():
+    assert not firewall.functions.checkInterface(None)
+    assert not firewall.functions.checkInterface(0)
+    with pytest.raises(TypeError):
+        firewall.functions.checkInterface(b"eth0")
+
+    assert not firewall.functions.checkInterface("")
+    assert not firewall.functions.checkInterface("/")
+    assert not firewall.functions.checkInterface("a/")
+    assert firewall.functions.checkInterface("\240a")
+    assert firewall.functions.checkInterface(".")
+    assert firewall.functions.checkInterface("..")
+    assert firewall.functions.checkInterface("...")
+    assert firewall.functions.checkInterface("all")
+    assert firewall.functions.checkInterface("bonding_masters")
+    assert firewall.functions.checkInterface("default")
+    assert firewall.functions.checkInterface("defaultx")
+    assert firewall.functions.checkInterface("1234567890abcd")
+    assert firewall.functions.checkInterface("1234567890abcde")
+    assert firewall.functions.checkInterface("1234567890abcdef")
+    assert not firewall.functions.checkInterface("1234567890abcdefg")
+    assert not firewall.functions.checkInterface("eth!x")
+    assert not firewall.functions.checkInterface("eth*x")
+
+    smiley = b"\xF0\x9F\x98\x8A".decode("utf-8")
+    iface = f"{smiley}{smiley}{smiley}"
+    assert firewall.functions.checkInterface(f"123{iface}")
+    assert firewall.functions.checkInterface(f"1234{iface}")
+    assert firewall.functions.checkInterface(f"1234567890abc{iface}")
+    assert not firewall.functions.checkInterface(f"1234567890abcd{iface}")

--- a/src/tests/unit/test_functions.py
+++ b/src/tests/unit/test_functions.py
@@ -187,3 +187,7 @@ def test_addr_family():
         f2 = firewall.functions.addr_family(family_str, allow_unspec=True)
         assert family_str == firewall.functions.addr_family_str(f2)
         assert family_str == firewall.functions.addr_family_str(family_str)
+
+
+def test_addr_parse():
+    assert firewall.functions.IPAddrZero4 == helpers.ipaddr_to_bin("0.0.0.0")

--- a/src/tests/unit/test_functions.py
+++ b/src/tests/unit/test_functions.py
@@ -97,3 +97,33 @@ def test_fcnport():
     assert firewall.functions.portStr(" http") == "80"
     assert firewall.functions.portStr(" 1 - 5") == "1:5"
     assert firewall.functions.portStr(" http - 5") == "5:80"
+
+
+def test_checkIP():
+    with pytest.raises(TypeError):
+        assert not firewall.functions.checkIP(None)
+    assert firewall.functions.checkIP("0.0.0.0")
+    assert firewall.functions.checkIP("1.2.3.4")
+    assert not firewall.functions.checkIP("::")
+    assert not firewall.functions.checkIP("")
+
+    with pytest.raises(AttributeError):
+        assert not firewall.functions.checkIP6(None)
+    assert firewall.functions.checkIP6("[::]")
+    assert firewall.functions.checkIP6("[1:00::a22]")
+    assert firewall.functions.checkIP6("[::")
+    assert firewall.functions.checkIP6("[[[[[::")
+    assert firewall.functions.checkIP6("[[[[[::[")
+    assert firewall.functions.checkIP6("[[[[[1::2[")
+    assert not firewall.functions.checkIP6("[[[[[bogus[")
+
+    with pytest.raises(AttributeError):
+        assert not firewall.functions.normalizeIP6(None)
+    assert firewall.functions.normalizeIP6("[::]") == "::"
+    assert firewall.functions.normalizeIP6("[1:00::a22]") == "1:00::a22"
+    assert firewall.functions.normalizeIP6("1:00::a22") == "1:00::a22"
+    assert firewall.functions.normalizeIP6("[::") == "::"
+    assert firewall.functions.normalizeIP6("[[[[[::") == "::"
+    assert firewall.functions.normalizeIP6("[[[[[::[") == "::"
+    assert firewall.functions.normalizeIP6("[[[[[1::2[") == "1::2"
+    assert firewall.functions.normalizeIP6("[[[[[bogus[") == "bogus"

--- a/src/tests/unit/test_functions.py
+++ b/src/tests/unit/test_functions.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import pytest
+
+import firewall.functions
+
+from tests.unit import helpers
+
+###############################################################################
+
+
+def test_fcnport():
+    http_port = helpers.getservbyname("http", 80)
+    www_http_port = helpers.getservbyname("www-http", 80, maybe_missing=True)
+    gopher_port = helpers.getservbyname("gopher", 70, maybe_missing=True)
+
+    with pytest.raises(TypeError):
+        assert firewall.functions.getPortID(None)
+    assert firewall.functions.getPortID(1) == 1
+    assert firewall.functions.getPortID(65535) == 65535
+    assert firewall.functions.getPortID(0) == 0
+    assert firewall.functions.getPortID(-1) == -1
+    assert firewall.functions.getPortID(-3) == -3
+    assert firewall.functions.getPortID(65536) == -2
+    assert firewall.functions.getPortID("6") == 6
+    assert firewall.functions.getPortID("  66 ") == 66
+    assert firewall.functions.getPortID("  65535 ") == 65535
+    assert firewall.functions.getPortID("  65536 ") == -2
+    assert firewall.functions.getPortID("0") == 0
+    assert firewall.functions.getPortID("-1") == -1
+    assert firewall.functions.getPortID("-3") == -3
+    assert firewall.functions.getPortID("foo") == -1
+    assert firewall.functions.getPortID("") == -1
+    assert firewall.functions.getPortID(" ") == -1
+    assert firewall.functions.getPortID("http") == http_port
+    assert firewall.functions.getPortID(" http") == http_port
+    if www_http_port is not None:
+        assert firewall.functions.getPortID(" www-http   ") == www_http_port
+
+    with pytest.raises(AttributeError):
+        assert firewall.functions.getPortRange(None)
+    assert firewall.functions.getPortRange([]) == []
+    assert firewall.functions.getPortRange(()) == ()
+    assert firewall.functions.getPortRange((1,)) == (1,)
+    assert firewall.functions.getPortRange([2342423432]) == [2342423432]
+    assert firewall.functions.getPortRange((1, 4)) == (1, 4)
+    assert firewall.functions.getPortRange([2342423432, 5]) == [2342423432, 5]
+    assert firewall.functions.getPortRange((1, 6, 4)) == (1, 6, 4)
+
+    assert firewall.functions.getPortRange(-5) == -5
+    assert firewall.functions.getPortRange(-1) == -1
+    assert firewall.functions.getPortRange(0) == (0,)
+    assert firewall.functions.getPortRange(5) == (5,)
+    assert firewall.functions.getPortRange(65535) == (65535,)
+    assert firewall.functions.getPortRange(65536) == -2
+
+    assert firewall.functions.getPortRange("-5") == -1
+    assert firewall.functions.getPortRange("-1") == -1
+    assert firewall.functions.getPortRange("0") == (0,)
+    assert firewall.functions.getPortRange("0 ") == (0,)
+    assert firewall.functions.getPortRange("1") == (1,)
+    assert firewall.functions.getPortRange(" 1 ") == (1,)
+    assert firewall.functions.getPortRange("65535") == (65535,)
+    assert firewall.functions.getPortRange("65536") == -2
+    assert firewall.functions.getPortRange(" 65536 ") == -1
+
+    assert firewall.functions.getPortRange("-") == -1
+    assert firewall.functions.getPortRange("1-1") == (1,)
+    assert firewall.functions.getPortRange("1-2") == (1, 2)
+    assert firewall.functions.getPortRange(" 1-2") == (1, 2)
+    assert firewall.functions.getPortRange(" 2-1") == (1, 2)
+    assert firewall.functions.getPortRange(" 0-1") == (0, 1)
+    assert firewall.functions.getPortRange(" 0-65535") == (0, 65535)
+    assert firewall.functions.getPortRange(" 65535 \n - 1  ") == (1, 65535)
+    assert firewall.functions.getPortRange(" 65536-1") == -1
+
+    assert firewall.functions.getPortRange(" http") == (http_port,)
+    assert firewall.functions.getPortRange(" http-http") == (http_port,)
+    if www_http_port is not None:
+        assert firewall.functions.getPortRange(" http-www-http") == (http_port,)
+    if www_http_port is not None and gopher_port is not None:
+        assert firewall.functions.getPortRange(" gopher-www-http") == (
+            gopher_port,
+            http_port,
+        )
+        assert firewall.functions.getPortRange(" gopher -www-http") == (
+            gopher_port,
+            http_port,
+        )
+        assert firewall.functions.getPortRange(" gopher -76") == (gopher_port, 76)
+
+    assert firewall.functions.getPortRange("foo") == -1
+    assert firewall.functions.getPortRange(" xgopher -76") == -1
+
+    assert firewall.functions.portStr("0") == "0"
+    assert firewall.functions.portStr("x") is None
+    assert firewall.functions.portStr(" http") == "80"
+    assert firewall.functions.portStr(" 1 - 5") == "1:5"
+    assert firewall.functions.portStr(" http - 5") == "5:80"


### PR DESCRIPTION
This is the first part of https://github.com/firewalld/firewalld/pull/1172 , which is pending review. Split the branch into smaller pieces.

the overall goal is to have solid functions for handling strings. firewalld mainly deals with (firewall) configuration, where we express data as strings. We need functions that can handle those strings, and thus define (by implementation) how the strings are handled. Such functions in part already exist, however, their implementation and API is lacking. This introduces new functions. In particular:

- functions can handle IPv4/IPv6 similarly (there is now an `addr_family` argument)
- the branch adds unit tests.
- the branch fixes bugs in the existing implementation
- the new functions have a better name. Better, because they establish a pattern how similar function (eg. to parse a MAC address or a port) will be called.