### PR TITLE
zones: Remove SSH service from public zone

### DIFF
--- a/config/zones/public.xml
+++ b/config/zones/public.xml
@@ -2,7 +2,6 @@
 <zone>
   <short>Public</short>
   <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
-  <service name="ssh"/>
   <service name="dhcpv6-client"/>
   <forward/>
 </zone>


### PR DESCRIPTION
Remove SSH service rule because public zone is designed to be used against untrusted or shared public networks.