### PR TITLE
fix(firewall-config): Set width request for long label

### DIFF
--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -3437,6 +3437,7 @@
                                                 <property name="left_padding">6</property>
                                                 <child>
                                                   <object class="GtkBox" id="box9">
+                                                    <property name="width-request">250</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="orientation">vertical</property>


### PR DESCRIPTION
Adding a width request ensures that the height of the label on the ICMP Filter panel won't become too large. This fixes the problem that the height of the window cannot fit in a 1366x768 display.

Closes: https://github.com/firewalld/firewalld/issues/312