### PR TITLE
fix(firewall-config): Add long labels into a scrolled window

### DIFF
--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -3436,70 +3436,86 @@
                                                 <property name="can_focus">False</property>
                                                 <property name="left_padding">6</property>
                                                 <child>
-                                                  <object class="GtkBox" id="box9">
-                                                    <property name="width-request">250</property>
+                                                  <object class="GtkScrolledWindow">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="orientation">vertical</property>
-                                                    <property name="spacing">6</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="shadow_type">in</property>
                                                     <child>
-                                                      <object class="GtkLabel" id="label220">
+                                                      <object class="GtkViewport">
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">False</property>
-                                                        <property name="label" translatable="yes">Mark the ICMP types in the list, which should be rejected. All other ICMP types are allowed to pass the firewall. The default is no limitation.</property>
-                                                        <property name="wrap">True</property>
-                                                        <property name="xalign">0</property>
-                                                        <property name="yalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">False</property>
-                                                        <property name="position">0</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkLabel" id="label138">
-                                                        <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
-                                                        <property name="label" translatable="yes">If Invert Filter is enabled, marked ICMP entries are accepted and the others are rejected. In a zone with the target DROP, they are dropped.</property>
-                                                        <property name="use_markup">True</property>
-                                                        <property name="wrap">True</property>
-                                                        <property name="xalign">0</property>
-                                                        <property name="yalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">False</property>
-                                                        <property name="position">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkEventBox" id="icmpBlockInversionEventbox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
-                                                        <property name="halign">start</property>
-                                                        <property name="visible_window">False</property>
-                                                        <property name="above_child">True</property>
+                                                        <property name="margin_left">6</property>
+                                                        <property name="margin_right">6</property>
+                                                        <property name="margin_top">3</property>
+                                                        <property name="margin_bottom">3</property>
                                                         <child>
-                                                          <object class="GtkCheckButton" id="icmpBlockInversionCheck">
-                                                            <property name="label" translatable="yes">Invert Filter</property>
+                                                          <object class="GtkBox" id="box9">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">True</property>
-                                                            <property name="receives_default">False</property>
-                                                            <property name="valign">start</property>
-                                                            <property name="xalign">0</property>
-                                                            <property name="draw_indicator">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="orientation">vertical</property>
+                                                            <property name="spacing">6</property>
+                                                            <child>
+                                                              <object class="GtkLabel" id="label220">
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">False</property>
+                                                                <property name="label" translatable="yes">Mark the ICMP types in the list, which should be rejected. All other ICMP types are allowed to pass the firewall. The default is no limitation.</property>
+                                                                <property name="wrap">True</property>
+                                                                <property name="xalign">0</property>
+                                                                <property name="yalign">0</property>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="expand">False</property>
+                                                                <property name="fill">False</property>
+                                                                <property name="position">0</property>
+                                                              </packing>
+                                                            </child>
+                                                            <child>
+                                                              <object class="GtkLabel" id="label138">
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">False</property>
+                                                                <property name="label" translatable="yes">If Invert Filter is enabled, marked ICMP entries are accepted and the others are rejected. In a zone with the target DROP, they are dropped.</property>
+                                                                <property name="use_markup">True</property>
+                                                                <property name="wrap">True</property>
+                                                                <property name="xalign">0</property>
+                                                                <property name="yalign">0</property>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="expand">False</property>
+                                                                <property name="fill">False</property>
+                                                                <property name="position">1</property>
+                                                              </packing>
+                                                            </child>
+                                                            <child>
+                                                              <object class="GtkEventBox" id="icmpBlockInversionEventbox">
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">False</property>
+                                                                <property name="halign">start</property>
+                                                                <property name="visible_window">False</property>
+                                                                <property name="above_child">True</property>
+                                                                <child>
+                                                                  <object class="GtkCheckButton" id="icmpBlockInversionCheck">
+                                                                    <property name="label" translatable="yes">Invert Filter</property>
+                                                                    <property name="visible">True</property>
+                                                                    <property name="can_focus">True</property>
+                                                                    <property name="receives_default">False</property>
+                                                                    <property name="valign">start</property>
+                                                                    <property name="xalign">0</property>
+                                                                    <property name="draw_indicator">True</property>
+                                                                  </object>
+                                                                </child>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="expand">False</property>
+                                                                <property name="fill">True</property>
+                                                                <property name="position">2</property>
+                                                              </packing>
+                                                            </child>
+                                                            <child>
+                                                              <placeholder/>
+                                                            </child>
                                                           </object>
                                                         </child>
                                                       </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -6219,47 +6235,149 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="label91">
+                                          <object class="GtkPaned">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="label" translatable="yes">The priority is used to order rules. Priority 0 means add rule on top of the chain, with a higher priority the rule will be added further down. Rules with the same priority are on the same level and the order of these rules is not fixed and may change. If you want to make sure that a rule will be added after another one, use a low priority for the first and a higher for the following.</property>
-                                            <property name="wrap">True</property>
-                                            <property name="xalign">0</property>
-                                            <property name="yalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="hbox15">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="spacing">6</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="position">400</property>
+                                            <property name="position_set">True</property>
                                             <child>
-                                              <object class="GtkScrolledWindow" id="otherPortsSW7">
+                                              <object class="GtkBox" id="hbox15">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="shadow_type">out</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="spacing">6</property>
                                                 <child>
-                                                  <object class="GtkTreeView" id="directRuleView">
+                                                  <object class="GtkScrolledWindow" id="otherPortsSW7">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">True</property>
-                                                    <property name="enable_search">False</property>
-                                                    <signal name="button-press-event" handler="onRuleClicked" swapped="no"/>
-                                                    <child internal-child="selection">
-                                                      <object class="GtkTreeSelection" id="treeview-selection28"/>
+                                                    <property name="shadow_type">out</property>
+                                                    <child>
+                                                      <object class="GtkTreeView" id="directRuleView">
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="enable_search">False</property>
+                                                        <signal name="button-press-event" handler="onRuleClicked" swapped="no"/>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">True</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkButtonBox" id="directRulesButtonbox">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="spacing">6</property>
+                                                    <property name="layout_style">start</property>
+                                                    <child>
+                                                      <object class="GtkButton" id="addDirectRuleButton">
+                                                        <property name="label">gtk-add</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="focus_on_click">False</property>
+                                                        <property name="receives_default">True</property>
+                                                        <property name="has_tooltip">True</property>
+                                                        <property name="tooltip_text" translatable="yes">Add Rule</property>
+                                                        <property name="use_stock">True</property>
+                                                        <signal name="clicked" handler="onAddRule" swapped="no"/>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkButton" id="editDirectRuleButton">
+                                                        <property name="label">gtk-edit</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="sensitive">False</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="focus_on_click">False</property>
+                                                        <property name="receives_default">True</property>
+                                                        <property name="has_tooltip">True</property>
+                                                        <property name="tooltip_text" translatable="yes">Edit Rule</property>
+                                                        <property name="use_stock">True</property>
+                                                        <signal name="clicked" handler="onEditRule" swapped="no"/>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">1</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkButton" id="removeDirectRuleButton">
+                                                        <property name="label">gtk-remove</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="sensitive">False</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="focus_on_click">False</property>
+                                                        <property name="receives_default">True</property>
+                                                        <property name="has_tooltip">True</property>
+                                                        <property name="tooltip_text" translatable="yes">Remove Rule</property>
+                                                        <property name="use_stock">True</property>
+                                                        <signal name="clicked" handler="onRemoveRule" swapped="no"/>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">2</property>
+                                                      </packing>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="resize">True</property>
+                                                <property name="shrink">False</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkAlignment">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="left_padding">5</property>
+                                                <child>
+                                                  <object class="GtkScrolledWindow">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="shadow_type">in</property>
+                                                    <child>
+                                                      <object class="GtkViewport">
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">False</property>
+                                                        <child>
+                                                          <object class="GtkLabel" id="label91">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="halign">start</property>
+                                                            <property name="margin_left">6</property>
+                                                            <property name="margin_right">6</property>
+                                                            <property name="margin_top">3</property>
+                                                            <property name="margin_bottom">3</property>
+                                                            <property name="label" translatable="yes">The priority is used to order rules. Priority 0 means add rule on top of the chain, with a higher priority the rule will be added further down. Rules with the same priority are on the same level and the order of these rules is not fixed and may change. If you want to make sure that a rule will be added after another one, use a low priority for the first and a higher for the following.</property>
+                                                            <property name="wrap">True</property>
+                                                            <property name="xalign">0</property>
+                                                            <property name="yalign">0</property>
+                                                          </object>
+                                                        </child>
+                                                      </object>
                                                     </child>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
+                                                <property name="resize">True</property>
+                                                <property name="shrink">False</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -6267,75 +6385,6 @@
                                             <property name="expand">True</property>
                                             <property name="fill">True</property>
                                             <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButtonBox" id="directRulesButtonbox">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="spacing">6</property>
-                                            <property name="layout_style">start</property>
-                                            <child>
-                                              <object class="GtkButton" id="addDirectRuleButton">
-                                                <property name="label">gtk-add</property>
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <property name="receives_default">True</property>
-                                                <property name="has_tooltip">True</property>
-                                                <property name="tooltip_text" translatable="yes">Add Rule</property>
-                                                <property name="use_stock">True</property>
-                                                <signal name="clicked" handler="onAddRule" swapped="no"/>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkButton" id="editDirectRuleButton">
-                                                <property name="label">gtk-edit</property>
-                                                <property name="visible">True</property>
-                                                <property name="sensitive">False</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <property name="receives_default">True</property>
-                                                <property name="has_tooltip">True</property>
-                                                <property name="tooltip_text" translatable="yes">Edit Rule</property>
-                                                <property name="use_stock">True</property>
-                                                <signal name="clicked" handler="onEditRule" swapped="no"/>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkButton" id="removeDirectRuleButton">
-                                                <property name="label">gtk-remove</property>
-                                                <property name="visible">True</property>
-                                                <property name="sensitive">False</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <property name="receives_default">True</property>
-                                                <property name="has_tooltip">True</property>
-                                                <property name="tooltip_text" translatable="yes">Remove Rule</property>
-                                                <property name="use_stock">True</property>
-                                                <signal name="clicked" handler="onRemoveRule" swapped="no"/>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">2</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">4</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -6378,47 +6427,149 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="label88">
+                                          <object class="GtkPaned">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="label" translatable="yes">Please be careful with passthrough rules to not damage the firewall.</property>
-                                            <property name="wrap">True</property>
-                                            <property name="xalign">0</property>
-                                            <property name="yalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="hbox16">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="spacing">6</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="position">400</property>
+                                            <property name="position_set">True</property>
                                             <child>
-                                              <object class="GtkScrolledWindow" id="otherPortsSW8">
+                                              <object class="GtkBox" id="hbox16">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="shadow_type">out</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="orientation">vertical</property>
+                                                <property name="spacing">6</property>
                                                 <child>
-                                                  <object class="GtkTreeView" id="directPassthroughView">
+                                                  <object class="GtkScrolledWindow" id="otherPortsSW8">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">True</property>
-                                                    <property name="enable_search">False</property>
-                                                    <signal name="button-press-event" handler="onPassthroughClicked" swapped="no"/>
-                                                    <child internal-child="selection">
-                                                      <object class="GtkTreeSelection" id="treeview-selection30"/>
+                                                    <property name="shadow_type">out</property>
+                                                    <child>
+                                                      <object class="GtkTreeView" id="directPassthroughView">
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="enable_search">False</property>
+                                                        <signal name="button-press-event" handler="onPassthroughClicked" swapped="no"/>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">True</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkButtonBox" id="directPassthroughButtonbox">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="spacing">6</property>
+                                                    <property name="layout_style">start</property>
+                                                    <child>
+                                                      <object class="GtkButton" id="addDirectPassthroughButton">
+                                                        <property name="label">gtk-add</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="focus_on_click">False</property>
+                                                        <property name="receives_default">True</property>
+                                                        <property name="has_tooltip">True</property>
+                                                        <property name="tooltip_text" translatable="yes">Add Passthrough</property>
+                                                        <property name="use_stock">True</property>
+                                                        <signal name="clicked" handler="onAddPassthrough" swapped="no"/>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkButton" id="editDirectPassthroughButton">
+                                                        <property name="label">gtk-edit</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="sensitive">False</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="focus_on_click">False</property>
+                                                        <property name="receives_default">True</property>
+                                                        <property name="has_tooltip">True</property>
+                                                        <property name="tooltip_text" translatable="yes">Edit Passthrough</property>
+                                                        <property name="use_stock">True</property>
+                                                        <signal name="clicked" handler="onEditPassthrough" swapped="no"/>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">1</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkButton" id="removeDirectPassthroughButton">
+                                                        <property name="label">gtk-remove</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="sensitive">False</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="focus_on_click">False</property>
+                                                        <property name="receives_default">True</property>
+                                                        <property name="has_tooltip">True</property>
+                                                        <property name="tooltip_text" translatable="yes">Remove Passthrough</property>
+                                                        <property name="use_stock">True</property>
+                                                        <signal name="clicked" handler="onRemovePassthrough" swapped="no"/>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">2</property>
+                                                      </packing>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="resize">True</property>
+                                                <property name="shrink">False</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkAlignment">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="left_padding">5</property>
+                                                <child>
+                                                  <object class="GtkScrolledWindow">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="shadow_type">in</property>
+                                                    <child>
+                                                      <object class="GtkViewport">
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="margin_left">6</property>
+                                                        <property name="margin_right">6</property>
+                                                        <property name="margin_top">3</property>
+                                                        <property name="margin_bottom">3</property>
+                                                        <child>
+                                                          <object class="GtkLabel" id="label88">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="halign">start</property>
+                                                            <property name="label" translatable="yes">Please be careful with passthrough rules to not damage the firewall.</property>
+                                                            <property name="wrap">True</property>
+                                                            <property name="xalign">0</property>
+                                                            <property name="yalign">0</property>
+                                                          </object>
+                                                        </child>
+                                                      </object>
                                                     </child>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
+                                                <property name="resize">True</property>
+                                                <property name="shrink">False</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -6426,75 +6577,6 @@
                                             <property name="expand">True</property>
                                             <property name="fill">True</property>
                                             <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButtonBox" id="directPassthroughButtonbox">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="spacing">6</property>
-                                            <property name="layout_style">start</property>
-                                            <child>
-                                              <object class="GtkButton" id="addDirectPassthroughButton">
-                                                <property name="label">gtk-add</property>
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <property name="receives_default">True</property>
-                                                <property name="has_tooltip">True</property>
-                                                <property name="tooltip_text" translatable="yes">Add Passthrough</property>
-                                                <property name="use_stock">True</property>
-                                                <signal name="clicked" handler="onAddPassthrough" swapped="no"/>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkButton" id="editDirectPassthroughButton">
-                                                <property name="label">gtk-edit</property>
-                                                <property name="visible">True</property>
-                                                <property name="sensitive">False</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <property name="receives_default">True</property>
-                                                <property name="has_tooltip">True</property>
-                                                <property name="tooltip_text" translatable="yes">Edit Passthrough</property>
-                                                <property name="use_stock">True</property>
-                                                <signal name="clicked" handler="onEditPassthrough" swapped="no"/>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkButton" id="removeDirectPassthroughButton">
-                                                <property name="label">gtk-remove</property>
-                                                <property name="visible">True</property>
-                                                <property name="sensitive">False</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="focus_on_click">False</property>
-                                                <property name="receives_default">True</property>
-                                                <property name="has_tooltip">True</property>
-                                                <property name="tooltip_text" translatable="yes">Remove Passthrough</property>
-                                                <property name="use_stock">True</property>
-                                                <signal name="clicked" handler="onRemovePassthrough" swapped="no"/>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">2</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">4</property>
                                           </packing>
                                         </child>
                                       </object>


### PR DESCRIPTION
This allows the main window to fit into smaller screens, regardless of the size of the labels.

This is a better and more general fix for https://github.com/firewalld/firewalld/issues/312.