### PR TITLE
feat(service): stun and stuns protocols

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -331,6 +331,8 @@ CONFIG_FILES = \
 	services/steam-lan-transfer.xml \
 	services/stellaris.xml \
 	services/stronghold-crusader.xml \
+	services/stun.xml \
+	services/stuns.xml \
 	services/submission.xml \
 	services/supertuxkart.xml \
 	services/svdrp.xml \
@@ -350,6 +352,8 @@ CONFIG_FILES = \
 	services/tinc.xml \
 	services/tor-socks.xml \
 	services/transmission-client.xml \
+	services/turn.xml \
+	services/turns.xml \
 	services/upnp-client.xml \
 	services/vdsm.xml \
 	services/vnc-server.xml \

--- a/config/services/stun.xml
+++ b/config/services/stun.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>STUN and TURN</short>
+  <description>Session Traversal Utilities for NAT and Traversal Using Relay NAT protocols to get through firewalls and traverse NATs.</description>
+  <port protocol="tcp" port="3478"/>
+  <port protocol="udp" port="3478"/>
+</service>

--- a/config/services/stuns.xml
+++ b/config/services/stuns.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>STUN and TURN over TLS</short>
+  <description>Session Traversal Utilities for NAT and Traversal Using Relay NAT protocols to get through firewalls and traverse NATs using socket layer encryption.</description>
+  <port protocol="tcp" port="5349"/>
+  <port protocol="udp" port="5349"/>
+</service>

--- a/config/services/turn.xml
+++ b/config/services/turn.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>STUN and TURN</short>
+  <description>Session Traversal Utilities for NAT and Traversal Using Relay NAT protocols to get through firewalls and traverse NATs.</description>
+  <include service="stun"/>
+</service>

--- a/config/services/turns.xml
+++ b/config/services/turns.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>STUN and TURN over TLS</short>
+  <description>Session Traversal Utilities for NAT and Traversal Using Relay NAT protocols to get through firewalls and traverse NATs using socket layer encryption.</description>
+  <include service="stuns"/>
+</service>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -256,6 +256,8 @@ config/services/steam-streaming.xml
 config/services/steam-lan-transfer.xml
 config/services/stellaris.xml
 config/services/stronghold-crusader.xml
+config/services/stun.xml
+config/services/stuns.xml
 config/services/submission.xml
 config/services/supertuxkart.xml
 config/services/svdrp.xml
@@ -275,6 +277,8 @@ config/services/tile38.xml
 config/services/tinc.xml
 config/services/tor-socks.xml
 config/services/transmission-client.xml
+config/services/turn.xml
+config/services/turns.xml
 config/services/upnp-client.xml
 config/services/vdsm.xml
 config/services/vnc-server.xml


### PR DESCRIPTION
References:

STUN: [IETF RFC 8489](https://datatracker.ietf.org/doc/html/rfc8489)
TURN: [IETF RFC 8656](https://datatracker.ietf.org/doc/html/rfc8656)

STUN and TURN use the same ports and are very closely related and often end up used interchangeably.