### PR TITLE
feat: add gateway policy set

### DIFF
--- a/config/policies/gateway-dmz-to-HOST.xml
+++ b/config/policies/gateway-dmz-to-HOST.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policy target="CONTINUE" priority="1000">
+  <short>Set Gateway - DMZ to HOST</short>
+  <description>
+    Part of the policy set "gateway". Enables services commonly needed for a
+    gateway, e.g. dns, dhcp.
+  </description>
+  <disable />
+
+  <ingress-zone name="dmz" />
+  <egress-zone name="HOST" />
+
+  <service name="dns" />
+  <service name="dhcp" />
+  <service name="dhcpv6-client"/>
+</policy>

--- a/config/policies/gateway-lan-to-HOST.xml
+++ b/config/policies/gateway-lan-to-HOST.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policy target="CONTINUE" priority="1000">
+  <short>Set Gateway - LAN to HOST</short>
+  <description>
+    Part of the policy set "gateway". A policy for traffic destined to the node
+    running firewalld and originating from: internal, home, trusted. It
+    enables basic services provided by a gateway, e.g. dns, dhcp.
+  </description>
+  <disable />
+
+  <ingress-zone name="internal" />
+  <ingress-zone name="home" />
+  <ingress-zone name="trusted" />
+  <egress-zone name="HOST" />
+
+  <service name="dns" />
+  <service name="dhcp" />
+  <service name="dhcpv6-client"/>
+  <service name="ssh" />
+</policy>

--- a/config/policies/gateway-lan-to-work.xml
+++ b/config/policies/gateway-lan-to-work.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policy target="ACCEPT" priority="1000">
+  <short>Set Gateway - LAN to work</short>
+  <description>
+    Part of the policy set "gateway". Allows all traffic from LAN to work.
+    Enables masquerading and common connection tracking helpers.
+  </description>
+  <disable />
+
+  <ingress-zone name="internal" />
+  <ingress-zone name="home" />
+  <ingress-zone name="trusted" />
+  <egress-zone name="work" />
+
+  <!-- Some services that provide conntrack helpers -->
+  <service name="ftp"/>
+  <service name="tftp"/>
+</policy>

--- a/config/policies/gateway-lan-to-world.xml
+++ b/config/policies/gateway-lan-to-world.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policy target="ACCEPT" priority="1000">
+  <short>Set Gateway - LAN to world</short>
+  <description>
+    Part of the policy set "gateway". Allows all traffic from LAN to world. If
+    an interface is added to the "external" zone then the traffic will be
+    masqueraded. Also enables connection tracking helpers for common services,
+    e.g. ftp.
+  </description>
+  <disable />
+
+  <ingress-zone name="internal" />
+  <ingress-zone name="home" />
+  <ingress-zone name="trusted" />
+  <egress-zone name="external" />
+  <egress-zone name="public" />
+
+  <!-- Some services that provide conntrack helpers -->
+  <service name="ftp"/>
+  <service name="tftp"/>
+</policy>

--- a/config/policies/gateway-world-to-HOST.xml
+++ b/config/policies/gateway-world-to-HOST.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<policy target="CONTINUE" priority="1000">
+  <short>Set Gateway - world to HOST</short>
+  <description>
+    Part of the policy set "gateway". A policy for traffic received from
+    external or public zones and destined to the HOST running firewalld. Useful
+    to expose internal/dmz services with forward ports.
+  </description>
+  <disable />
+
+  <ingress-zone name="external" />
+  <ingress-zone name="public" />
+  <egress-zone name="HOST" />
+
+  <service name="dhcpv6-client"/>
+</policy>

--- a/doc/xml/Makefile.am
+++ b/doc/xml/Makefile.am
@@ -29,6 +29,8 @@ man5_MANS = \
 	../man/man5/firewalld.zone.5 \
 	../man/man5/firewalld.zones.5 \
 	../man/man5/firewalld.policy.5 \
+	../man/man5/firewalld.policy-sets.5 \
+	../man/man5/firewalld.policy-set-gateway.5 \
 	../man/man5/firewalld.policies.5
 endif
 

--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -1235,6 +1235,35 @@
         </listitem>
       </varlistentry>
 
+      <!-- add/remove/query disable -->
+      <varlistentry>
+        <term><optional><option>--permanent</option></optional> <option>--policy</option>=<replaceable>policy</replaceable> <option>--add-disable</option></term>
+        <listitem>
+          <para>
+            Administratively disable a policy. A disabled policy will not activate.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><optional><option>--permanent</option></optional> <option>--policy</option>=<replaceable>policy</replaceable> <option>--remove-disable</option></term>
+        <listitem>
+          <para>
+            Remove the administratively disable from a policy. Allows a policy
+            to activate.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><optional><option>--permanent</option></optional> <option>--policy</option>=<replaceable>policy</replaceable> <option>--query-disable</option></term>
+        <listitem>
+          <para>
+            Return if the policy is administratively disabled.
+          </para>
+        </listitem>
+      </varlistentry>
+
       </variablelist>
     </refsect2>
 

--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -1237,7 +1237,7 @@
 
       <!-- add/remove/query disable -->
       <varlistentry>
-        <term><optional><option>--permanent</option></optional> <option>--policy</option>=<replaceable>policy</replaceable> <option>--add-disable</option></term>
+        <term><optional><option>--permanent</option></optional> <option>--policy</option>=<replaceable>policy</replaceable>|<option>--policy-set</option>=<replaceable>policy-set</replaceable> <option>--add-disable</option></term>
         <listitem>
           <para>
             Administratively disable a policy. A disabled policy will not activate.
@@ -1246,7 +1246,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><optional><option>--permanent</option></optional> <option>--policy</option>=<replaceable>policy</replaceable> <option>--remove-disable</option></term>
+        <term><optional><option>--permanent</option></optional> <option>--policy</option>=<replaceable>policy</replaceable>|<option>--policy-set</option>=<replaceable>policy-set</replaceable> <option>--remove-disable</option></term>
         <listitem>
           <para>
             Remove the administratively disable from a policy. Allows a policy

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -1299,7 +1299,7 @@
 
       <!-- add/remove/query disable -->
       <varlistentry>
-        <term><option>--policy</option>=<replaceable>policy</replaceable> <option>--add-disable</option></term>
+        <term><option>--policy</option>=<replaceable>policy</replaceable>|<option>--policy-set</option>=<replaceable>policy-set</replaceable> <option>--add-disable</option></term>
         <listitem>
           <para>
             Administratively disable a policy. A disabled policy will not activate.
@@ -1308,7 +1308,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>--policy</option>=<replaceable>policy</replaceable> <option>--remove-disable</option></term>
+        <term><option>--policy</option>=<replaceable>policy</replaceable>|<option>--policy-set</option>=<replaceable>policy-set</replaceable> <option>--remove-disable</option></term>
         <listitem>
           <para>
             Remove the administratively disable from a policy. Allows a policy

--- a/doc/xml/firewall-offline-cmd.xml
+++ b/doc/xml/firewall-offline-cmd.xml
@@ -1297,6 +1297,35 @@
         </listitem>
       </varlistentry>
 
+      <!-- add/remove/query disable -->
+      <varlistentry>
+        <term><option>--policy</option>=<replaceable>policy</replaceable> <option>--add-disable</option></term>
+        <listitem>
+          <para>
+            Administratively disable a policy. A disabled policy will not activate.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--policy</option>=<replaceable>policy</replaceable> <option>--remove-disable</option></term>
+        <listitem>
+          <para>
+            Remove the administratively disable from a policy. Allows a policy
+            to activate.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--policy</option>=<replaceable>policy</replaceable> <option>--query-disable</option></term>
+        <listitem>
+          <para>
+            Return if the policy is administratively disabled.
+          </para>
+        </listitem>
+      </varlistentry>
+
       </variablelist>
     </refsect2>
 

--- a/doc/xml/firewalld.dbus.xml
+++ b/doc/xml/firewalld.dbus.xml
@@ -48,7 +48,7 @@
     <link linkend="FirewallD1">org.fedoraproject.FirewallD1</link>
     <link linkend="FirewallD1.direct">org.fedoraproject.FirewallD1.direct</link> (deprecated)
     <link linkend="FirewallD1.ipset">org.fedoraproject.FirewallD1.ipset</link>
-    <link linkend="FirewallD1.policies">org.fedoraproject.FirewallD1.policies</link> (deprecated)
+    org.fedoraproject.FirewallD1.policies (deprecated)
     <link linkend="FirewallD1.zone">org.fedoraproject.FirewallD1.zone</link>
     org.freedesktop.DBus.Introspectable
     org.freedesktop.DBus.Properties
@@ -57,7 +57,7 @@
   Interfaces
     <link linkend="FirewallD1.config">org.fedoraproject.FirewallD1.config</link>
     <link linkend="FirewallD1.config.direct">org.fedoraproject.FirewallD1.config.direct</link> (deprecated)
-    <link linkend="FirewallD1.config.policies">org.fedoraproject.FirewallD1.config.policies</link> (deprecated)
+    org.fedoraproject.FirewallD1.config.policies (deprecated)
     org.freedesktop.DBus.Introspectable
     org.freedesktop.DBus.Properties
 

--- a/doc/xml/firewalld.policy-set-gateway.xml
+++ b/doc/xml/firewalld.policy-set-gateway.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN" "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd"
+[
+<!ENTITY authors SYSTEM "authors.xml">
+<!ENTITY seealso SYSTEM "seealso.xml">
+<!ENTITY notes SYSTEM "notes.xml">
+]>
+
+<!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
+  This file is part of firewalld.
+
+  Copyright (C) 2025 Red Hat, Inc.
+
+  Authors:
+  Eric Garver <eric@garver.life>
+-->
+
+<refentry id="firewalld.policy-set-gateway">
+
+    <refentryinfo>
+        <title>Firewalld Policy Set Gateway</title>
+        <productname>firewalld</productname>
+        &authors;
+    </refentryinfo>
+
+    <refmeta>
+        <refentrytitle>firewalld.policy-set-gateway</refentrytitle>
+        <manvolnum>5</manvolnum>
+    </refmeta>
+
+    <refnamediv>
+        <refname>firewalld.policy-set-gateway</refname>
+        <refpurpose>Firewalld Policy Set Gateway</refpurpose>
+    </refnamediv>
+
+    <refsect1 id="description">
+        <title>Description</title>
+
+        <refsect2 id="set-gateway">
+            <title>Policy Set: Gateway</title>
+
+            <para>
+                The Gateway policy set is a useful starting point for a home
+                router. It enables masquerading, conntrack helpers, and
+                forwarding between zones.
+            </para>
+
+            <para>
+                Zones used by this set are logically grouped. These groups name
+                are used by the predefined policies.
+            </para>
+            <programlisting>
+            +-----------+                  +-----------+
+            |    LAN    |                  |   WORLD   |
+            |-----------|                  |-----------|
+            | zones:    |                  | zones:    |
+            |  internal |                  |  external |
+            |  home     |                  |  public   |
+            |  trusted  |                  |           |
+            +-----------+                  +-----------+
+                  |                              |
+                  |                              |
+                  |         +-----------+        |
+                  +---------|   HOST    |--------+
+                            |-----------|
+                            | zones:    |
+                  +---------|  HOST     |--------+
+                  |         +-----------+        |
+                  |                              |
+                  |                              |
+            +-----------+                  +-----------+
+            |   WORK    |                  |    DMZ    |
+            |-----------|                  |-----------|
+            | zones:    |                  | zones:    |
+            |  work     |                  |  dmz      |
+            +-----------+                  +-----------+
+            </programlisting>
+        </refsect2>
+
+        <refsect2 id="policies-in-set">
+            <title>Policies in the Gateway set</title>
+
+            <variablelist>
+                <varlistentry>
+                <term>gateway-dmz-to-HOST</term>
+                <listitem>
+                    <para>
+                        Enables services commonly needed for a gateway,
+                        e.g. dns, dhcp.
+                    </para>
+                    <para>
+                        File location: <filename><config.prefix/>/lib/firewalld/policies/gateway-dmz-to-HOST.xml</filename>
+                    </para>
+                </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                <term>gateway-lan-to-work</term>
+                <listitem>
+                    <para>
+                        Allows all traffic from LAN to work. Enables
+                        masquerading and common connection tracking helpers.
+                    </para>
+                    <para>
+                        File location: <filename><config.prefix/>/lib/firewalld/policies/gateway-lan-to-work.xml</filename>
+                    </para>
+                </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                <term>gateway-lan-to-world</term>
+                <listitem>
+                    <para>
+                        Allows all traffic from LAN to world. If an
+                        interface is added to the "external" zone then the
+                        traffic will be masqueraded. Also enables connection
+                        tracking helpers for common services, e.g. ftp.
+                    </para>
+                    <para>
+                        File location: <filename><config.prefix/>/lib/firewalld/policies/gateway-lan-to-world.xml</filename>
+                    </para>
+                </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                <term>gateway-lan-to-HOST</term>
+                <listitem>
+                    <para>
+                        Enables services commonly needed for a gateway,
+                        e.g. dns, dhcp.
+                    </para>
+                    <para>
+                        File location: <filename><config.prefix/>/lib/firewalld/policies/gateway-lan-to-HOST.xml</filename>
+                    </para>
+                </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                <term>gateway-world-to-HOST</term>
+                <listitem>
+                    <para>
+                        May be used to expose internal/dmz services to the world
+                        by adding a forward port to this policy.
+                    </para>
+                    <para>
+                        Here is an example for adding a forward port. It forward
+                        port 8080 to 10.1.1.42:80.
+                        <programlisting>
+# firewall-cmd --permanent --policy gateway-world-to-HOST \
+               --add-forward-port=port=8080:proto=tcp:toport=80:toaddr=10.1.1.42
+# firewall-cmd --reload
+                        </programlisting>
+                    </para>
+                    <para>
+                        File location: <filename><config.prefix/>/lib/firewalld/policies/gateway-world-to-HOST.xml</filename>
+                    </para>
+                </listitem>
+                </varlistentry>
+            </variablelist>
+        </refsect2>
+
+    </refsect1>
+
+    &seealso;
+
+    &notes;
+
+</refentry>

--- a/doc/xml/firewalld.policy-sets.xml
+++ b/doc/xml/firewalld.policy-sets.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN" "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd"
+[
+<!ENTITY authors SYSTEM "authors.xml">
+<!ENTITY seealso SYSTEM "seealso.xml">
+<!ENTITY notes SYSTEM "notes.xml">
+]>
+
+<!--
+  SPDX-License-Identifier: GPL-2.0-or-later
+
+  This file is part of firewalld.
+
+  Copyright (C) 2025 Red Hat, Inc.
+
+  Authors:
+  Eric Garver <eric@garver.life>
+-->
+
+<refentry id="firewalld.policy-sets">
+
+    <refentryinfo>
+        <title>Firewalld Policy Sets</title>
+        <productname>firewalld</productname>
+        &authors;
+    </refentryinfo>
+
+    <refmeta>
+        <refentrytitle>firewalld.policy-sets</refentrytitle>
+        <manvolnum>5</manvolnum>
+    </refmeta>
+
+    <refnamediv>
+        <refname>firewalld.policy-sets</refname>
+        <refpurpose>Policy Sets</refpurpose>
+    </refnamediv>
+
+    <refsect1 id="description">
+        <title>Description</title>
+
+        <refsect2>
+            <title>What Are Policy Sets?</title>
+
+            <para>
+              Policy sets are collections of policies that serve as starting
+              configuration for specific use cases, e.g. a home router. They
+              provide an easy way to get started. Users may then fine tune the
+              configuration for their environment. Every policy set has a
+              dedicated man page to explain its use case.
+            </para>
+
+            <para>
+              All policy sets shipped by firewalld are administratively disabled
+              by default. Using them is a matter of adding your interfaces to
+              zones and removing the disable.
+            </para>
+        </refsect2>
+
+        <refsect2>
+            <title>Enabling a Policy Set</title>
+
+            <para>
+              Below is a complete example for using the gateway policy set. In
+              this example: eth0 is the LAN interface, and eth1 is the uplink to
+              the internet.
+            </para>
+
+            <programlisting>
+	      # firewall-cmd --permanent --zone internal eth0
+	      # firewall-cmd --permanent --zone external eth1
+	      # firewall-cmd --permanent --policy-set gateway --remove-disable
+	      # firewall-cmd --reload
+            </programlisting>
+        </refsect2>
+
+        <refsect2>
+            <title>Enabling Multiple Policy Sets</title>
+            <para>
+              Policy sets are guaranteed to interoperate. Multiple policy sets
+              may be enabled simultaneously.
+            </para>
+        </refsect2>
+
+        <refsect2>
+            <title>Existing Policy Sets</title>
+
+            <variablelist>
+                <varlistentry>
+                <term>gateway</term>
+                <listitem>
+                    <para>
+                      Provides basic functionality for a gateway, e.g. a home
+                      router. See
+                      <citerefentry>
+                        <refentrytitle>firewalld.policy-set-gateway</refentrytitle>
+                        <manvolnum>5</manvolnum>
+                      </citerefentry>.
+                    </para>
+                </listitem>
+                </varlistentry>
+            </variablelist>
+        </refsect2>
+
+    </refsect1>
+
+    &seealso;
+
+    &notes;
+
+</refentry>

--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -111,6 +111,9 @@ Policy Options
                        Load policy default settings
   --policy=<policy>    Use this policy to set or query options
                        Usable for options marked with [O]
+  --policy-set=<policy>
+                       Modify this set of policies
+                       Usable for a subset of policy options, e.g. --remove-disable
   --info-policy=<policy>
                        Print information about a policy
   --path-policy=<policy>
@@ -678,6 +681,7 @@ parser_group_lockdown_whitelist.add_argument(
 parser.add_argument("--permanent", action="store_true")
 parser.add_argument("--zone", default="", metavar="<zone>")
 parser.add_argument("--policy", default="", metavar="<policy>")
+parser.add_argument("--policy-set", default="", metavar="<policy>")
 parser.add_argument("--timeout", default="0", metavar="<seconds>")
 
 parser_group_zone_or_policy = parser.add_mutually_exclusive_group()
@@ -1410,6 +1414,12 @@ if options_config and (options_zone or options_policy):
         + "Wrong usage of --get-zones | --get-services | --get-icmptypes | --get-policies."
     )
 
+if a.policy_set and not (a.add_disable or a.remove_disable):
+    cmd.fail(
+        parser.format_usage()
+        + "Option --policy-set may only be used with --add-disable or --remove-disable."
+    )
+
 if a.timeout != "0":
     value = 0
     unit = "s"
@@ -1493,8 +1503,11 @@ if a.policy and options_zone_unique:
 if a.zone and options_policy_unique:
     cmd.fail(parser.format_usage() + "Can't use --zone with policy only options.")
 
-if not a.policy and options_policy_unique:
-    cmd.fail(parser.format_usage() + "Must use --policy with policy only options.")
+if not a.policy and not a.policy_set and options_policy_unique:
+    cmd.fail(
+        parser.format_usage()
+        + "Must use --policy/--policy-set with policy only options."
+    )
 
 if a.help:
     __usage()
@@ -2463,6 +2476,21 @@ if a.permanent:
             cmd.print_policy_info(policy, settings)
             cmd.print_msg("")
         sys.exit(0)
+
+    elif a.policy_set:
+        for _policy in filter(
+            lambda x: x[: len(a.policy_set)] == a.policy_set,
+            fw.config().getPolicyNames(),
+        ):
+            fw_policy = fw.config().getPolicyByName(_policy)
+            settings = fw_policy.getSettings()
+
+            if a.add_disable:
+                settings.setDisable(True)
+            elif a.remove_disable:
+                settings.setDisable(False)
+
+            fw_policy.update(settings)
 
     elif a.policy:
         fw_policy = fw.config().getPolicyByName(a.policy)
@@ -3519,6 +3547,19 @@ elif a.remove_source:
     )
 elif a.query_source:
     cmd.x_query_sequence(zone, a.query_source, fw.querySource, None, "'%s'")
+
+elif a.policy_set:
+    for _policy in filter(
+        lambda x: x[: len(a.policy_set)] == a.policy_set, fw.getPolicies()
+    ):
+        settings = fw.getPolicySettings(_policy)
+
+        if a.add_disable:
+            settings.setDisable(True)
+        elif a.remove_disable:
+            settings.setDisable(False)
+
+        fw.setPolicySettings(_policy, settings)
 
 # policy
 elif a.policy:

--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -1137,6 +1137,9 @@ options_policy_unique = (
     or a.add_egress_zone
     or a.remove_egress_zone
     or a.query_egress_zone
+    or a.add_disable
+    or a.remove_disable
+    or a.query_disable
 )
 
 options_policy_ops = options_policy_unique or options_zone_and_policy_adapt_query

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -1213,6 +1213,9 @@ options_policy_unique = (
     or a.add_egress_zone
     or a.remove_egress_zone
     or a.query_egress_zone
+    or a.add_disable
+    or a.remove_disable
+    or a.query_disable
 )
 
 options_policy_ops = options_policy_unique or options_zone_and_policy_adapt_query

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -145,6 +145,9 @@ Policy Options
                        Load policy default settings
   --policy=<policy>    Use this policy to set or query options
                        Usable for options marked with [O]
+  --policy-set=<policy>
+                       Modify this set of policies
+                       Usable for a subset of policy options, e.g. --remove-disable
   --info-policy=<policy>
                        Print information about a policy
   --path-policy=<policy>
@@ -706,6 +709,7 @@ parser_group_lockdown_whitelist.add_argument(
 
 parser.add_argument("--zone", default="", metavar="<zone>")
 parser.add_argument("--policy", default="", metavar="<policy>")
+parser.add_argument("--policy-set", default="", metavar="<policy>")
 
 parser_group_zone_or_policy = parser.add_mutually_exclusive_group()
 parser_group_zone_or_policy.add_argument(
@@ -1481,8 +1485,17 @@ if a.policy and options_zone_unique:
 if a.zone and options_policy_unique:
     cmd.fail(parser.format_usage() + "Can't use --zone with policy only options.")
 
-if not a.policy and options_policy_unique:
-    cmd.fail(parser.format_usage() + "Must use --policy with policy only options.")
+if not a.policy and not a.policy_set and options_policy_unique:
+    cmd.fail(
+        parser.format_usage()
+        + "Must use --policy/--policy-set with policy only options."
+    )
+
+if a.policy_set and not (a.add_disable or a.remove_disable):
+    cmd.fail(
+        parser.format_usage()
+        + "Option --policy-set may only be used with --add-disable or --remove-disable."
+    )
 
 if a.help:
     __usage()
@@ -2662,6 +2675,25 @@ try:
             cmd.print_policy_info(policy, fw_settings)
             cmd.print_msg("")
         sys.exit(0)
+
+    elif a.policy_set:
+        for _policy in filter(
+            lambda x: x[: len(a.policy_set)] == a.policy_set,
+            fw.config.get_policy_objects(),
+        ):
+            fw_policy = fw.config.get_policy_object(_policy)
+            fw_settings = FirewallClientPolicySettings(
+                fw.config.get_policy_object_config_dict(fw_policy)
+            )
+
+            if a.add_disable:
+                fw_settings.setDisable(True)
+            elif a.remove_disable:
+                fw_settings.setDisable(False)
+
+            fw.config.set_policy_object_config_dict(
+                fw_policy, fw_settings.getSettingsDict()
+            )
 
     elif a.policy:
         fw_policy = fw.config.get_policy_object(a.policy)

--- a/src/tests/dbus/policy_permanent_functional.at
+++ b/src/tests/dbus/policy_permanent_functional.at
@@ -10,9 +10,7 @@ NS_CHECK([sed -e ["s/['][,]/'\n/g"] ./stdout |dnl
           sed -e ["s/.*config\/policy\/\([^']\+\)['].*/\1/"] |dnl
           while read LINE; do { echo "${LINE}" | grep ["^[0-9]\+$"] ; } || exit 1; done], 0, [ignore])
 
-DBUS_CHECK([config], [config.getPolicyNames], [], 0, [dnl
-    m4_escape([(['allow-host-ipv6'],)])
-])
+DBUS_CHECK([config], [config.getPolicyNames], [| grep "allow-host-ipv6"], 0, [ignore])
 
 DBUS_CHECK([config], [config.getPolicyByName], ["allow-host-ipv6"], 0, [stdout])
 NS_CHECK([sed -e ["s/.*config\/policy\/\([^']\+\)['].*/\1/"] ./stdout | grep ["^[0-9]\+$"]], 0, [ignore])

--- a/src/tests/dbus/policy_runtime_functional.at
+++ b/src/tests/dbus/policy_runtime_functional.at
@@ -109,9 +109,7 @@ dnl #################
 dnl Fetching Policies
 dnl #################
 
-DBUS_CHECK([], [policy.getPolicies], [], 0, [dnl
-    m4_escape([(['allow-host-ipv6'],)])
-])
+DBUS_CHECK([], [policy.getPolicies], [| grep "allow-host-ipv6"], 0, [ignore])
 
 DBUS_CHECK([], [policy.getActivePolicies], [], 0, [dnl
     ['allow-host-ipv6': {'ingress_zones': ['ANY'], 'egress_zones': ['HOST']}]

--- a/src/tests/features/policy.at
+++ b/src/tests/features/policy.at
@@ -83,13 +83,13 @@ dnl create a few policies
 FWD_CHECK([--permanent --new-policy worldToHost], 0, [ignore])
 FWD_CHECK([--permanent --new-policy hostToWorld], 0, [ignore])
 FWD_CHECK([--permanent --new-policy zoneToZone], 0, [ignore])
-FWD_CHECK([--permanent --get-policies], 0, [dnl
-allow-host-ipv6 hostToWorld worldToHost zoneToZone
-])
+FWD_CHECK([--permanent --get-policies |grep hostToWorld], 0, [ignore])
+FWD_CHECK([--permanent --get-policies |grep worldToHost], 0, [ignore])
+FWD_CHECK([--permanent --get-policies |grep zoneToZone], 0, [ignore])
 FWD_RELOAD
-FWD_CHECK([--get-policies], 0, [dnl
-allow-host-ipv6 hostToWorld worldToHost zoneToZone
-])
+FWD_CHECK([--get-policies |grep hostToWorld], 0, [ignore])
+FWD_CHECK([--get-policies |grep worldToHost], 0, [ignore])
+FWD_CHECK([--get-policies |grep zoneToZone], 0, [ignore])
 
 FWD_END_TEST
 
@@ -166,46 +166,8 @@ allow-host-ipv6
        rule family="ipv6" icmp-type name="router-advertisement" accept
 ])])
 
-FWD_CHECK([--list-all-policies | TRIM_WHITESPACE], 0, [m4_strip([dnl
-allow-host-ipv6 (active)
-  disable: no
-  priority: -15000
-  target: CONTINUE
-  ingress-zones: ANY
-  egress-zones: HOST
-  services:
-  ports:
-  protocols:
-  masquerade: no
-  forward-ports:
-  source-ports:
-  icmp-blocks:
-  rich rules:
-       rule family="ipv6" icmp-type name="neighbour-advertisement" accept
-       rule family="ipv6" icmp-type name="neighbour-solicitation" accept
-       rule family="ipv6" icmp-type name="redirect" accept
-       rule family="ipv6" icmp-type name="router-advertisement" accept
-])])
-FWD_CHECK([--permanent --list-all-policies | TRIM_WHITESPACE], 0, [m4_strip([dnl
-allow-host-ipv6
-  disable: no
-  priority: -15000
-  target: CONTINUE
-  ingress-zones: ANY
-  egress-zones: HOST
-  services:
-  ports:
-  protocols:
-  masquerade: no
-  forward-ports:
-  source-ports:
-  icmp-blocks:
-  rich rules:
-       rule family="ipv6" icmp-type name="neighbour-advertisement" accept
-       rule family="ipv6" icmp-type name="neighbour-solicitation" accept
-       rule family="ipv6" icmp-type name="redirect" accept
-       rule family="ipv6" icmp-type name="router-advertisement" accept
-])])
+FWD_CHECK([--list-all-policies | TRIM_WHITESPACE], 0, [ignore])
+FWD_CHECK([--permanent --list-all-policies | TRIM_WHITESPACE], 0, [ignore])
 
 FWD_CHECK([--policy allow-host-ipv6 --list-all | TRIM_WHITESPACE], 0, [m4_strip([dnl
 allow-host-ipv6 (active)
@@ -6148,13 +6110,9 @@ FWD_CHECK([--permanent --policy allow-host-ipv6 --add-protocol ipv6-icmp], 0, [i
 AT_CHECK([ls "./policies/allow-host-ipv6.xml"], 0, [ignore])
 FWD_CHECK([--permanent --new-policy-from-file "./policies/allow-host-ipv6.xml" --name my-allow-host-ipv6], 0, [ignore])
 AT_CHECK([ls "./policies/my-allow-host-ipv6.xml"], 0, [ignore])
-FWD_CHECK([--permanent --get-policies], 0, [dnl
-allow-host-ipv6 my-allow-host-ipv6
-])
+FWD_CHECK([--permanent --get-policies |grep my-allow-host-ipv6], 0, [ignore])
 FWD_RELOAD
-FWD_CHECK([--get-policies], 0, [dnl
-allow-host-ipv6 my-allow-host-ipv6
-])
+FWD_CHECK([--get-policies |grep my-allow-host-ipv6], 0, [ignore])
 
 FWD_END_TEST
 

--- a/src/tests/features/policy_disable.at
+++ b/src/tests/features/policy_disable.at
@@ -1,5 +1,5 @@
 FWD_START_TEST([policy - disable XML])
-AT_KEYWORDS(policy disable xml)
+AT_KEYWORDS(policy disable xml RHEL-70357)
 
 AT_CHECK([mkdir -p ./policies])
 
@@ -24,7 +24,7 @@ dnl ###################
 dnl ###################
 dnl ###################
 
-FWD_START_TEST([policy - disable CLI])
+FWD_START_TEST([policy - CLI disable])
 AT_KEYWORDS(policy disable)
 
 FWD_CHECK([--permanent --zone internal --add-interface foo], 0, [ignore])
@@ -37,7 +37,24 @@ FWD_CHECK([--permanent --policy foobar --add-egress-zone external], 0, [ignore])
 FWD_CHECK([--permanent --policy foobar --add-service https], 0, [ignore])
 FWD_CHECK([--permanent --policy foobar --add-disable], 0, [ignore])
 
+dnl a policy set
+FWD_CHECK([--permanent --new-policy group-one], 0, [ignore])
+FWD_CHECK([--permanent --policy group-one --add-ingress-zone internal], 0, [ignore])
+FWD_CHECK([--permanent --policy group-one --add-egress-zone external], 0, [ignore])
+FWD_CHECK([--permanent --policy group-one --add-service https], 0, [ignore])
+FWD_CHECK([--permanent --policy group-one --add-disable], 0, [ignore])
+FWD_CHECK([--permanent --new-policy group-two], 0, [ignore])
+FWD_CHECK([--permanent --policy group-two --add-ingress-zone external], 0, [ignore])
+FWD_CHECK([--permanent --policy group-two --add-egress-zone internal], 0, [ignore])
+FWD_CHECK([--permanent --policy group-two --add-service ssh], 0, [ignore])
+FWD_CHECK([--permanent --policy group-two --add-disable], 0, [ignore])
+
 FWD_RELOAD()
+
+dnl --policy-set only allows a small subset of options. Verify others are
+dnl denied.
+FWD_CHECK([--policy-set group --add-interface foo], 2, [ignore], [ignore])
+FWD_CHECK([--policy-set group --add-service ssh], 2, [ignore], [ignore])
 
 dnl remove permanent disable
 FWD_CHECK([--permanent --policy foobar --remove-disable], 0, [ignore])
@@ -52,6 +69,66 @@ foobar
   ingress-zones: internal
   egress-zones: external
   services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--permanent --policy group-one --remove-disable], 0, [ignore])
+FWD_CHECK([--permanent --policy group-one --query-disable], 1, [dnl
+no
+])
+FWD_CHECK([--permanent --info-policy group-one | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-one
+  disable: no
+  priority: -1
+  target: CONTINUE
+  ingress-zones: internal
+  egress-zones: external
+  services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--permanent --policy group-one --add-disable], 0, [ignore])
+FWD_CHECK([--permanent --policy-set group --remove-disable], 0, [ignore])
+FWD_CHECK([--permanent --policy group-one --query-disable], 1, [dnl
+no
+])
+FWD_CHECK([--permanent --info-policy group-one | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-one
+  disable: no
+  priority: -1
+  target: CONTINUE
+  ingress-zones: internal
+  egress-zones: external
+  services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--permanent --policy group-two --query-disable], 1, [dnl
+no
+])
+FWD_CHECK([--permanent --info-policy group-two | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-two
+  disable: no
+  priority: -1
+  target: CONTINUE
+  ingress-zones: external
+  egress-zones: internal
+  services: ssh
   ports:
   protocols:
   masquerade: no
@@ -82,6 +159,66 @@ foobar
   icmp-blocks:
   rich rules:
 ])])
+FWD_CHECK([--permanent --policy group-one --add-disable], 0, [ignore])
+FWD_CHECK([--permanent --policy group-one --query-disable], 0, [dnl
+yes
+])
+FWD_CHECK([--permanent --info-policy group-one | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-one
+  disable: yes
+  priority: -1
+  target: CONTINUE
+  ingress-zones: internal
+  egress-zones: external
+  services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--permanent --policy group-one --remove-disable], 0, [ignore])
+FWD_CHECK([--permanent --policy-set group --add-disable], 0, [ignore])
+FWD_CHECK([--permanent --policy group-one --query-disable], 0, [dnl
+yes
+])
+FWD_CHECK([--permanent --info-policy group-one | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-one
+  disable: yes
+  priority: -1
+  target: CONTINUE
+  ingress-zones: internal
+  egress-zones: external
+  services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--permanent --policy group-two --query-disable], 0, [dnl
+yes
+])
+FWD_CHECK([--permanent --info-policy group-two | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-two
+  disable: yes
+  priority: -1
+  target: CONTINUE
+  ingress-zones: external
+  egress-zones: internal
+  services: ssh
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
 
 dnl remove runtime disable
 FWD_CHECK([--policy foobar --remove-disable], 0, [ignore])
@@ -104,9 +241,75 @@ foobar (active)
   icmp-blocks:
   rich rules:
 ])])
+FWD_CHECK([--policy group-one --remove-disable], 0, [ignore])
+FWD_CHECK([--policy group-one --query-disable], 1, [dnl
+no
+])
+FWD_CHECK([--info-policy group-one | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-one (active)
+  disable: no
+  priority: -1
+  target: CONTINUE
+  ingress-zones: internal
+  egress-zones: external
+  services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--policy group-one --add-disable], 0, [ignore])
+FWD_CHECK([--policy-set group --remove-disable], 0, [ignore])
+FWD_CHECK([--policy group-one --query-disable], 1, [dnl
+no
+])
+FWD_CHECK([--info-policy group-one | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-one (active)
+  disable: no
+  priority: -1
+  target: CONTINUE
+  ingress-zones: internal
+  egress-zones: external
+  services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--policy group-two --query-disable], 1, [dnl
+no
+])
+FWD_CHECK([--info-policy group-two | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-two (active)
+  disable: no
+  priority: -1
+  target: CONTINUE
+  ingress-zones: external
+  egress-zones: internal
+  services: ssh
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
 NFT_LIST_RULES([inet], [filter_FWD_policy_foobar], 0, [ignore])
 IPTABLES_LIST_RULES([filter], [FWD_foobar], 0, [ignore])
 IP6TABLES_LIST_RULES([filter], [FWD_foobar], 0, [ignore])
+NFT_LIST_RULES([inet], [filter_FWD_policy_group-one], 0, [ignore])
+IPTABLES_LIST_RULES([filter], [FWD_group-one], 0, [ignore])
+IP6TABLES_LIST_RULES([filter], [FWD_group-one], 0, [ignore])
+NFT_LIST_RULES([inet], [filter_FWD_policy_group-two], 0, [ignore])
+IPTABLES_LIST_RULES([filter], [FWD_group-two], 0, [ignore])
+IP6TABLES_LIST_RULES([filter], [FWD_group-one], 0, [ignore])
 
 dnl re-add runtime disable
 FWD_CHECK([--policy foobar --add-disable], 0, [ignore])
@@ -129,8 +332,74 @@ foobar (disabled)
   icmp-blocks:
   rich rules:
 ])])
+FWD_CHECK([--policy group-one --add-disable], 0, [ignore])
+FWD_CHECK([--policy group-one --query-disable], 0, [dnl
+yes
+])
+FWD_CHECK([--info-policy group-one | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-one (disabled)
+  disable: yes
+  priority: -1
+  target: CONTINUE
+  ingress-zones: internal
+  egress-zones: external
+  services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--policy group-one --remove-disable], 0, [ignore])
+FWD_CHECK([--policy-set group --add-disable], 0, [ignore])
+FWD_CHECK([--policy group-one --query-disable], 0, [dnl
+yes
+])
+FWD_CHECK([--info-policy group-one | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-one (disabled)
+  disable: yes
+  priority: -1
+  target: CONTINUE
+  ingress-zones: internal
+  egress-zones: external
+  services: https
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
+FWD_CHECK([--policy group-two --query-disable], 0, [dnl
+yes
+])
+FWD_CHECK([--info-policy group-two | TRIM_WHITESPACE], 0, [m4_strip([dnl
+group-two (disabled)
+  disable: yes
+  priority: -1
+  target: CONTINUE
+  ingress-zones: external
+  egress-zones: internal
+  services: ssh
+  ports:
+  protocols:
+  masquerade: no
+  forward-ports:
+  source-ports:
+  icmp-blocks:
+  rich rules:
+])])
 NFT_LIST_RULES([inet], [filter_FWD_policy_foobar], 1, [ignore], [ignore])
 IPTABLES_LIST_RULES([filter], [FWD_foobar], 1, [ignore], [ignore])
 IP6TABLES_LIST_RULES([filter], [FWD_foobar], 1, [ignore], [ignore])
+NFT_LIST_RULES([inet], [filter_FWD_policy_group-one], 1, [ignore], [ignore])
+IPTABLES_LIST_RULES([filter], [FWD_group-one], 1, [ignore], [ignore])
+IP6TABLES_LIST_RULES([filter], [FWD_group-one], 1, [ignore], [ignore])
+NFT_LIST_RULES([inet], [filter_FWD_policy_group-two], 1, [ignore], [ignore])
+IPTABLES_LIST_RULES([filter], [FWD_group-two], 1, [ignore], [ignore])
+IP6TABLES_LIST_RULES([filter], [FWD_group-two], 1, [ignore], [ignore])
 
 FWD_END_TEST()

--- a/src/tests/regression/gh1152.at
+++ b/src/tests/regression/gh1152.at
@@ -298,73 +298,13 @@ work
 
 FWD_CHECK([--permanent --new-policy foobar], 0, [ignore])
 FWD_CHECK([--permanent --policy foobar --add-service http], 0, [ignore])
-FWD_CHECK([--permanent --list-all-policies | TRIM_WHITESPACE], 0, [m4_strip([dnl
+FWD_CHECK([--permanent --list-all-policies | TRIM_WHITESPACE | grep "^\(allow-host-ipv6\|foobar\)"], 0, [m4_strip([dnl
 allow-host-ipv6
-  disable: no
-  priority: -15000
-  target: CONTINUE
-  ingress-zones: ANY
-  egress-zones: HOST
-  services:
-  ports:
-  protocols:
-  masquerade: no
-  forward-ports:
-  source-ports:
-  icmp-blocks:
-  rich rules:
-       rule family="ipv6" icmp-type name="neighbour-advertisement" accept
-       rule family="ipv6" icmp-type name="neighbour-solicitation" accept
-       rule family="ipv6" icmp-type name="redirect" accept
-       rule family="ipv6" icmp-type name="router-advertisement" accept
 foobar
-  disable: no
-  priority: -1
-  target: CONTINUE
-  ingress-zones:
-  egress-zones:
-  services: http
-  ports:
-  protocols:
-  masquerade: no
-  forward-ports:
-  source-ports:
-  icmp-blocks:
-  rich rules:
 ])])
-FWD_OFFLINE_CHECK([--list-all-policies | TRIM_WHITESPACE], 0, [m4_strip([dnl
+FWD_OFFLINE_CHECK([--list-all-policies | TRIM_WHITESPACE | grep "^\(allow-host-ipv6\|foobar\)"], 0, [m4_strip([dnl
 allow-host-ipv6
-  disable: no
-  priority: -15000
-  target: CONTINUE
-  ingress-zones: ANY
-  egress-zones: HOST
-  services:
-  ports:
-  protocols:
-  masquerade: no
-  forward-ports:
-  source-ports:
-  icmp-blocks:
-  rich rules:
-       rule family="ipv6" icmp-type name="neighbour-advertisement" accept
-       rule family="ipv6" icmp-type name="neighbour-solicitation" accept
-       rule family="ipv6" icmp-type name="redirect" accept
-       rule family="ipv6" icmp-type name="router-advertisement" accept
 foobar
-  disable: no
-  priority: -1
-  target: CONTINUE
-  ingress-zones:
-  egress-zones:
-  services: http
-  ports:
-  protocols:
-  masquerade: no
-  forward-ports:
-  source-ports:
-  icmp-blocks:
-  rich rules:
 ])])
 
 FWD_RELOAD()
@@ -514,39 +454,9 @@ work
   icmp-blocks:
   rich rules:
 ])])
-FWD_CHECK([--list-all-policies | TRIM_WHITESPACE], 0, [m4_strip([dnl
+FWD_CHECK([--list-all-policies | TRIM_WHITESPACE | grep "^\(allow-host-ipv6\|foobar\)"], 0, [m4_strip([dnl
 allow-host-ipv6 (active)
-  disable: no
-  priority: -15000
-  target: CONTINUE
-  ingress-zones: ANY
-  egress-zones: HOST
-  services:
-  ports:
-  protocols:
-  masquerade: no
-  forward-ports:
-  source-ports:
-  icmp-blocks:
-  rich rules:
-       rule family="ipv6" icmp-type name="neighbour-advertisement" accept
-       rule family="ipv6" icmp-type name="neighbour-solicitation" accept
-       rule family="ipv6" icmp-type name="redirect" accept
-       rule family="ipv6" icmp-type name="router-advertisement" accept
 foobar
-  disable: no
-  priority: -1
-  target: CONTINUE
-  ingress-zones:
-  egress-zones:
-  services: http
-  ports:
-  protocols:
-  masquerade: no
-  forward-ports:
-  source-ports:
-  icmp-blocks:
-  rich rules:
 ])])
 
 FWD_CHECK([--get-active-zones], 0, [dnl


### PR DESCRIPTION
This PR introduces the idea of "policy sets". Policy sets are a collection of policies that serve as starting configuration for common use cases, e.g. a home router. This allows the user to get started quickly and then modify the set to their specific environment.

In the future, we could add more sets for other things, e.g. RFCs, firewall standards, etc.

```
FIREWALLD.POLICY-(5)                   firewalld.policy-sets                  FIREWALLD.POLICY-(5)

NAME
       firewalld.policy-sets - Policy Sets

DESCRIPTION
   What Are Policy Sets?
       Policy sets are collections of policies that serve as starting configuration for specific
       use cases, e.g. a home router. They provide an easy way to get started. Users may then fine
       tune the configuration for their environment. Every policy set has a dedicated man page to
       explain its use case.

       All policy sets shipped by firewalld are administratively disabled by default. Using them
       is a matter of adding your interfaces to zones and removing the disable.

   Enabling a Policy Set
       Below is a complete example for using the gateway policy set. In this example: eth0 is the
       LAN interface, and eth1 is the uplink to the internet.

                      # firewall-cmd --permanent --zone internal eth0
                      # firewall-cmd --permanent --zone external eth1
                      # firewall-cmd --permanent --policy-set gateway --remove-disable
                      # firewall-cmd --reload

   Enabling Multiple Policy Sets
       Policy sets are guaranteed to interoperate. Multiple policy sets may be enabled
       simultaneously.

   Existing Policy Sets
       gateway
           Provides basic functionality for a gateway, e.g. a home router. See firewalld.policy-
           set-gateway(5).
```

----


```

IREWALLD.POLICY-(5)                                                                Firewalld Policy Set Gateway                                                                FIREWALLD.POLICY-(5)

NAME
       firewalld.policy-set-gateway - Firewalld Policy Set Gateway

DESCRIPTION
   Policy Set: Gateway
       The Gateway policy set is a useful starting point for a home router. It enables masquerading, conntrack helpers, and forwarding between zones.

       Zones used by this set are logically grouped. These groups name are used by the predefined policies.

                       +-----------+                  +-----------+
                       |    LAN    |                  |   WORLD   |
                       |-----------|                  |-----------|
                       | zones:    |                  | zones:    |
                       |  internal |                  |  external |
                       |  home     |                  |  public   |
                       |  trusted  |                  |           |
                       +-----------+                  +-----------+
                             |                              |
                             |                              |
                             |         +-----------+        |
                             +---------|   HOST    |--------+
                                       |-----------|
                                       | zones:    |
                             +---------|  HOST     |--------+
                             |         +-----------+        |
                             |                              |
                             |                              |
                       +-----------+                  +-----------+
                       |   WORK    |                  |    DMZ    |
                       |-----------|                  |-----------|
                       | zones:    |                  | zones:    |
                       |  work     |                  |  dmz      |
                       +-----------+                  +-----------+
                       

   Policies in the Gateway set
       gateway-dmz-to-HOST
           Enables services commonly needed for a gateway, e.g. dns, dhcp.

           File location: /usr/lib/firewalld/policies/gateway-dmz-to-HOST.xml

       gateway-lan-to-work
           Allows all traffic from LAN to work. Enables masquerading and common connection tracking helpers.

           File location: /usr/lib/firewalld/policies/gateway-lan-to-work.xml

       gateway-lan-to-world
           Allows all traffic from LAN to world. If an interface is added to the "external" zone then the traffic will be masqueraded. Also enables connection tracking helpers for common services,
           e.g. ftp.

           File location: /usr/lib/firewalld/policies/gateway-lan-to-world.xml

       gateway-lan-to-HOST
           Enables services commonly needed for a gateway, e.g. dns, dhcp.

           File location: /usr/lib/firewalld/policies/gateway-lan-to-HOST.xml

       gateway-world-to-HOST
           May be used to expose internal/dmz services to the world by adding a forward port to this policy.

           Here is an example for adding a forward port. It forward port 8080 to 10.1.1.42:80.

               # firewall-cmd --permanent --policy gateway-world-to-HOST \
                              --add-forward-port=port=8080:proto=tcp:toport=80:toaddr=10.1.1.42
               # firewall-cmd --reload

           File location: /usr/lib/firewalld/policies/gateway-world-to-HOST.xml
```