### PR TITLE
fix(systemd): do not wait on dbus

### DIFF
--- a/config/firewalld.service.in
+++ b/config/firewalld.service.in
@@ -2,9 +2,9 @@
 Description=firewalld - dynamic firewall daemon
 Before=network-pre.target
 Wants=network-pre.target
-Requires=dbus.service
-After=dbus.service
-After=polkit.service
+# Use PartOf so firewalld is restarted when dbus is restarted. But it doesn't
+# have to wait on it initially.
+PartOf=dbus.service
 Conflicts=iptables.service ip6tables.service ebtables.service ipset.service
 Documentation=man:firewalld(1)
 
@@ -14,8 +14,6 @@ ExecStart=@sbindir@/firewalld --nofork --nopid $FIREWALLD_ARGS
 ExecReload=/bin/kill -HUP $MAINPID
 StandardOutput=null
 StandardError=null
-Type=dbus
-BusName=org.fedoraproject.FirewallD1
 KillMode=mixed
 DevicePolicy=closed
 KeyringMode=private


### PR DESCRIPTION
With this change, firewalld does not depend on dbus to start.

```
# systemctl list-dependencies firewalld.service |grep dbus
<empty>
```

The service is also restarted when dbus is restarted.

```
# systemctl restart dbus
# systemctl status firewalld
● firewalld.service - firewalld - dynamic firewall daemon
     Loaded: loaded (/usr/lib/systemd/system/firewalld.service; enabled; preset: enabled)
     Active: active (running) since Wed 2025-12-03 11:25:27 EST; 3s ago
 Invocation: d5d2b3fddb914c0e8a558d1b91583049
[..]

# firewall-cmd --state
running
```