### PR TITLE
[RH-Satellite-6] Remove deprecated and unused ports

### DIFF
--- a/config/services/RH-Satellite-6-capsule.xml
+++ b/config/services/RH-Satellite-6-capsule.xml
@@ -3,5 +3,4 @@
   <short>Red Hat Satellite 6 Capsule</short>
   <description>Red Hat Satellite 6 is a systems management server that can be used to configure new systems, subscribe to updates, and maintain installations in distributed environments.</description>
   <include service="RH-Satellite-6"/>
-  <port protocol="tcp" port="8443"/>
 </service>

--- a/config/services/RH-Satellite-6.xml
+++ b/config/services/RH-Satellite-6.xml
@@ -3,10 +3,9 @@
   <short>Red Hat Satellite 6</short>
   <description>Red Hat Satellite 6 is a systems management server that can be used to configure new systems, subscribe to updates, and maintain installations in distributed environments.</description>
   <include service="foreman"/>
-  <port protocol="tcp" port="5000"/>
+  <include service="mqtt"/>
+  <include service="cockpit"/>
+  <port protocol="tcp" port="5910-5930"/>
   <port protocol="tcp" port="5646-5647"/>
-  <port protocol="tcp" port="5671"/>
   <port protocol="tcp" port="8000"/>
-  <port protocol="tcp" port="8080"/>
-  <port protocol="tcp" port="9090"/>
 </service>


### PR DESCRIPTION
Hello dear firewalld team,
I am working with Red Hat Satellite for professional reasons and currently have to create my own service file that reflects the new developments in Satellite.

Therefore, I thought I could suggest these changes upstream.

Here is a short explanation of my changes:
I used the documentation of the oldest still supported Satellite version 6.12 as a guide. There you can find these firewall requirements: [Satellite 6.12 Firewall requirements](https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html/installing_satellite_server_in_a_connected_network_environment/preparing_your_environment_for_installation_satellite#Ports_and_Firewalls_Requirements_satellite)

`RH-Satellite-6.xml`:
- Port `5000`, `5671` and `8080` are no longer mentioned in the documentation.
- Newly added are `5910-5930` and `1883` (included as mqtt service)
- Port 9090 has been replaced by an include of the cockpit service

`RH-Satellite-6-capsule.xml`:
- Port `8443` is deprecated, content host registrations are handled via `443`

Since the `RH-Satellite-6-capsule` service includes the `RH-Satellite-6` service, port `5910-5930` would also be opened on the Capsules.
However, these ports are not listed in the [Capsule documentation](https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html/installing_capsule_server/preparing-environment-for-capsule-installation#capsule-ports-and-firewalls-requirements_capsule).
Is there a way to overwrite them so that they remain closed for the Capsule service?

My only idea would be to reverse the dependencies, since the Capsule now contains a subset of the Satellite rules.