### PR TITLE
fix(appdata): Mark metainfo translatable

### DIFF
--- a/config/firewall-config.appdata.xml.in
+++ b/config/firewall-config.appdata.xml.in
@@ -5,17 +5,15 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <description>
-    <p>
-   Firewall Configuration provides a graphical tool for administering firewall.
-  </p>
-    <p>Allows to inspect and set:</p>
+    <_p>Firewall Configuration provides a graphical tool for administering firewall.</_p>
+    <_p>Allows to inspect and set:</_p>
     <ul>
-      <li>Runtime and permanent firewall configuration</li>
-      <li>Predefined zones (levels of trust for network connections)</li>
-      <li>Predefined services (port/protocol, netfilter helper module) </li>
-      <li>Port forwarding, masquerading, ICMP blocking</li>
-      <li>Complex firewall rules a.k.a. Rich Language</li>
-      <li>Iptables rules a.k.a. Direct Interface</li>
+      <_li>Runtime and permanent firewall configuration</_li>
+      <_li>Predefined zones (levels of trust for network connections)</_li>
+      <_li>Predefined services (port/protocol, netfilter helper module)</_li>
+      <_li>Port forwarding, masquerading, ICMP blocking</_li>
+      <_li>Complex firewall rules a.k.a. Rich Language</_li>
+      <_li>Iptables rules a.k.a. Direct Interface</_li>
     </ul>
   </description>
   <screenshots>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,5 @@
 config/firewall-applet.desktop.in
+config/firewall-config.appdata.xml.in
 config/firewall-config.desktop.in
 config/icmptypes/address-unreachable.xml
 config/icmptypes/bad-header.xml


### PR DESCRIPTION
This allows to translate the text appearing in the AppStream metadata.