### PR TITLE
docs(policy): fix typo

### DIFF
--- a/doc/xml/firewalld.policies.xml
+++ b/doc/xml/firewalld.policies.xml
@@ -42,7 +42,7 @@
             <title>What is a policy?</title>
 
             <para>
-                A policy applies a set of rules to traffic flowing between
+                A policy applies a set of rules to traffic flowing
                 between zones (see zones (see <citerefentry>
                 <refentrytitle>firewalld.zones</refentrytitle>
                 <manvolnum>5</manvolnum> </citerefentry>). The policy affects


### PR DESCRIPTION
Fixes typo in [firewalld.policies(5)](https://firewalld.org/documentation/man-pages/firewalld.policies.html) docs.