### PR TITLE
fix(policy): allow forward ports w/ to-addr for egress-zone=HOST

### DIFF
--- a/src/firewall/core/io/policy.py
+++ b/src/firewall/core/io/policy.py
@@ -1094,38 +1094,34 @@ class Policy(IO_Object):
                                 )
                 elif obj.element and isinstance(obj.element, rich.Rich_ForwardPort):
                     if "egress_zones" in all_config:
-                        if "HOST" in all_config["egress_zones"]:
-                            if obj.element.to_address:
-                                raise FirewallError(
-                                    errors.INVALID_FORWARD,
-                                    "Policy '{}': A 'forward-port' with 'to-addr' is invalid for egress zone 'HOST'".format(
-                                        self.name
-                                    ),
-                                )
-                        elif all_config["egress_zones"]:
-                            if not obj.element.to_address:
+                        if all_config["egress_zones"]:
+                            if (
+                                "HOST" not in all_config["egress_zones"]
+                                and not obj.element.to_address
+                            ):
                                 raise FirewallError(
                                     errors.INVALID_FORWARD,
                                     "Policy '{}': 'forward-port' requires 'to-addr' if egress zone is 'ANY' or a zone".format(
                                         self.name
                                     ),
                                 )
-                            if "ANY" not in all_config["egress_zones"]:
-                                for zone in all_config["egress_zones"]:
-                                    if zone not in all_io_objects["zones"]:
-                                        raise FirewallError(
-                                            errors.INVALID_ZONE,
-                                            "Policy '{}': Zone '{}' does not exist.".format(
-                                                self.name, zone
-                                            ),
-                                        )
-                                    if all_io_objects["zones"][zone].interfaces:
-                                        raise FirewallError(
-                                            errors.INVALID_ZONE,
-                                            "Policy '{}': 'forward-port' cannot be used because egress zone '{}' has assigned interfaces".format(
-                                                self.name, zone
-                                            ),
-                                        )
+                            for zone in all_config["egress_zones"]:
+                                if zone in ("HOST", "ANY"):
+                                    continue
+                                if zone not in all_io_objects["zones"]:
+                                    raise FirewallError(
+                                        errors.INVALID_ZONE,
+                                        "Policy '{}': Zone '{}' does not exist.".format(
+                                            self.name, zone
+                                        ),
+                                    )
+                                if all_io_objects["zones"][zone].interfaces:
+                                    raise FirewallError(
+                                        errors.INVALID_ZONE,
+                                        "Policy '{}': 'forward-port' cannot be used because egress zone '{}' has assigned interfaces".format(
+                                            self.name, zone
+                                        ),
+                                    )
                 elif obj.action and isinstance(obj.action, rich.Rich_Mark):
                     if "egress_zones" in all_config:
                         for zone in all_config["egress_zones"]:
@@ -1148,38 +1144,31 @@ class Policy(IO_Object):
         elif item == "forward_ports":
             for fwd_port in config:
                 if "egress_zones" in all_config:
-                    if "HOST" in all_config["egress_zones"]:
-                        if fwd_port[3]:
-                            raise FirewallError(
-                                errors.INVALID_FORWARD,
-                                "Policy '{}': A 'forward-port' with 'to-addr' is invalid for egress zone 'HOST'".format(
-                                    self.name
-                                ),
-                            )
-                    elif all_config["egress_zones"]:
-                        if not fwd_port[3]:
+                    if all_config["egress_zones"]:
+                        if "HOST" not in all_config["egress_zones"] and not fwd_port[3]:
                             raise FirewallError(
                                 errors.INVALID_FORWARD,
                                 "Policy '{}': 'forward-port' requires 'to-addr' if egress zone is 'ANY' or a zone".format(
                                     self.name
                                 ),
                             )
-                        if "ANY" not in all_config["egress_zones"]:
-                            for zone in all_config["egress_zones"]:
-                                if zone not in all_io_objects["zones"]:
-                                    raise FirewallError(
-                                        errors.INVALID_ZONE,
-                                        "Policy '{}': Zone '{}' does not exist.".format(
-                                            self.name, zone
-                                        ),
-                                    )
-                                if all_io_objects["zones"][zone].interfaces:
-                                    raise FirewallError(
-                                        errors.INVALID_ZONE,
-                                        "Policy '{}': 'forward-port' cannot be used because egress zone '{}' has assigned interfaces".format(
-                                            self.name, zone
-                                        ),
-                                    )
+                        for zone in all_config["egress_zones"]:
+                            if zone in ("HOST", "ANY"):
+                                continue
+                            if zone not in all_io_objects["zones"]:
+                                raise FirewallError(
+                                    errors.INVALID_ZONE,
+                                    "Policy '{}': Zone '{}' does not exist.".format(
+                                        self.name, zone
+                                    ),
+                                )
+                            if all_io_objects["zones"][zone].interfaces:
+                                raise FirewallError(
+                                    errors.INVALID_ZONE,
+                                    "Policy '{}': 'forward-port' cannot be used because egress zone '{}' has assigned interfaces".format(
+                                        self.name, zone
+                                    ),
+                                )
 
     def check_name(self, name):
         super(Policy, self).check_name(name)

--- a/src/tests/features/forward_ports.at
+++ b/src/tests/features/forward_ports.at
@@ -106,34 +106,42 @@ FWD_CHECK([            --policy=foobar --add-rich-rule='rule family=ipv4 forward
 FWD_CHECK([--permanent --policy=foobar --remove-egress-zone ANY], 0, [ignore])
 FWD_CHECK([            --policy=foobar --remove-egress-zone ANY], 0, [ignore])
 
-dnl if egress-zone is HOST then to-addr is invalid
+dnl if egress-zone is HOST then to-addr is valid
 FWD_CHECK([--permanent --policy=foobar --add-egress-zone HOST], 0, [ignore])
-FWD_CHECK([--permanent --policy=foobar --add-forward-port port=22:proto=tcp:toport=2222:toaddr=10.0.0.1], 106, [ignore], [ignore])
-FWD_CHECK([--permanent --policy=foobar --add-rich-rule='rule family=ipv4 forward-port port=444 protocol=udp to-port=4444 to-addr=10.44.44.44'], 106, [ignore], [ignore])
+FWD_CHECK([--permanent --policy=foobar --add-forward-port port=22:proto=tcp:toport=2222:toaddr=10.0.0.1], 0, [ignore], [ignore])
+FWD_CHECK([--permanent --policy=foobar --add-rich-rule='rule family=ipv4 forward-port port=444 protocol=udp to-port=4444 to-addr=10.44.44.44'], 0, [ignore], [ignore])
 FWD_CHECK([--permanent --policy=foobar --add-forward-port port=22:proto=tcp:toport=2222], 0, [ignore], [ignore])
 FWD_CHECK([--permanent --policy=foobar --add-rich-rule='rule family=ipv6 forward-port port=444 protocol=udp to-port=4444'], 0, [ignore], [ignore])
 FWD_CHECK([--policy=foobar --add-egress-zone HOST], 0, [ignore])
-FWD_CHECK([--policy=foobar --add-forward-port port=22:proto=tcp:toport=2222:toaddr=10.0.0.1], 106, [ignore], [ignore])
-FWD_CHECK([--policy=foobar --add-rich-rule='rule family=ipv4 forward-port port=444 protocol=udp to-port=4444 to-addr=10.44.44.44'], 106, [ignore], [ignore])
+FWD_CHECK([--policy=foobar --add-forward-port port=22:proto=tcp:toport=2222:toaddr=10.0.0.1], 0, [ignore], [ignore])
+FWD_CHECK([--policy=foobar --add-rich-rule='rule family=ipv4 forward-port port=444 protocol=udp to-port=4444 to-addr=10.44.44.44'], 0, [ignore], [ignore])
 FWD_CHECK([--policy=foobar --add-forward-port port=22:proto=tcp:toport=2222], 0, [ignore], [ignore])
 FWD_CHECK([--policy=foobar --add-rich-rule='rule family=ipv6 forward-port port=444 protocol=udp to-port=4444'], 0, [ignore], [ignore])
 NFT_LIST_RULES([inet], [nat_PRE_policy_foobar_allow], 0, [dnl
     table inet firewalld {
         chain nat_PRE_policy_foobar_allow {
+            meta nfproto ipv4 tcp dport 22 dnat ip to 10.0.0.1:2222
+            meta nfproto ipv4 udp dport 444 dnat ip to 10.44.44.44:4444
             meta nfproto ipv4 tcp dport 22 redirect to :2222
             meta nfproto ipv6 udp dport 444 redirect to :4444
         }
     }
 ])
 IPTABLES_LIST_RULES([nat], [PRE_foobar_allow], 0, [dnl
+    DNAT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 to:10.0.0.1:2222
+    DNAT 17 -- 0.0.0.0/0 0.0.0.0/0 udp dpt:444 to:10.44.44.44:4444
     DNAT 6 -- 0.0.0.0/0 0.0.0.0/0 tcp dpt:22 to::2222
 ])
 IP6TABLES_LIST_RULES([nat], [PRE_foobar_allow], 0, [dnl
     DNAT 17 -- ::/0 ::/0 udp dpt:444 to::4444
 ])
+FWD_CHECK([--permanent --policy=foobar --remove-forward-port port=22:proto=tcp:toport=2222:toaddr=10.0.0.1], 0, [ignore], [ignore])
+FWD_CHECK([--permanent --policy=foobar --remove-rich-rule='rule family=ipv4 forward-port port=444 protocol=udp to-port=4444 to-addr=10.44.44.44'], 0, [ignore], [ignore])
 FWD_CHECK([--permanent --policy=foobar --remove-forward-port port=22:proto=tcp:toport=2222], 0, [ignore], [ignore])
 FWD_CHECK([--permanent --policy=foobar --remove-rich-rule='rule family=ipv6 forward-port port=444 protocol=udp to-port=4444'], 0, [ignore], [ignore])
 FWD_CHECK([--permanent --policy=foobar --remove-egress-zone HOST], 0, [ignore])
+FWD_CHECK([--policy=foobar --remove-forward-port port=22:proto=tcp:toport=2222:toaddr=10.0.0.1], 0, [ignore], [ignore])
+FWD_CHECK([--policy=foobar --remove-rich-rule='rule family=ipv4 forward-port port=444 protocol=udp to-port=4444 to-addr=10.44.44.44'], 0, [ignore], [ignore])
 FWD_CHECK([--policy=foobar --remove-forward-port port=22:proto=tcp:toport=2222], 0, [ignore], [ignore])
 FWD_CHECK([--policy=foobar --remove-rich-rule='rule family=ipv6 forward-port port=444 protocol=udp to-port=4444'], 0, [ignore], [ignore])
 FWD_CHECK([--policy=foobar --remove-egress-zone HOST], 0, [ignore])


### PR DESCRIPTION
If the destination address is the host then this is necessary. A policy with egress-zone=ANY does not work because the policy dispatch will match the egress zones "source" in the destination address.