### PR TITLE
fix(firewall-applet): Set fallback icons

### DIFF
--- a/src/firewall-applet.in
+++ b/src/firewall-applet.in
@@ -450,13 +450,16 @@ class TrayApplet(QtWidgets.QSystemTrayIcon):
         self.name = _("Firewall Applet")
         self.prog = "firewall-applet"
         self.icon_name = "firewall-applet"
+        self.normal_icon = QtGui.QIcon.fromTheme(self.icon_name)
         self.icons = {
-            "normal": QtGui.QIcon.fromTheme(self.icon_name),
+            "normal": self.normal_icon,
             "error": QtGui.QIcon.fromTheme(self.icon_name + "-error"),
             "panic": QtGui.QIcon.fromTheme(self.icon_name + "-panic"),
-            "normal-shields_up": QtGui.QIcon.fromTheme(self.icon_name + "-shields_up"),
+            "normal-shields_up": QtGui.QIcon.fromTheme(
+                self.icon_name + "-shields_up", self.normal_icon
+            ),
             "normal-shields_down": QtGui.QIcon.fromTheme(
-                self.icon_name + "-shields_down"
+                self.icon_name + "-shields_down", self.normal_icon
             ),
         }
         self.timer = None


### PR DESCRIPTION
Qt6 does not fallback to the normal icon if the -shields_up/-shields_down icons are missing, causing missing icons for the applet. Set the normal icon as fallback explicitly.