### PR TITLE
fix(service): update highest port number for ceph

### DIFF
--- a/config/services/ceph.xml
+++ b/config/services/ceph.xml
@@ -2,5 +2,5 @@
 <service>
   <short>ceph</short>
   <description>Ceph is a distributed object store and file system. Enable this option to support Ceph's Object Storage Daemons (OSD), Metadata Server Daemons (MDS), or Manager Daemons (MGR).</description>
-  <port protocol="tcp" port="6800-7300"/>
+  <port protocol="tcp" port="6800-7568"/>
 </service>


### PR DESCRIPTION
The highest port number used by Ceph was updated in https://github.com/ceph/ceph/pull/42210.

Fixes https://github.com/firewalld/firewalld/issues/1329