### PR TITLE
fix(systemd): allow start code 251 (RUNNING_BUT_FAILED)

### DIFF
--- a/config/firewalld.service.in
+++ b/config/firewalld.service.in
@@ -11,6 +11,8 @@ Documentation=man:firewalld(1)
 EnvironmentFile=-/etc/sysconfig/firewalld
 ExecStart=@sbindir@/firewalld --nofork --nopid $FIREWALLD_ARGS
 ExecStartPost=@bindir@/firewall-cmd --state
+# don't fail ExecStartPost on RUNNING_BUT_FAILED
+SuccessExitStatus=251
 ExecReload=/bin/kill -HUP $MAINPID
 StandardOutput=null
 StandardError=null


### PR DESCRIPTION
Do not fail to start the service if `firewall-cmd --state` returns this error code. The daemon is started, but in a recovery mode due to invalid configuration.

Fixes: 4ddfe5672e3a ("fix(systemd): verify firewalld is responsive to dbus")