### PR TITLE
improvement(service): transmission-client: Add 9091/tcp

### DIFF
--- a/config/services/transmission-client.xml
+++ b/config/services/transmission-client.xml
@@ -2,6 +2,7 @@
 <service>
   <short>Transmission</short>
   <description>Transmission is a lightweight BitTorrent client.</description>
+  <port protocol="tcp" port="9091"/>
   <port protocol="tcp" port="51413"/>
   <port protocol="udp" port="51413"/>
 </service>


### PR DESCRIPTION
Transmission client (as well as daemon) uses 9091 by default for its remote web interface.