### PR TITLE
Adding Bash completion for service options of firewall-cmd

### DIFF
--- a/shell-completion/bash/firewall-cmd
+++ b/shell-completion/bash/firewall-cmd
@@ -68,8 +68,16 @@ OPTIONS_POLICY="${OPTIONS_ZONE_POLICY_ACTION} \
 
 OPTIONS_IPSET="${OPTIONS_IPSET_ACTION_ACTION} ${OPTIONS_IPSET_ADAPT_QUERY}"
 
+OPTIONS_SERVICE="--set-description= --get-description --set-short= --get-short \
+                --add-port= --remove-port= --query-port= --get-ports \
+                --add-protocol= --remove-protocol= --query-protocol= --get-protocols --add-source-port= \
+                --remove-source-port= --query-source-port= --get-source-ports --add-helper= \
+                --remove-helper= --query-helper= --get-service-helpers --set-destination= \
+                --remove-destination= --query-destination= --get-destinations --add-include= \
+                --remove-include= --query-include= --get-includes"
+
 OPTIONS_PERMANENT_ONLY="--new-icmptype= --new-icmptype-from-file= --delete-icmptype= \
-                        --new-service= --new-service-from-file= --delete-service= \
+                        --new-service= --new-service-from-file= --service= --delete-service= \
                         --new-zone= --new-zone-from-file= --delete-zone= \
                         --load-zone-defaults= \
                         --new-policy= --new-policy-from-file= --delete-policy= \
@@ -179,11 +187,16 @@ _firewall_cmd()
           COMPREPLY=( $( compgen -W '`firewall-cmd --get-ipsets`' -- "$cur" ) )
         fi
         ;;
-    --*-service)
+    --*-service|--service)
         if [[ ${words[@]} == *--permanent* ]]; then
           COMPREPLY=( $( compgen -W '`firewall-cmd --permanent --get-services`' -- "$cur" ) )
         else
           COMPREPLY=( $( compgen -W '`firewall-cmd --get-services`' -- "$cur" ) )
+        fi
+        ;;
+    --service=*)
+        if [[ ${words[@]} == *--permanent* ]]; then
+            COMPREPLY=( $( compgen -W "${OPTIONS_SERVICE}" -- "$cur" ) )
         fi
         ;;
     --helper|--info-helper|--path-helper)


### PR DESCRIPTION
I was showing Firewalld to a friend and it has been a while that I used `firewall-cmd` myself.  When I could not auto-complete the `--service` option I looked at the man page thinking I missed something.

It appears that Bash completions for the service options of `firewall-cmd` are not configured.  I'm not certain if this is _by design_, but I searched in opened / closed PR and could not find anything related.

From the man page, my understanding is that `--service=` is only valid with `--permanent`, therefore I replicated the logic already used for other similar options.   Hopefully this PR can be helpful but note that I'm not a Bash completion _expert_! :sweat:

