### PR TITLE
feat(IPv6_filter): support loose and forward-only RPF checks

### DIFF
--- a/config/firewalld.conf
+++ b/config/firewalld.conf
@@ -19,14 +19,19 @@ CleanupOnExit=yes
 CleanupModulesOnExit=no
 
 # IPv6_rpfilter
-# Performs a reverse path filter test on a packet for IPv6. If a reply to the
-# packet would be sent via the same interface that the packet arrived on, the
-# packet will match and be accepted, otherwise dropped.
+# Performs reverse path filtering (RPF) on IPv6 packets as per RFC 3704.
+# Possible values:
+#   - strict: Performs "strict" filtering as per RFC 3704. This check
+#             verifies that the in ingress interface is the same interface
+#             that would be used to send a packet reply to the source. That
+#             is, ingress == egress.      
+#   - no: RPF is completely disabled.
+#
 # The rp_filter for IPv4 is controlled using sysctl.
 # Note: This feature has a performance impact. See man page FIREWALLD.CONF(5)
 # for details.
-# Default: yes
-IPv6_rpfilter=yes
+# Default: strict
+IPv6_rpfilter=strict
 
 # IndividualCalls
 # Do not use combined -restore calls, but individual calls. This increases the

--- a/config/firewalld.conf
+++ b/config/firewalld.conf
@@ -29,6 +29,8 @@ CleanupModulesOnExit=no
 #            verifies that there is a route back to the source through any
 #            interface; even if it's not the same one on which the packet
 #            arrived.
+#   - strict-forward: This is almost identical to "strict", but does not perform
+#                     RPF for packets targeted to the host (INPUT).
 #   - loose-forward: This is almost identical to "loose", but does not perform
 #                    RPF for packets targeted to the host (INPUT).
 #   - no: RPF is completely disabled.

--- a/config/firewalld.conf
+++ b/config/firewalld.conf
@@ -25,6 +25,10 @@ CleanupModulesOnExit=no
 #             verifies that the in ingress interface is the same interface
 #             that would be used to send a packet reply to the source. That
 #             is, ingress == egress.      
+#   - loose: Performs "loose" filtering as per RFC 3704. This check only
+#            verifies that there is a route back to the source through any
+#            interface; even if it's not the same one on which the packet
+#            arrived.
 #   - no: RPF is completely disabled.
 #
 # The rp_filter for IPv4 is controlled using sysctl.

--- a/config/firewalld.conf
+++ b/config/firewalld.conf
@@ -29,6 +29,8 @@ CleanupModulesOnExit=no
 #            verifies that there is a route back to the source through any
 #            interface; even if it's not the same one on which the packet
 #            arrived.
+#   - loose-forward: This is almost identical to "loose", but does not perform
+#                    RPF for packets targeted to the host (INPUT).
 #   - no: RPF is completely disabled.
 #
 # The rp_filter for IPv4 is controlled using sysctl.

--- a/doc/xml/firewalld.conf.xml
+++ b/doc/xml/firewalld.conf.xml
@@ -112,6 +112,8 @@
 	               verifies that there is a route back to the source through any
 	               interface; even if it's not the same one on which the packet
 	               arrived.
+	      - loose-forward: This is almost identical to "loose", but does not perform
+	                       RPF for packets targeted to the host (INPUT).
 	      - no: RPF is completely disabled.
 
 	    The rp_filter for IPv4 is controlled using sysctl.

--- a/doc/xml/firewalld.conf.xml
+++ b/doc/xml/firewalld.conf.xml
@@ -112,6 +112,8 @@
 	               verifies that there is a route back to the source through any
 	               interface; even if it's not the same one on which the packet
 	               arrived.
+	      - strict-forward: This is almost identical to "loose", but does not perform
+	                        RPF for packets targeted to the host (INPUT).
 	      - loose-forward: This is almost identical to "loose", but does not perform
 	                       RPF for packets targeted to the host (INPUT).
 	      - no: RPF is completely disabled.
@@ -125,7 +127,8 @@
         the established connections fast path. As such it can have a
         significant performance impact if there is a lot of traffic. It's
         enabled by default for security, but can be disabled if performance is
-        a concern.
+	a concern. Alternatively one of the variants that only does RPF on
+	forwarded packets may be used.
       </para>
 	</listitem>
       </varlistentry>

--- a/doc/xml/firewalld.conf.xml
+++ b/doc/xml/firewalld.conf.xml
@@ -108,6 +108,10 @@
 	                verifies that the in ingress interface is the same interface
 	                that would be used to send a packet reply to the source. That
 	                is, ingress == egress.      
+	      - loose: Performs "loose" filtering as per RFC 3704. This check only
+	               verifies that there is a route back to the source through any
+	               interface; even if it's not the same one on which the packet
+	               arrived.
 	      - no: RPF is completely disabled.
 
 	    The rp_filter for IPv4 is controlled using sysctl.

--- a/doc/xml/firewalld.conf.xml
+++ b/doc/xml/firewalld.conf.xml
@@ -102,9 +102,15 @@
 	<term><option>IPv6_rpfilter</option></term>
         <listitem>
 	  <para>
-	    If this option is enabled (it is by default), reverse path filter test on a packet for IPv6 is performed.
-	    If a reply to the packet would be sent via the same interface that the packet arrived on, the packet will match and be accepted, otherwise dropped.
-            For IPv4 the rp_filter is controlled using sysctl.
+	    Performs reverse path filtering (RPF) on IPv6 packets as per RFC 3704.
+	    Possible values:
+	      - strict: Performs "strict" filtering as per RFC 3704. This check
+	                verifies that the in ingress interface is the same interface
+	                that would be used to send a packet reply to the source. That
+	                is, ingress == egress.      
+	      - no: RPF is completely disabled.
+
+	    The rp_filter for IPv4 is controlled using sysctl.
 	  </para>
       <para>
         <emphasis role="bold">Note</emphasis>: This feature has a performance

--- a/doc/xml/firewalld.dbus.xml
+++ b/doc/xml/firewalld.dbus.xml
@@ -2545,8 +2545,12 @@
             </listitem>
           </varlistentry>
           <varlistentry id="FirewallD1.config.Properties.IPv6_rpfilter">
-            <term><parameter>IPv6_rpfilter</parameter> - s - (rw)</term>
-            <listitem><para>Indicates whether the reverse path filter test on a packet for IPv6 is enabled. If a reply to the packet would be sent via the same interface that the packet arrived on, the packet will match and be accepted, otherwise dropped.</para></listitem>
+            <term><parameter>IPv6_rpfilter</parameter> - b - (rw)</term>
+            <listitem><para>Deprecated. See <link linkend="FirewallD1.config.Properties.IPv6_rpfilter2">org.fedoraproject.FirewallD1.config.Properties.IPv6_rpfilter2</link>.</para></listitem>
+          </varlistentry>
+          <varlistentry id="FirewallD1.config.Properties.IPv6_rpfilter2">
+            <term><parameter>IPv6_rpfilter2</parameter> - s - (rw)</term>
+            <listitem><para>Indicates whether the reverse path filter (RFE 3704) test on a packet for IPv6 is enabled.</para></listitem>
           </varlistentry>
           <varlistentry id="FirewallD1.config.Properties.IndividualCalls">
             <term><parameter>IndividualCalls</parameter> - s - (ro)</term>

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -111,7 +111,7 @@ COMMANDS = {
 LOG_DENIED_VALUES = ["all", "unicast", "broadcast", "multicast", "off"]
 AUTOMATIC_HELPERS_VALUES = ["yes", "no", "system"]
 FIREWALL_BACKEND_VALUES = ["nftables", "iptables"]
-IPV6_RPFILTER_VALUES = ["yes", "true", "no", "false", "strict"]
+IPV6_RPFILTER_VALUES = ["yes", "true", "no", "false", "strict", "loose"]
 
 # fallbacks: will be overloaded by firewalld.conf
 FALLBACK_ZONE = "public"

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -111,13 +111,14 @@ COMMANDS = {
 LOG_DENIED_VALUES = ["all", "unicast", "broadcast", "multicast", "off"]
 AUTOMATIC_HELPERS_VALUES = ["yes", "no", "system"]
 FIREWALL_BACKEND_VALUES = ["nftables", "iptables"]
+IPV6_RPFILTER_VALUES = ["yes", "true", "no", "false", "strict"]
 
 # fallbacks: will be overloaded by firewalld.conf
 FALLBACK_ZONE = "public"
 FALLBACK_MINIMAL_MARK = 100
 FALLBACK_CLEANUP_ON_EXIT = True
 FALLBACK_CLEANUP_MODULES_ON_EXIT = False
-FALLBACK_IPV6_RPFILTER = True
+FALLBACK_IPV6_RPFILTER = "strict"
 FALLBACK_INDIVIDUAL_CALLS = False
 FALLBACK_LOG_DENIED = "off"
 FALLBACK_AUTOMATIC_HELPERS = "no"

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -119,6 +119,7 @@ IPV6_RPFILTER_VALUES = [
     "strict",
     "loose",
     "loose-forward",
+    "strict-forward",
 ]
 
 # fallbacks: will be overloaded by firewalld.conf

--- a/src/firewall/config/__init__.py.in
+++ b/src/firewall/config/__init__.py.in
@@ -111,7 +111,15 @@ COMMANDS = {
 LOG_DENIED_VALUES = ["all", "unicast", "broadcast", "multicast", "off"]
 AUTOMATIC_HELPERS_VALUES = ["yes", "no", "system"]
 FIREWALL_BACKEND_VALUES = ["nftables", "iptables"]
-IPV6_RPFILTER_VALUES = ["yes", "true", "no", "false", "strict", "loose"]
+IPV6_RPFILTER_VALUES = [
+    "yes",
+    "true",
+    "no",
+    "false",
+    "strict",
+    "loose",
+    "loose-forward",
+]
 
 # fallbacks: will be overloaded by firewalld.conf
 FALLBACK_ZONE = "public"

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -411,6 +411,8 @@ class Firewall:
                         self._ipv6_rpfilter = "strict"
                     elif value.lower() in ["loose"]:
                         self._ipv6_rpfilter = "loose"
+                    elif value.lower() in ["loose-forward"]:
+                        self._ipv6_rpfilter = "loose-forward"
                 log.debug1(f"IPv6_rpfilter is set to '{self._ipv6_rpfilter}'")
 
             if self._firewalld_conf.get("IndividualCalls"):

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -413,6 +413,8 @@ class Firewall:
                         self._ipv6_rpfilter = "loose"
                     elif value.lower() in ["loose-forward"]:
                         self._ipv6_rpfilter = "loose-forward"
+                    elif value.lower() in ["strict-forward"]:
+                        self._ipv6_rpfilter = "strict-forward"
                 log.debug1(f"IPv6_rpfilter is set to '{self._ipv6_rpfilter}'")
 
             if self._firewalld_conf.get("IndividualCalls"):

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -409,6 +409,8 @@ class Firewall:
                         self._ipv6_rpfilter = "no"
                     elif value.lower() in ["yes", "true", "strict"]:
                         self._ipv6_rpfilter = "strict"
+                    elif value.lower() in ["loose"]:
+                        self._ipv6_rpfilter = "loose"
                 log.debug1(f"IPv6_rpfilter is set to '{self._ipv6_rpfilter}'")
 
             if self._firewalld_conf.get("IndividualCalls"):

--- a/src/firewall/core/io/firewalld_conf.py
+++ b/src/firewall/core/io/firewalld_conf.py
@@ -74,7 +74,7 @@ class firewalld_conf:
             "CleanupModulesOnExit",
             "yes" if config.FALLBACK_CLEANUP_MODULES_ON_EXIT else "no",
         )
-        self.set("IPv6_rpfilter", "yes" if config.FALLBACK_IPV6_RPFILTER else "no")
+        self.set("IPv6_rpfilter", config.FALLBACK_IPV6_RPFILTER)
         self.set("IndividualCalls", "yes" if config.FALLBACK_INDIVIDUAL_CALLS else "no")
         self.set("LogDenied", config.FALLBACK_LOG_DENIED)
         self.set("AutomaticHelpers", config.FALLBACK_AUTOMATIC_HELPERS)
@@ -178,14 +178,14 @@ class firewalld_conf:
 
         # check ipv6_rpfilter
         value = self.get("IPv6_rpfilter")
-        if not value or value.lower() not in ["yes", "true", "no", "false"]:
+        if not value or value.lower() not in config.IPV6_RPFILTER_VALUES:
             if value is not None:
                 log.warning(
                     "IPv6_rpfilter '%s' is not valid, using default " "value %s",
                     value if value else "",
                     config.FALLBACK_IPV6_RPFILTER,
                 )
-            self.set("IPv6_rpfilter", "yes" if config.FALLBACK_IPV6_RPFILTER else "no")
+            self.set("IPv6_rpfilter", config.FALLBACK_IPV6_RPFILTER)
 
         # check individual calls
         value = self.get("IndividualCalls")

--- a/src/firewall/core/io/firewalld_conf.py
+++ b/src/firewall/core/io/firewalld_conf.py
@@ -94,13 +94,13 @@ class firewalld_conf:
         )
 
     def sanity_check(self):
-        if (
-            self.get("FirewallBackend") == "iptables"
-            and self.get("IPv6_rpfilter") == "loose-forward"
+        if self.get("FirewallBackend") == "iptables" and self.get("IPv6_rpfilter") in (
+            "loose-forward",
+            "strict-forward",
         ):
             raise errors.FirewallError(
                 errors.INVALID_VALUE,
-                "IPv6_rpfilter=loose-forward is incompatible "
+                f"IPv6_rpfilter={self.get('IPv6_rpfilter')} is incompatible "
                 "with FirewallBackend=iptables. This is a limitation "
                 "of the iptables backend.",
             )

--- a/src/firewall/core/ipXtables.py
+++ b/src/firewall/core/ipXtables.py
@@ -1782,16 +1782,19 @@ class ip6tables(ip4tables):
 
     def build_rpfilter_rules(self, log_denied=False):
         rules = []
+        rpfilter_fragment = ["-m", "rpfilter", "--invert", "--validmark"]
+        if self._fw._ipv6_rpfilter == "loose":
+            rpfilter_fragment += ["--loose"]
+
         rules.append(
             [
                 "-I",
                 "PREROUTING",
                 "-t",
                 "mangle",
-                "-m",
-                "rpfilter",
-                "--invert",
-                "--validmark",
+            ]
+            + rpfilter_fragment
+            + [
                 "-j",
                 "DROP",
             ]
@@ -1803,10 +1806,9 @@ class ip6tables(ip4tables):
                     "PREROUTING",
                     "-t",
                     "mangle",
-                    "-m",
-                    "rpfilter",
-                    "--invert",
-                    "--validmark",
+                ]
+                + rpfilter_fragment
+                + [
                     "-j",
                     "LOG",
                     "--log-prefix",

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -2492,6 +2492,12 @@ class nftables:
 
     def build_rpfilter_rules(self, log_denied=False):
         rules = []
+
+        if self._fw._ipv6_rpfilter == "loose":
+            fib_flags = ["saddr", "mark"]
+        else:
+            fib_flags = ["saddr", "mark", "iif"]
+
         expr_fragments = [
             {
                 "match": {
@@ -2502,9 +2508,7 @@ class nftables:
             },
             {
                 "match": {
-                    "left": {
-                        "fib": {"flags": ["saddr", "iif", "mark"], "result": "oif"}
-                    },
+                    "left": {"fib": {"flags": fib_flags, "result": "oif"}},
                     "op": "==",
                     "right": False,
                 }

--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -2499,6 +2499,9 @@ class nftables:
         elif self._fw._ipv6_rpfilter == "loose-forward":
             fib_flags = ["saddr", "mark"]
             rpfilter_chain = "filter_FORWARD"
+        elif self._fw._ipv6_rpfilter == "strict-forward":
+            fib_flags = ["saddr", "mark", "iif"]
+            rpfilter_chain = "filter_FORWARD"
         else:
             fib_flags = ["saddr", "mark", "iif"]
 
@@ -2535,7 +2538,7 @@ class nftables:
             }
         )
         # RHBZ#1058505, RHBZ#1575431 (bug in kernel 4.16-4.17)
-        if self._fw._ipv6_rpfilter != "loose-forward":
+        if self._fw._ipv6_rpfilter not in ("loose-forward", "strict-forward"):
             # this rule doesn't make sense for forwarded packets
             rules.append(
                 {
@@ -2620,7 +2623,7 @@ class nftables:
             forward_index += 1
         if self._fw.get_log_denied() != "off":
             forward_index += 1
-        if self._fw._ipv6_rpfilter == "loose-forward":
+        if self._fw._ipv6_rpfilter in ("loose-forward", "strict-forward"):
             forward_index += 1
         rules.append(
             {

--- a/src/firewall/server/config.py
+++ b/src/firewall/server/config.py
@@ -65,7 +65,8 @@ CONFIG_PROPERTIES = {
     "MinimalMark": ConfigPropertiesTuple("readwrite", True, True),
     "CleanupOnExit": ConfigPropertiesTuple("readwrite", False, False),
     "CleanupModulesOnExit": ConfigPropertiesTuple("readwrite", False, False),
-    "IPv6_rpfilter": ConfigPropertiesTuple("readwrite", False, False),
+    "IPv6_rpfilter": ConfigPropertiesTuple("readwrite", True, False),
+    "IPv6_rpfilter2": ConfigPropertiesTuple("readwrite", False, False),
     "Lockdown": ConfigPropertiesTuple("readwrite", True, True),
     "IndividualCalls": ConfigPropertiesTuple("readwrite", False, False),
     "LogDenied": ConfigPropertiesTuple("readwrite", False, False),
@@ -619,8 +620,13 @@ class FirewallDConfig(DbusServiceObject):
             # Deprecated and dropped.
             return dbus.String("no")
         elif prop == "IPv6_rpfilter":
+            if value is None or value != "no":
+                return dbus.String("yes")
+            else:
+                return dbus.String("no")
+        elif prop == "IPv6_rpfilter2":
             if value is None:
-                value = "yes" if config.FALLBACK_IPV6_RPFILTER else "no"
+                value = config.FALLBACK_IPV6_RPFILTER
             return dbus.String(value)
         elif prop == "IndividualCalls":
             if value is None:
@@ -756,6 +762,12 @@ class FirewallDConfig(DbusServiceObject):
                         )
                 elif property_name == "FirewallBackend":
                     if new_value not in config.FIREWALL_BACKEND_VALUES:
+                        raise FirewallError(
+                            errors.INVALID_VALUE,
+                            "'%s' for %s" % (new_value, property_name),
+                        )
+                elif property_name == "IPv6_rpfilter2":
+                    if new_value not in config.IPV6_RPFILTER_VALUES:
                         raise FirewallError(
                             errors.INVALID_VALUE,
                             "'%s' for %s" % (new_value, property_name),

--- a/src/firewall/server/firewalld.py
+++ b/src/firewall/server/firewalld.py
@@ -143,7 +143,7 @@ class FirewallD(DbusServiceObject):
             return dbus.Boolean(self.fw.is_ipv_enabled("ipv6"))
 
         elif prop == "IPv6_rpfilter":
-            return dbus.Boolean(self.fw.ipv6_rpfilter_enabled)
+            return dbus.Boolean(False if self.fw._ipv6_rpfilter == "no" else True)
 
         elif prop == "IPv6ICMPTypes":
             return dbus.Array(self.fw.ipv6_supported_icmp_types, "s")

--- a/src/tests/dbus/firewalld.conf.at
+++ b/src/tests/dbus/firewalld.conf.at
@@ -3,8 +3,10 @@ AT_KEYWORDS(dbus)
 
 IF_HOST_SUPPORTS_NFT_FIB([
    EXPECTED_IPV6_RPFILTER_VALUE=yes
+   EXPECTED_IPV6_RPFILTER2_VALUE=strict
 ], [
    EXPECTED_IPV6_RPFILTER_VALUE=no
+   EXPECTED_IPV6_RPFILTER2_VALUE=no
 ])
 
 IF_HOST_SUPPORTS_NFT_RULE_INDEX([
@@ -23,6 +25,7 @@ string "DefaultZone" : variant string "public"
 string "FirewallBackend" : variant string "nftables"
 string "FlushAllOnReload" : variant string "yes"
 string "IPv6_rpfilter" : variant string m4_escape(["${EXPECTED_IPV6_RPFILTER_VALUE}"])
+string "IPv6_rpfilter2" : variant string m4_escape(["${EXPECTED_IPV6_RPFILTER2_VALUE}"])
 string "IndividualCalls" : variant string m4_escape(["${EXPECTED_INDIVIDUAL_CALLS_VALUE}"])
 string "Lockdown" : variant string "no"
 string "LogDenied" : variant string "off"
@@ -46,6 +49,7 @@ _helper([Lockdown], [string:"no"], [variant string "no"])
 _helper([Lockdown], [string:"yes"], [variant string "no"])
 _helper([LogDenied], [string:"all"], [variant string "all"])
 _helper([IPv6_rpfilter], [string:"yes"], [variant string "yes"])
+_helper([IPv6_rpfilter2], [string:"no"], [variant string "no"])
 _helper([IndividualCalls], [string:"yes"], [variant string "yes"])
 _helper([FirewallBackend], [string:"iptables"], [variant string "iptables"])
 _helper([FlushAllOnReload], [string:"no"], [variant string "no"])

--- a/src/tests/features/rpfilter.at
+++ b/src/tests/features/rpfilter.at
@@ -2,7 +2,7 @@ FWD_START_TEST([rpfilter - strict])
 AT_KEYWORDS(rpfilter)
 CHECK_NFTABLES_FIB()
 
-AT_CHECK([sed -i 's/^IPv6_rpfilter.*/IPv6_rpfilter=yes/' ./firewalld.conf])
+AT_CHECK([sed -i 's/^IPv6_rpfilter.*/IPv6_rpfilter=strict/' ./firewalld.conf])
 FWD_RELOAD()
 
 NFT_LIST_RULES([inet], [filter_PREROUTING], 0, [dnl

--- a/src/tests/features/rpfilter.at
+++ b/src/tests/features/rpfilter.at
@@ -1,22 +1,17 @@
-FWD_START_TEST([rpfilter])
+FWD_START_TEST([rpfilter - strict])
 AT_KEYWORDS(rpfilter)
+CHECK_NFTABLES_FIB()
 
-IF_HOST_SUPPORTS_NFT_FIB([
-    NFT_LIST_RULES([inet], [filter_PREROUTING], 0, [dnl
-        table inet firewalld {
-            chain filter_PREROUTING {
-                icmpv6 type { nd-router-advert, nd-neighbor-solicit } accept
-                meta nfproto ipv6 fib saddr . mark . iif oif missing drop
-            }
+AT_CHECK([sed -i 's/^IPv6_rpfilter.*/IPv6_rpfilter=yes/' ./firewalld.conf])
+FWD_RELOAD()
+
+NFT_LIST_RULES([inet], [filter_PREROUTING], 0, [dnl
+    table inet firewalld {
+        chain filter_PREROUTING {
+            icmpv6 type { nd-router-advert, nd-neighbor-solicit } accept
+            meta nfproto ipv6 fib saddr . mark . iif oif missing drop
         }
-    ])
-], [
-    NFT_LIST_RULES([inet], [filter_PREROUTING], 0, [dnl
-        table inet firewalld {
-            chain filter_PREROUTING {
-            }
-        }
-    ])
+    }
 ])
 
 IP6TABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl

--- a/src/tests/features/rpfilter.at
+++ b/src/tests/features/rpfilter.at
@@ -50,6 +50,42 @@ IP6TABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl
 
 FWD_END_TEST()
 
+FWD_START_TEST([rpfilter - strict-forward])
+AT_KEYWORDS(rpfilter)
+CHECK_NFTABLES_FIB()
+CHECK_NFTABLES_FIB_IN_FORWARD()
+
+AT_CHECK([sed -i 's/^IPv6_rpfilter.*/IPv6_rpfilter=strict-forward/' ./firewalld.conf])
+m4_if(iptables, FIREWALL_BACKEND, [
+FWD_RELOAD(114, [ignore], [ignore])
+], [
+FWD_RELOAD()
+])
+
+NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
+    table inet firewalld {
+        chain filter_FORWARD {
+            meta nfproto ipv6 fib saddr . mark . iif oif missing drop
+            ct state established,related accept
+            ct status dnat accept
+            iifname "lo" accept
+            ct state invalid drop
+            ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } reject with icmpv6 addr-unreachable
+            jump filter_FORWARD_POLICIES
+            reject with icmpx admin-prohibited
+        }
+    }
+])
+
+NFT_LIST_RULES([inet], [filter_PREROUTING], 0, [dnl
+    table inet firewalld {
+        chain filter_PREROUTING {
+        }
+    }
+])
+
+FWD_END_TEST([-e "/^ERROR: INVALID_VALUE:/d"])
+
 FWD_START_TEST([rpfilter - loose-forward])
 AT_KEYWORDS(rpfilter)
 CHECK_NFTABLES_FIB()

--- a/src/tests/features/rpfilter.at
+++ b/src/tests/features/rpfilter.at
@@ -24,6 +24,32 @@ IP6TABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl
 
 FWD_END_TEST()
 
+FWD_START_TEST([rpfilter - loose])
+AT_KEYWORDS(rpfilter)
+CHECK_NFTABLES_FIB()
+
+AT_CHECK([sed -i 's/^IPv6_rpfilter.*/IPv6_rpfilter=loose/' ./firewalld.conf])
+FWD_RELOAD()
+
+NFT_LIST_RULES([inet], [filter_PREROUTING], 0, [dnl
+    table inet firewalld {
+        chain filter_PREROUTING {
+            icmpv6 type { nd-router-advert, nd-neighbor-solicit } accept
+            meta nfproto ipv6 fib saddr . mark oif missing drop
+        }
+    }
+])
+
+IP6TABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl
+    ACCEPT 58 -- ::/0 ::/0 ipv6-icmptype 134
+    ACCEPT 58 -- ::/0 ::/0 ipv6-icmptype 135
+    DROP 0 -- ::/0 ::/0 rpfilter loose validmark invert
+    PREROUTING_direct 0 -- ::/0 ::/0
+    PREROUTING_POLICIES 0 -- ::/0 ::/0
+])
+
+FWD_END_TEST()
+
 FWD_START_TEST([rpfilter - config values])
 AT_KEYWORDS(rpfilter)
 CHECK_NFTABLES_FIB()

--- a/src/tests/features/rpfilter.at
+++ b/src/tests/features/rpfilter.at
@@ -22,4 +22,20 @@ IP6TABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl
     PREROUTING_POLICIES 0 -- ::/0 ::/0
 ])
 
-FWD_END_TEST
+FWD_END_TEST()
+
+FWD_START_TEST([rpfilter - config values])
+AT_KEYWORDS(rpfilter)
+CHECK_NFTABLES_FIB()
+
+dnl Verify other/deprecated configuration values are accepted.
+dnl
+m4_foreach([VALUE], [[no], [yes], [false], [true]], [
+    AT_CHECK([sed -i 's/^IPv6_rpfilter.*/IPv6_rpfilter=VALUE/' ./firewalld.conf])
+    FWD_RELOAD()
+])
+dnl And a bogus one.
+AT_CHECK([sed -i 's/^IPv6_rpfilter.*/IPv6_rpfilter=bogus/' ./firewalld.conf])
+FWD_RELOAD()
+
+FWD_END_TEST([-e "/^WARNING: IPv6_rpfilter 'bogus' is not valid/d"])

--- a/src/tests/features/rpfilter.at
+++ b/src/tests/features/rpfilter.at
@@ -50,6 +50,42 @@ IP6TABLES_LIST_RULES([mangle], [PREROUTING], 0, [dnl
 
 FWD_END_TEST()
 
+FWD_START_TEST([rpfilter - loose-forward])
+AT_KEYWORDS(rpfilter)
+CHECK_NFTABLES_FIB()
+CHECK_NFTABLES_FIB_IN_FORWARD()
+
+AT_CHECK([sed -i 's/^IPv6_rpfilter.*/IPv6_rpfilter=loose-forward/' ./firewalld.conf])
+m4_if(iptables, FIREWALL_BACKEND, [
+FWD_RELOAD(114, [ignore], [ignore])
+], [
+FWD_RELOAD()
+])
+
+NFT_LIST_RULES([inet], [filter_FORWARD], 0, [dnl
+    table inet firewalld {
+        chain filter_FORWARD {
+            meta nfproto ipv6 fib saddr . mark oif missing drop
+            ct state established,related accept
+            ct status dnat accept
+            iifname "lo" accept
+            ct state invalid drop
+            ip6 daddr { ::/96, ::ffff:0.0.0.0/96, 2002::/24, 2002:a00::/24, 2002:7f00::/24, 2002:a9fe::/32, 2002:ac10::/28, 2002:c0a8::/32, 2002:e000::/19 } reject with icmpv6 addr-unreachable
+            jump filter_FORWARD_POLICIES
+            reject with icmpx admin-prohibited
+        }
+    }
+])
+
+NFT_LIST_RULES([inet], [filter_PREROUTING], 0, [dnl
+    table inet firewalld {
+        chain filter_PREROUTING {
+        }
+    }
+])
+
+FWD_END_TEST([-e "/^ERROR: INVALID_VALUE:/d"])
+
 FWD_START_TEST([rpfilter - config values])
 AT_KEYWORDS(rpfilter)
 CHECK_NFTABLES_FIB()

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -787,3 +787,9 @@ m4_define([SKIP_IF_FW_IN_CONTAINER_WITH_NFTABLES], [
         SKIP_IF_FW_IN_CONTAINER
     ])
 ])
+
+m4_define([CHECK_NFTABLES_FIB], [
+    m4_if(nftables, FIREWALL_BACKEND, [
+        IF_HOST_SUPPORTS_NFT_FIB([], [AT_SKIP_IF([:])])
+    ])
+])

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -793,3 +793,12 @@ m4_define([CHECK_NFTABLES_FIB], [
         IF_HOST_SUPPORTS_NFT_FIB([], [AT_SKIP_IF([:])])
     ])
 ])
+
+m4_define([CHECK_NFTABLES_FIB_IN_FORWARD], [
+    m4_if(nftables, FIREWALL_BACKEND, [
+        NS_CHECK([nft add table inet firewalld_check])
+        NS_CHECK([nft add chain inet firewalld_check foobar { type filter hook forward priority 0 \; }])
+        AT_SKIP_IF([! NS_CMD([nft add rule inet firewalld_check foobar meta nfproto ipv6 fib saddr . mark . iif oif missing drop >/dev/null 2>&1])])
+        NS_CHECK([nft delete table inet firewalld_check])
+    ])
+])


### PR DESCRIPTION
After these changes rpfilter supports the below options.

```
# IPv6_rpfilter
# Performs reverse path filtering (RPF) on IPv6 packets as per RFC 3704.
# Possible values:
#   - strict: Performs "strict" filtering as per RFC 3704. This check
#             verifies that the in ingress interface is the same interface
#             that would be used to send a packet reply to the source. That
#             is, ingress == egress.      
#   - loose: Performs "loose" filtering as per RFC 3704. This check only
#            verifies that there is a route back to the source through any
#            interface; even if it's not the same one on which the packet
#            arrived.
#   - strict-forward: This is almost identical to "strict", but does not perform
#                     RPF for packets targeted to the host (INPUT).
#   - loose-forward: This is almost identical to "loose", but does not perform
#                    RPF for packets targeted to the host (INPUT).
#   - no: RPF is completely disabled.
#
# The rp_filter for IPv4 is controlled using sysctl.
# Note: This feature has a performance impact. See man page FIREWALLD.CONF(5)
# for details.
# Default: strict
IPv6_rpfilter=strict
```