### PR TITLE
fix(polkit): allow 60 seconds for authorization

### DIFF
--- a/src/firewall/server/decorators.py
+++ b/src/firewall/server/decorators.py
@@ -232,7 +232,12 @@ class dbus_polkit_require_auth:
                 # use polkit if it's available
                 if type(self)._interface_polkit:
                     (result, _, _) = type(self)._interface_polkit.CheckAuthorization(
-                        ("system-bus-name", {"name": sender}), action_id, {}, 1, ""
+                        ("system-bus-name", {"name": sender}),
+                        action_id,
+                        {},
+                        1,
+                        "",
+                        timeout=60,
                     )
                     if not result:
                         raise NotAuthorizedException(action_id, "polkit")


### PR DESCRIPTION
Allow up to 60 seconds for polkit authorization. The current default is 25 seconds which can be a bit short for a user to type a password.

Fixes: #1328