### PR TITLE
test(functions): nftables: normalize icmp reject codes

### DIFF
--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -473,6 +473,9 @@ m4_define([NFT_LIST_RULES_NORMALIZE], [dnl
         -e ['s/reject$/reject with icmp port-unreachable/g'] dnl
         dnl newer nft always outputs the default value of "burst"
         -e ['s/burst 5 packets //g'] dnl
+        dnl newer nft replace ICMP reject aliases with code values
+        dnl nftables commit 5fecd2a6ef61 ("src: disentangle ICMP code types")
+        -e ['s/\(icmp\|icmpv6\|icmpx\) code no-route/\1 code 0/g'] dnl
 ])
 
 m4_define([NFT_LIST_RULES_ALWAYS], [

--- a/src/tests/regression/rhbz1855140.at
+++ b/src/tests/regression/rhbz1855140.at
@@ -9,7 +9,7 @@ FWD_RELOAD
 NFT_LIST_RULES([inet], [mangle_PRE_public_allow], 0, [dnl
     table inet firewalld {
         chain mangle_PRE_public_allow {
-            icmpv6 parameter-problem icmpv6 code no-route mark set mark & 0x00000086 ^ 0x00000086
+            icmpv6 parameter-problem icmpv6 code 0 mark set mark & 0x00000086 ^ 0x00000086
         }
     }
 ])


### PR DESCRIPTION
This changed in nftables commit 5fecd2a6ef61 ("src: disentangle ICMP code types").