### PR TITLE
add missing python3-dbus dependancy to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ MAINTAINER Firewalld Maintainers <firewalld-users@lists.fedorahosted.org>
 #
 RUN dnf -y install automake autoconf make intltool \
                    docbook-style-xsl python3-nftables \
-                   python3-gobject-base libxslt glib2-devel
+                   python3-gobject-base libxslt glib2-devel \
+                   python3-dbus
 
 # firewalld testsuite dependencies
 #


### PR DESCRIPTION
Fixes #1395 

Container was missing python3-dbus dependency.

This caused `firewalld` to fail to start and exist with

```
Traceback (most recent call last):
  File "/usr/sbin/firewalld", line 17, in <module>
    import dbus
ModuleNotFoundError: No module named 'dbus'
```

Verification
```
docker run -it --rm --privileged --entrypoint=/bin/sh quay.io/firewalld/firewalld:2.2.0

dnf install python3-dbus
bash /root/docker_start.sh
firewall-cmd --state
```

```
$ docker run -it --rm --privileged --entrypoint=/bin/sh quay.io/firewalld/firewalld:2.2.0
sh-5.1# dnf install python3-dbus
CentOS Stream 9 - BaseOS                                                                                                                                                                     322 kB/s | 8.3 MB     00:26    
CentOS Stream 9 - AppStream                                                                                                                                                                  432 kB/s |  21 MB     00:49    
CentOS Stream 9 - Extras packages                                                                                                                                                            1.5 kB/s |  19 kB     00:12    
Dependencies resolved.
=============================================================================================================================================================================================================================
 Package                                                 Architecture                                      Version                                                   Repository                                         Size
=============================================================================================================================================================================================================================
Installing:
 python3-dbus                                            x86_64                                            1.2.18-2.el9                                              baseos                                            144 k

Transaction Summary
=============================================================================================================================================================================================================================
Install  1 Package

Total download size: 144 k
Installed size: 491 k
Is this ok [y/N]: y
Downloading Packages:
python3-dbus-1.2.18-2.el9.x86_64.rpm                                                                                                                                                          31 kB/s | 144 kB     00:04    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                                         28 kB/s | 144 kB     00:05     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                     1/1 
  Installing       : python3-dbus-1.2.18-2.el9.x86_64                                                                                                                                                                    1/1 
  Running scriptlet: python3-dbus-1.2.18-2.el9.x86_64                                                                                                                                                                    1/1 
  Verifying        : python3-dbus-1.2.18-2.el9.x86_64                                                                                                                                                                    1/1 

Installed:
  python3-dbus-1.2.18-2.el9.x86_64                                                                                                                                                                                           

Complete!
sh-5.1# bash /root/docker_start.sh
2024-10-10 00:55:19 ipset not usable, disabling ipset usage in firewall. Other set backends (nftables) remain usable.
2024-10-10 00:55:19 Configuration has NftablesTableOwner=True, but it's not supported by nftables. Table ownership will be disabled.
2024-10-10 00:55:19 iptables is not usable.
2024-10-10 00:55:19 ip6tables is not usable.
2024-10-10 00:55:19 ebtables is not usable.
^C
sh-5.1# firewall-cmd --state
running
```

