### PR TITLE
feat(service): Add Steam local network transfers service

### DIFF
--- a/config/services/steam-local-transfer.xml
+++ b/config/services/steam-local-transfer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Steam Local Network Game Transfers</short>
+  <description>Local network game transfers allow for Steam users to copy existing Steam game installation and update files from one PC to another over a local area network, without having to download and install from a Steam content server on the internet. This helps you stay below your ISP monthly transfer limits and can speed up installs or updates.</description>
+  <port protocol="tcp" port="27040"/>
+  <port protocol="udp" port="27031-27036"/>
+</service>


### PR DESCRIPTION
In the same way there is a service for In-Home streaming, I find useful to have a service for Local Network Game transfers.

The required ports come from the documentation here: https://help.steampowered.com/en/faqs/view/46BD-6BA8-B012-CE43