### PR TITLE
fix configuration file being mistakenly cleared

### DIFF
--- a/src/firewall/core/fw_nm.py
+++ b/src/firewall/core/fw_nm.py
@@ -172,6 +172,9 @@ def nm_get_interfaces():
 
         try:
             con = active_con.get_connection()
+            if con is None:
+                continue
+
             if con.get_flags() & (
                 NM.SettingsConnectionFlags.NM_GENERATED
                 | NM.SettingsConnectionFlags.NM_VOLATILE


### PR DESCRIPTION
public.xml will be cleared when quickly adding and removing vlan together with quickly adding and removing permanent rules, which result  in SSH connection failure.

1. Version:
firewalld: 1.2.6-7
nftables: 1.0.8-7
kernel: 6.6.0-72

2. reproduce: (the bash scripts are in firewalld.zip)
```
[root@localhost ~]# cat /etc/firewalld/zones/public.xml
<?xml version="1.0" encoding="utf-8"?>
<zone>
  <short>Public</short>
  <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
  <service name="ssh"/>
  <service name="mdns"/>
  <service name="dhcpv6-client"/>
  <forward/>
</zone>
[root@localhost ~]# sh ./add_rule.sh
[root@localhost ~]# sh ./nmc.sh > /dev/null &
[1] 32943
[root@localhost ~]# sh ./dom.sh
```

A few minutes later：public.xml is mistakenly cleared:
```
Fri Aug  2 05:29:06 PM CST 2025
****** The configuration file is cleared !!! ******
[1]+  Killed                  sh ./nmc.sh > /dev/null
[root@localhost ~]#

[root@localhost ~]# cat /etc/firewalld/zones/public.xml
<?xml version="1.0" encoding="utf-8"?>
<zone>
  <service name="ssh"/>
  <port port="9999" protocol="tcp"/>
  <forward/>
</zone>
```