### PR TITLE
fix(firewall-config): don't create rich rule with invalid element

### DIFF
--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -3986,6 +3986,14 @@ class FirewallConfig:
                 self.richRuleDialogActionCheck.set_sensitive(False)
                 self.richRuleDialogActionBox.set_sensitive(False)
 
+            if (
+                self.richRuleDialogElementChooser.is_sensitive()
+                and not self.richRuleDialogElementChooser.get_text()
+            ):
+                self.richRuleDialogOkButton.set_sensitive(False)
+                self.richRuleDialogOkButton.set_tooltip_text(_("invalid element"))
+                return
+
         rule = self.richRuleDialog_getRule()
         try:
             rule.check()


### PR DESCRIPTION
Disable the rich rule creation button and make an early return from the on_richRuleDialog_changed function so that no errors are thrown when the element is invalid (e.g. no port is specified when the element is instance of Rich_Port).