### PR TITLE
fix(firewall-config): allow selecting the first service in the list

### DIFF
--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -3549,7 +3549,8 @@ class FirewallConfig:
                 selection.select_iter(iter)
             iter = self.serviceDialogServiceStore.iter_next(iter)
 
-        self.serviceDialogOkButton.set_sensitive(False)
+        if old_service:
+            self.serviceDialogOkButton.set_sensitive(False)
         self.serviceDialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
         self.serviceDialog.set_transient_for(self.mainWindow)
         self.serviceDialog.show_all()


### PR DESCRIPTION
When the service selection dialog opens and no service is set, you can't
select the first service in the list right away. You have to choose
another service and then select the first one. This happens due to the
unconditional disabling of the service selection button.

To resolve this issue, we can simply check whether the service is set by
verifying that the `old_service` param of the `service_select_dialog`
function is not empty.