### PR TITLE
Add KNX router and tool services.

### DIFF
--- a/config/services/knx-router.xml
+++ b/config/services/knx-router.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>KNX router</short>
+  <description>KNXnet/IP router</description>
+  <port port="3671" protocol="tcp"/>
+  <port port="3671" protocol="udp"/>
+</service>

--- a/config/services/knx-tool.xml
+++ b/config/services/knx-tool.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>KNX tool</short>
+  <description>KNXnet/IP configuration and system maintenance tool</description>
+  <source-port port="3671" protocol="tcp"/>
+  <source-port port="3671" protocol="udp"/>
+</service>


### PR DESCRIPTION
Hi,

this patch adds two service configurations:

- KNX router is when the host acts as a KNX IP server offering routing functionality.
- KNX tool is when the host runs an (Open)ETS instance and wants to connect to a KNX IP router.

Bye
Tobias