### PR TITLE
(feat)service: Flannel and MetalLB for Kubernetes

### DIFF
--- a/config/services/kube-flannel.xml
+++ b/config/services/kube-flannel.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kubernetes Flannel</short>
+  <description>Flannel is an overlay network provider that can be used with Kubernetes.</description>
+  <port protocol="udp" port="8285"/>
+  <port protocol="udp" port="8472"/>
+</service>

--- a/config/services/kube-metallb.xml
+++ b/config/services/kube-metallb.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Kubernetes MetalLB</short>
+  <description>MetalLB is a load-balancer implementation for bare-metal Kubernetes clusters, providing external IPs for services.</description>
+  <port protocol="tcp" port="7472"/>
+  <port protocol="udp" port="7472"/>
+  <port protocol="tcp" port="7946"/>
+  <port protocol="udp" port="7946"/>
+</service>


### PR DESCRIPTION
Added the service definition file for two Kubernetes Services:

* Flannel (CNI Provider)
* MetalLB (Provider for External IP addresses)