### PR TITLE
Implement policy management in firewall-config

### DIFF
--- a/config/org.fedoraproject.FirewallConfig.gschema.xml.in
+++ b/config/org.fedoraproject.FirewallConfig.gschema.xml.in
@@ -13,6 +13,10 @@
       <default>false</default>
       <summary>Shows direct chains and rules tab if true</summary>
     </key>
+    <key type="b" name="show-policies">
+      <default>false</default>
+      <summary>Shows policies tab if true</summary>
+    </key>
     <key type="b" name="show-lockdown-whitelist">
       <default>false</default>
       <summary>Shows lockdown whitelist tab if true</summary>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -6649,17 +6649,15 @@
                                 <property name="margin-top">6</property>
                                 <property name="position">175</property>
                                 <child>
-                                  <object class="GtkBox">
+                                  <object class="GtkBox" id="box3">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
+                                      <object class="GtkLabel" id="label71">
                                         <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Policy</property>
                                         <property name="xalign">0</property>
-                                        <property name="yalign">0</property>
                                         <attributes>
                                           <attribute name="weight" value="bold"/>
                                         </attributes>
@@ -6671,14 +6669,17 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkScrolledWindow">
+                                      <object class="GtkScrolledWindow" id="scrolledwindow24">
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="shadow-type">in</property>
                                         <child>
                                           <object class="GtkTreeView" id="policyView">
+                                            <property name="width-request">150</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
+                                            <property name="headers-visible">False</property>
+                                            <property name="tooltip-column">1</property>
                                             <child internal-child="selection">
                                               <object class="GtkTreeSelection"/>
                                             </child>
@@ -6695,12 +6696,15 @@
                                       <object class="GtkToolbar" id="policyEditBox">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
+                                        <property name="has-tooltip">True</property>
+                                        <property name="hexpand">True</property>
                                         <property name="show-arrow">False</property>
                                         <property name="icon_size">1</property>
                                         <child>
-                                          <object class="GtkToolButton" id="policyEditAddButton">
+                                          <object class="GtkToolButton" id="toolbutton6">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Add Policy</property>
                                             <property name="use-underline">True</property>
                                             <property name="stock-id">gtk-add</property>
                                             <signal name="clicked" handler="onAddPolicy" swapped="no"/>
@@ -6714,6 +6718,7 @@
                                           <object class="GtkToolButton" id="policyEditEditButton">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Edit Policy</property>
                                             <property name="use-underline">True</property>
                                             <property name="stock-id">gtk-edit</property>
                                             <signal name="clicked" handler="onEditPolicy" swapped="no"/>
@@ -6727,6 +6732,7 @@
                                           <object class="GtkToolButton" id="policyEditRemoveButton">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Remove Policy</property>
                                             <property name="use-underline">True</property>
                                             <property name="stock-id">gtk-remove</property>
                                             <signal name="clicked" handler="onRemovePolicy" swapped="no"/>
@@ -6740,6 +6746,7 @@
                                           <object class="GtkToolButton" id="policyEditLoadDefaultsButton">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Load Policy Defaults</property>
                                             <property name="use-underline">True</property>
                                             <property name="stock-id">gtk-revert-to-saved</property>
                                             <signal name="clicked" handler="onLoadPolicyDefaults" swapped="no"/>
@@ -6759,7 +6766,7 @@
                                   </object>
                                   <packing>
                                     <property name="resize">False</property>
-                                    <property name="shrink">True</property>
+                                    <property name="shrink">False</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -7225,20 +7232,24 @@
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="expand">True</property>
+                                            <property name="expand">False</property>
                                             <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                     <child type="tab">
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="label" translatable="yes">Zones</property>
+                                        <property name="label" translatable="yes">Ports</property>
                                       </object>
                                       <packing>
+                                        <property name="position">2</property>
                                         <property name="tab-fill">False</property>
                                       </packing>
                                     </child>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -7034,6 +7034,75 @@
                                         <property name="tab-fill">False</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label67">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Here you can define which services are trusted in the policy.</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="box1">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <child>
+                                              <object class="GtkScrolledWindow" id="scrolledwindow23">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="shadow-type">out</property>
+                                                <child>
+                                                  <object class="GtkTreeView" id="policyServiceView">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <child internal-child="selection">
+                                                      <object class="GtkTreeSelection"/>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">3</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Zones</property>
+                                      </object>
+                                      <packing>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="resize">True</property>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -7392,6 +7392,148 @@
                                         <property name="tab-fill">False</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkBox" id="sourcePortsVBox1">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label73">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Add additional source ports or port ranges,</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="hbox12">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <child>
+                                              <object class="GtkScrolledWindow" id="sourcePortsSW2">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="shadow-type">out</property>
+                                                <child>
+                                                  <object class="GtkTreeView" id="policySourcePortView">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="enable-search">False</property>
+                                                    <signal name="button-press-event" handler="onPolicySourcePortClicked" swapped="no"/>
+                                                    <child internal-child="selection">
+                                                      <object class="GtkTreeSelection"/>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButtonBox" id="vbuttonbox9">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <property name="layout-style">start</property>
+                                            <child>
+                                              <object class="GtkButton" id="addPolicySourcePortButton">
+                                                <property name="label">gtk-add</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Add Port</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onAddPolicySourcePort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="editPolicySourcePortButton">
+                                                <property name="label">gtk-edit</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Edit Port</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onEditPolicySourcePort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="removePolicySourcePortButton">
+                                                <property name="label">gtk-remove</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Remove Port</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onRemovePolicySourcePort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="position">4</property>
+                                      </packing>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Source Ports</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">4</property>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="resize">True</property>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -7253,6 +7253,145 @@
                                         <property name="tab-fill">False</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkBox" id="protocolsVBox1">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label72">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Add protocols.</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="hbox11">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <child>
+                                              <object class="GtkScrolledWindow" id="protocolsSW1">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="shadow-type">out</property>
+                                                <child>
+                                                  <object class="GtkTreeView" id="policyProtocolView">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="enable-search">False</property>
+                                                    <signal name="button-press-event" handler="onPolicyProtocolClicked" swapped="no"/>
+                                                    <child internal-child="selection">
+                                                      <object class="GtkTreeSelection"/>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButtonBox" id="vbuttonbox8">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <property name="layout-style">start</property>
+                                            <child>
+                                              <object class="GtkButton" id="addPolicyProtocolButton">
+                                                <property name="label">gtk-add</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="tooltip-text" translatable="yes">Add Protocol</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onAddPolicyProtocol" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="editPolicyProtocolButton">
+                                                <property name="label">gtk-edit</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="tooltip-text" translatable="yes">Edit Protocol</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onEditPolicyProtocol" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="removePolicyProtocolButton">
+                                                <property name="label">gtk-remove</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="tooltip-text" translatable="yes">Remove Protocol</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onRemovePolicyProtocol" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Protocols</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">3</property>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="resize">True</property>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -7534,6 +7534,85 @@
                                         <property name="tab-fill">False</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkBox" id="masqueradingVBox1">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label74">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Masquerading allows you to set up a host or router that connects your local network to the internet. Your local network will not be visible and the hosts appear as a single address on the internet. Masquerading is IPv4 only.</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkEventBox" id="masqueradeEventbox1">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="visible-window">False</property>
+                                            <property name="above-child">True</property>
+                                            <signal name="button-press-event" handler="policy_masquerade_check_cb" swapped="no"/>
+                                            <child>
+                                              <object class="GtkCheckButton" id="policyMasqueradeCheck">
+                                                <property name="label" translatable="yes">Masquerade policy</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="valign">start</property>
+                                                <property name="xalign">0</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="label75">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">If you enable masquerading, IP forwarding will be enabled for your IPv4 networks.</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="position">5</property>
+                                      </packing>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Masquerading</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">5</property>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="resize">True</property>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -6625,6 +6625,434 @@
                             <property name="tab_fill">False</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkBox" id="policiesBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">label</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkPaned">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="margin-top">6</property>
+                                <property name="position">175</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Policy</property>
+                                        <property name="xalign">0</property>
+                                        <property name="yalign">0</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkScrolledWindow">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="shadow-type">in</property>
+                                        <child>
+                                          <object class="GtkTreeView" id="policyView">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <child internal-child="selection">
+                                              <object class="GtkTreeSelection"/>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkToolbar">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="show-arrow">False</property>
+                                        <property name="icon_size">1</property>
+                                        <child>
+                                          <object class="GtkToolButton">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="stock-id">gtk-add</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="homogeneous">True</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkToolButton">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="stock-id">gtk-edit</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="homogeneous">True</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkToolButton">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="stock-id">gtk-remove</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="homogeneous">True</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkToolButton">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="stock-id">gtk-revert-to-saved</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="homogeneous">True</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="resize">False</property>
+                                    <property name="shrink">True</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkNotebook">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="scrollable">True</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Ingress Zones</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEventBox" id="policyIngressHostEventBox">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="visible-window">False</property>
+                                                <property name="above-child">True</property>
+                                                <child>
+                                                  <object class="GtkRadioButton" id="policyIngressHostButton">
+                                                    <property name="label" translatable="yes">HOST</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEventBox" id="policyIngressAnyEventBox">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="visible-window">False</property>
+                                                <property name="above-child">True</property>
+                                                <child>
+                                                  <object class="GtkRadioButton" id="policyIngressAnyButton">
+                                                    <property name="label" translatable="yes">ANY</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="draw-indicator">True</property>
+                                                    <property name="group">policyIngressHostButton</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkBox">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                  <object class="GtkEventBox" id="policyIngressZonesEventBox">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="visible-window">False</property>
+                                                    <property name="above-child">True</property>
+                                                    <child>
+                                                      <object class="GtkRadioButton" id="policyIngressZonesButton">
+                                                        <property name="label" translatable="yes">Zones</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
+                                                        <property name="draw-indicator">True</property>
+                                                        <property name="group">policyIngressHostButton</property>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkScrolledWindow">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="shadow-type">in</property>
+                                                    <child>
+                                                      <object class="GtkTreeView" id="policyIngressZoneView">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">True</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">3</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Egress Zones</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEventBox" id="policyEgressHostEventBox">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="visible-window">False</property>
+                                                <property name="above-child">True</property>
+                                                <child>
+                                                  <object class="GtkRadioButton" id="policyEgressHostButton">
+                                                    <property name="label" translatable="yes">HOST</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEventBox" id="policyEgressAnyEventBox">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="visible-window">False</property>
+                                                <property name="above-child">True</property>
+                                                <child>
+                                                  <object class="GtkRadioButton" id="policyEgressAnyButton">
+                                                    <property name="label" translatable="yes">ANY</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="draw-indicator">True</property>
+                                                    <property name="group">policyEgressHostButton</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkBox">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                  <object class="GtkEventBox" id="policyEgressZonesEventBox">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="visible-window">False</property>
+                                                    <property name="above-child">True</property>
+                                                    <child>
+                                                      <object class="GtkRadioButton" id="policyEgressZonesButton">
+                                                        <property name="label" translatable="yes">Zones</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
+                                                        <property name="draw-indicator">True</property>
+                                                        <property name="group">policyEgressHostButton</property>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkScrolledWindow">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="shadow-type">in</property>
+                                                    <child>
+                                                      <object class="GtkTreeView" id="policyEgressZoneView">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                      </object>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">True</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">3</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Zones</property>
+                                      </object>
+                                      <packing>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="resize">True</property>
+                                    <property name="shrink">True</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="position">6</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Policies</property>
+                          </object>
+                          <packing>
+                            <property name="position">6</property>
+                            <property name="tab-fill">False</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -6653,7 +7081,7 @@
         <child>
           <object class="GtkSeparator">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -6664,17 +7092,17 @@
         <child>
           <object class="GtkBox" id="statusHBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_left">6</property>
-            <property name="margin_right">6</property>
-            <property name="margin_top">3</property>
-            <property name="margin_bottom">3</property>
+            <property name="can-focus">False</property>
+            <property name="margin-left">6</property>
+            <property name="margin-right">6</property>
+            <property name="margin-top">3</property>
+            <property name="margin-bottom">3</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="statusLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="use_markup">True</property>
+                <property name="can-focus">False</property>
+                <property name="use-markup">True</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -6686,7 +7114,7 @@
             <child>
               <object class="GtkLabel" id="modifiedLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <property name="xalign">0</property>
               </object>
@@ -6704,35 +7132,36 @@
           </packing>
         </child>
         <child>
+          <!-- n-columns=8 n-rows=3 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_left">6</property>
-            <property name="margin_right">6</property>
-            <property name="margin_top">3</property>
-            <property name="margin_bottom">3</property>
-            <property name="row_spacing">3</property>
-            <property name="column_spacing">3</property>
+            <property name="can-focus">False</property>
+            <property name="margin-left">6</property>
+            <property name="margin-right">6</property>
+            <property name="margin-top">3</property>
+            <property name="margin-bottom">3</property>
+            <property name="row-spacing">3</property>
+            <property name="column-spacing">3</property>
             <child>
               <object class="GtkLabel" id="defaultZoneLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_markup" translatable="yes">Current default zone of the system.</property>
-                <property name="tooltip_text" translatable="yes">Current default zone of the system.</property>
+                <property name="can-focus">False</property>
+                <property name="has-tooltip">True</property>
+                <property name="tooltip-markup" translatable="yes">Current default zone of the system.</property>
+                <property name="tooltip-text" translatable="yes">Current default zone of the system.</property>
                 <property name="label">label</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">6</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">6</property>
                 <property name="label" translatable="yes" context="Meaning: Log of denied packets. But this is too long. LogDenied is also the parameter used in firewalld.conf.">Log Denied:</property>
                 <property name="justify">right</property>
                 <property name="xalign">1</property>
@@ -6741,30 +7170,30 @@
                 </attributes>
               </object>
               <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">2</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="logDeniedLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_markup" translatable="yes">Current default zone of the system.</property>
-                <property name="tooltip_text" translatable="yes">Current default zone of the system.</property>
+                <property name="can-focus">False</property>
+                <property name="has-tooltip">True</property>
+                <property name="tooltip-markup" translatable="yes">Current default zone of the system.</property>
+                <property name="tooltip-text" translatable="yes">Current default zone of the system.</property>
                 <property name="label">label</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
-                <property name="left_attach">3</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">3</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="label19">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">6</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">6</property>
                 <property name="label" translatable="yes">Panic Mode:</property>
                 <property name="justify">right</property>
                 <property name="xalign">1</property>
@@ -6773,17 +7202,17 @@
                 </attributes>
               </object>
               <packing>
-                <property name="left_attach">4</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">4</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="panicLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_markup" translatable="yes">Current default zone of the system.</property>
-                <property name="tooltip_text" translatable="yes">Current default zone of the system.</property>
+                <property name="can-focus">False</property>
+                <property name="has-tooltip">True</property>
+                <property name="tooltip-markup" translatable="yes">Current default zone of the system.</property>
+                <property name="tooltip-text" translatable="yes">Current default zone of the system.</property>
                 <property name="label">label</property>
                 <property name="xalign">0</property>
               </object>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -7613,6 +7613,149 @@
                                         <property name="tab-fill">False</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkBox" id="portForwardingVBox1">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label82">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Add entries to forward ports either from one port to another on the local system or from the local system to another system. Forwarding to another system is only useful if the interface is masqueraded. Port forwarding is IPv4 only.</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="hbox13">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <child>
+                                              <object class="GtkScrolledWindow" id="scrolledwindow25">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="shadow-type">out</property>
+                                                <child>
+                                                  <object class="GtkTreeView" id="policyForwardView">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="enable-search">False</property>
+                                                    <signal name="button-press-event" handler="onPolicyForwardPortClicked" swapped="no"/>
+                                                    <child internal-child="selection">
+                                                      <object class="GtkTreeSelection"/>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButtonBox" id="vbuttonbox10">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <property name="layout-style">start</property>
+                                            <child>
+                                              <object class="GtkButton" id="addPolicyForwardButton">
+                                                <property name="label">gtk-add</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Add Forward Port</property>
+                                                <property name="relief">none</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onAddPolicyForwardPort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="editPolicyForwardButton">
+                                                <property name="label">gtk-edit</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Edit Forward Port</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onEditPolicyForwardPort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="removePolicyForwardButton">
+                                                <property name="label">gtk-remove</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Remove Forward Port</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onRemovePolicyForwardPort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="position">6</property>
+                                      </packing>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Port Forwarding</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">6</property>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="resize">True</property>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -6692,17 +6692,18 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkToolbar">
+                                      <object class="GtkToolbar" id="policyEditBox">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="show-arrow">False</property>
                                         <property name="icon_size">1</property>
                                         <child>
-                                          <object class="GtkToolButton">
+                                          <object class="GtkToolButton" id="policyEditAddButton">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="use-underline">True</property>
                                             <property name="stock-id">gtk-add</property>
+                                            <signal name="clicked" handler="onAddPolicy" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -6710,11 +6711,12 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkToolButton">
+                                          <object class="GtkToolButton" id="policyEditEditButton">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="use-underline">True</property>
                                             <property name="stock-id">gtk-edit</property>
+                                            <signal name="clicked" handler="onEditPolicy" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -6722,11 +6724,12 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkToolButton">
+                                          <object class="GtkToolButton" id="policyEditRemoveButton">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="use-underline">True</property>
                                             <property name="stock-id">gtk-remove</property>
+                                            <signal name="clicked" handler="onRemovePolicy" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -6734,11 +6737,12 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkToolButton">
+                                          <object class="GtkToolButton" id="policyEditLoadDefaultsButton">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="use-underline">True</property>
                                             <property name="stock-id">gtk-revert-to-saved</property>
+                                            <signal name="clicked" handler="onLoadPolicyDefaults" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -6867,6 +6871,9 @@
                                                       <object class="GtkTreeView" id="policyIngressZoneView">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">True</property>
+                                                        <child internal-child="selection">
+                                                          <object class="GtkTreeSelection"/>
+                                                        </child>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -6989,6 +6996,9 @@
                                                       <object class="GtkTreeView" id="policyEgressZoneView">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">True</property>
+                                                        <child internal-child="selection">
+                                                          <object class="GtkTreeSelection"/>
+                                                        </child>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -8679,9 +8689,331 @@
       <action-widget response="1">moduleDialogOkButton</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkDialog" id="policyBaseDialog">
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
+    <property name="title" translatable="yes">Base Policy Settings</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="policyBaseDialogCancelButton">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="policyBaseDialogOkButton">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox17">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">6</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label17">
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Please configure base policy settings:</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label46">
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Bold entries are mandatory, all others are optional.</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <!-- n-columns=3 n-rows=6 -->
+              <object class="GtkGrid" id="portUserTable4">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="border-width">6</property>
+                <property name="row-spacing">6</property>
+                <property name="column-spacing">6</property>
+                <child>
+                  <object class="GtkEntry" id="policyBaseDialogVersionEntry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="invisible-char">•</property>
+                    <property name="activates-default">True</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="policyBaseDialogShortEntry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="invisible-char">•</property>
+                    <property name="activates-default">True</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow22">
+                    <property name="width-request">250</property>
+                    <property name="height-request">80</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTextView" id="policyBaseDialogDescText">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="wrap-mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="policyBaseDialogTargetCheck">
+                    <property name="label" translatable="yes">Default Target</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="draw-indicator">True</property>
+                    <signal name="toggled" handler="onPolicyBaseDialogTargetCheckToggled" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label66">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Name:</property>
+                    <property name="xalign">1</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="policyBaseDialogNameEntry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="max-length">17</property>
+                    <property name="invisible-char">•</property>
+                    <property name="activates-default">True</property>
+                    <property name="width-chars">17</property>
+                    <property name="max-width-chars">17</property>
+                    <signal name="changed" handler="onPolicyBaseDialogNameChanged" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="protoLabel12">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Version:</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="protoLabel13">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Short:</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="protoLabel14">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Description:</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Target:</property>
+                    <property name="xalign">1</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="xalign">1</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="policyBaseDialogTargetCombobox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <items>
+                      <item translatable="yes">CONTINUE</item>
+                      <item>ACCEPT</item>
+                      <item>REJECT</item>
+                      <item>DROP</item>
+                    </items>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-1">policyBaseDialogCancelButton</action-widget>
+      <action-widget response="1">policyBaseDialogOkButton</action-widget>
+    </action-widgets>
+  </object>
   <object class="GtkDialog" id="portDialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
     <property name="title" translatable="yes">Port and Protocol</property>
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -7081,7 +7081,146 @@
                                               <packing>
                                                 <property name="expand">True</property>
                                                 <property name="fill">True</property>
-                                                <property name="position">3</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Services</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">1</property>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="otherPortsVBox2">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label68">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Add additional ports or port ranges.</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="hbox10">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <child>
+                                              <object class="GtkScrolledWindow" id="otherPortsSW2">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="shadow-type">out</property>
+                                                <child>
+                                                  <object class="GtkTreeView" id="policyPortView">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="enable-search">False</property>
+                                                    <signal name="button-press-event" handler="onPolicyPortClicked" swapped="no"/>
+                                                    <child internal-child="selection">
+                                                      <object class="GtkTreeSelection"/>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButtonBox" id="vbuttonbox7">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <property name="layout-style">start</property>
+                                            <child>
+                                              <object class="GtkButton" id="addPolicyPortButton">
+                                                <property name="label">gtk-add</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="tooltip-text" translatable="yes">Add Port</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onAddPolicyPort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="editPolicyPortButton">
+                                                <property name="label">gtk-edit</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="tooltip-text" translatable="yes">Edit Port</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onEditPolicyPort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="removePolicyPortButton">
+                                                <property name="label">gtk-remove</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="tooltip-text" translatable="yes">Remove Port</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onRemovePolicyPort" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
                                               </packing>
                                             </child>
                                           </object>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -2226,6 +2226,15 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkCheckMenuItem" id="policiesMenuitem">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Policies</property>
+                        <property name="use-underline">True</property>
+                        <signal name="toggled" handler="onViewPolicies_toggled" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkCheckMenuItem" id="activeBindingsMenuitem">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -7815,6 +7815,148 @@
                                         <property name="tab-fill">False</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkBox" id="rulesVBox1">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label84">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Here you can set rich language rules for the policy.</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="box15">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <child>
+                                              <object class="GtkScrolledWindow" id="scrolledwindow26">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="shadow-type">out</property>
+                                                <child>
+                                                  <object class="GtkTreeView" id="policyRichRuleView">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <signal name="button-press-event" handler="onPolicyRichRuleClicked" swapped="no"/>
+                                                    <child internal-child="selection">
+                                                      <object class="GtkTreeSelection"/>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkButtonBox" id="buttonbox2">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">6</property>
+                                            <property name="layout-style">start</property>
+                                            <child>
+                                              <object class="GtkButton" id="addPolicyRichRuleButton">
+                                                <property name="label">gtk-add</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Add Rich Rule</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onAddPolicyRichRule" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="editPolicyRichRuleButton">
+                                                <property name="label">gtk-edit</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Edit Rich Rule</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onEditPolicyRichRule" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="removePolicyRichRuleButton">
+                                                <property name="label">gtk-remove</property>
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="focus-on-click">False</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="has-tooltip">True</property>
+                                                <property name="tooltip-text" translatable="yes">Remove Rich Rule</property>
+                                                <property name="use-stock">True</property>
+                                                <signal name="clicked" handler="onRemovePolicyRichRule" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="position">8</property>
+                                      </packing>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Rich Rules</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">8</property>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="resize">True</property>

--- a/src/firewall-config.glade
+++ b/src/firewall-config.glade
@@ -7756,6 +7756,65 @@
                                         <property name="tab-fill">False</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkBox" id="vbox18">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="border-width">6</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label83">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">The Internet Control Message Protocol (ICMP) is mainly used to send error messages between networked computers, but additionally for informational messages like ping requests and replies.</property>
+                                            <property name="wrap">True</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkScrolledWindow" id="icmpScrolledWindow1">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="shadow-type">out</property>
+                                            <child>
+                                              <object class="GtkTreeView" id="policyIcmpView">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <child internal-child="selection">
+                                                  <object class="GtkTreeSelection"/>
+                                                </child>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="position">7</property>
+                                      </packing>
+                                    </child>
+                                    <child type="tab">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">ICMP Filter</property>
+                                      </object>
+                                      <packing>
+                                        <property name="position">7</property>
+                                        <property name="tab-fill">False</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="resize">True</property>

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -34,7 +34,7 @@ from dbus.exceptions import DBusException
 from firewall import config
 from firewall import client
 from firewall import functions
-from firewall.core.base import DEFAULT_ZONE_TARGET, REJECT_TYPES, SOURCE_IPSET_TYPES
+from firewall.core.base import DEFAULT_ZONE_TARGET, REJECT_TYPES, SOURCE_IPSET_TYPES, DEFAULT_POLICY_TARGET
 from firewall.core.ipset import IPSET_MAXNAMELEN
 from firewall.core.helper import HELPER_MAXNAMELEN
 from firewall.core.io.zone import Zone
@@ -42,6 +42,7 @@ from firewall.core.io.service import Service
 from firewall.core.io.icmptype import IcmpType
 from firewall.core.io.ipset import IPSet
 from firewall.core.io.helper import Helper
+from firewall.core.io.policy import Policy
 from firewall.core import rich
 from firewall.core.fw_nm import (
     nm_is_imported,
@@ -1258,6 +1259,28 @@ class FirewallConfig:
         self.policyStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
         self.policyView.get_selection().connect("changed", self.onChangePolicy)
 
+        self.policyEditBox = builder.get_object("policyEditBox")
+        self.policyEditBox.hide()
+        self.policyEditLoadDefaultsButton = builder.get_object(
+            "policyEditLoadDefaultsButton"
+        )
+        self.policyEditEditButton = builder.get_object("policyEditEditButton")
+        self.policyEditRemoveButton = builder.get_object("policyEditRemoveButton")
+
+        self.policyBaseDialog = builder.get_object("policyBaseDialog")
+        self.policyBaseDialogOkButton = builder.get_object("policyBaseDialogOkButton")
+
+        self.policyBaseDialogNameEntry = builder.get_object("policyBaseDialogNameEntry")
+        self.policyBaseDialogVersionEntry = builder.get_object(
+            "policyBaseDialogVersionEntry"
+        )
+        self.policyBaseDialogShortEntry = builder.get_object("policyBaseDialogShortEntry")
+        self.policyBaseDialogDescText = builder.get_object("policyBaseDialogDescText")
+        self.policyBaseDialogTargetCheck = builder.get_object("policyBaseDialogTargetCheck")
+        self.policyBaseDialogTargetCombobox = builder.get_object(
+            "policyBaseDialogTargetCombobox"
+        )
+
         self.policyIngressHostButton = builder.get_object("policyIngressHostButton")
         self.policyIngressHostEventBox = builder.get_object("policyIngressHostEventBox")
         self.policyIngressHostEventBox.connect("button-press-event", self.policy_ingress_host_toggle_cb)
@@ -2452,6 +2475,7 @@ class FirewallConfig:
             self.icmpDialogIcmpEditBox.hide()
             self.helperConfHelperEditBox.hide()
             self.helperConfPortBox.hide()
+            self.policyEditBox.hide()
         else:
             self.zoneEditBox.show()
             self.ipsetConfIPSetEditBox.show()
@@ -2463,6 +2487,7 @@ class FirewallConfig:
             self.icmpDialogIcmpEditBox.show()
             self.helperConfHelperEditBox.show()
             self.helperConfPortBox.show()
+            self.policyEditBox.show()
 
         self.load_ipsets()
         self.load_zones()
@@ -3160,7 +3185,7 @@ class FirewallConfig:
     def onAddZone(self, *args):
         if self.runtime_view:
             return
-        self.add_edit_zone(True)
+        self.add_edit_zone_policy(False, True)
 
     def onRemoveZone(self, *args):
         if self.runtime_view:
@@ -3175,7 +3200,7 @@ class FirewallConfig:
     def onEditZone(self, *args):
         if self.runtime_view:
             return
-        self.add_edit_zone(False)
+        self.add_edit_zone_policy(False, False)
 
     def onLoadDefaultsZone(self, *args):
         if self.runtime_view:
@@ -3185,6 +3210,185 @@ class FirewallConfig:
         zone.loadDefaults()
         self.changes_applied()
         self.onChangeZone()
+
+    def onAddPolicy(self, *args):
+        if self.runtime_view:
+            return
+        self.add_edit_zone_policy(True, True)
+
+    def onRemovePolicy(self, *args):
+        if self.runtime_view:
+            return
+        selected_policy = self.get_selected_policy()
+        policy = self.fw.config().getPolicyByName(selected_policy)
+        policy.remove()
+        self.changes_applied()
+
+    def onEditPolicy(self, *args):
+        if self.runtime_view:
+            return
+        self.add_edit_zone_policy(True, False)
+
+    def onLoadPolicyDefaults(self, *args):
+        if self.runtime_view:
+            return
+        selected_policy = self.get_selected_policy()
+        policy = self.fw.config().getPolicyByName(selected_policy)
+        policy.loadDefaults()
+
+    def add_edit_zone_policy(self, policy, add):
+        if policy:
+            l = functions.max_policy_name_len()
+            dialog = self.policyBaseDialog
+            dialog_name_entry = self.policyBaseDialogNameEntry
+            dialog_version_entry = self.policyBaseDialogVersionEntry
+            dialog_short_entry = self.policyBaseDialogShortEntry
+            dialog_desc_text = self.policyBaseDialogDescText
+            dialog_target_check = self.policyBaseDialogTargetCheck
+            dialog_target_combobox = self.policyBaseDialogTargetCombobox
+            dialog_ok_button = self.policyBaseDialogOkButton
+        else:
+            l = functions.max_zone_name_len()
+            dialog = self.zoneBaseDialog
+            dialog_name_entry = self.zoneBaseDialogNameEntry
+            dialog_version_entry = self.zoneBaseDialogVersionEntry
+            dialog_short_entry = self.zoneBaseDialogShortEntry
+            dialog_desc_text = self.zoneBaseDialogDescText
+            dialog_target_check = self.zoneBaseDialogTargetCheck
+            dialog_target_combobox = self.zoneBaseDialogTargetCombobox
+            dialog_ok_button = self.zoneBaseDialogOkButton
+
+        dialog_name_entry.set_max_length(l)
+        dialog_name_entry.set_width_chars(l)
+        dialog_name_entry.set_max_width_chars(l)
+
+        if add:
+            default = True
+            builtin = False
+            old_name = None
+            old_version = None
+            old_short = None
+            old_desc = None
+            old_target = None
+
+            dialog_name_entry.set_text("")
+            dialog_version_entry.set_text("")
+            dialog_short_entry.set_text("")
+            dialog_desc_text.get_buffer().set_text("")
+            dialog_target_check.set_active(True)
+            dialog_target_combobox.set_active(0)
+        else:
+            if policy:
+                selected = self.get_selected_policy()
+                zp = self.fw.config().getPolicyByName(selected)
+            else:
+                selected = self.get_selected_zone()
+                zp = self.fw.config().getZoneByName(selected)
+            settings = zp.getSettings()
+            props = zp.get_properties()
+            default = props["default"]
+            builtin = props["builtin"]
+
+            old_name = selected
+            old_version = settings.getVersion()
+            old_short = settings.getShort()
+            old_desc = settings.getDescription()
+            old_target = settings.getTarget()
+
+            dialog_name_entry.set_text(old_name)
+            dialog_version_entry.set_text(old_version)
+            dialog_short_entry.set_text(old_short)
+            dialog_desc_text.get_buffer().set_text(old_desc)
+
+            if (policy and old_target == DEFAULT_POLICY_TARGET) or (not policy and (old_target == "default" or old_target == DEFAULT_ZONE_TARGET)):
+                dialog_target_check.set_active(True)
+                dialog_target_combobox.set_active(0)
+            else:
+                dialog_target_check.set_active(False)
+                combobox_select_text(
+                    dialog_target_combobox,
+                    old_target if old_target != "%%REJECT%%" else "REJECT",
+                )
+
+        dialog_ok_button.set_sensitive(False)
+        if builtin:
+            dialog_name_entry.set_tooltip_markup(
+                _("Built-in policy, rename not supported.")
+            )
+        else:
+            dialog_name_entry.set_tooltip_markup("")
+        dialog_name_entry.set_sensitive(not builtin and default)
+
+        dialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
+        dialog.set_transient_for(self.mainWindow)
+        dialog.show_all()
+        self.add_visible_dialog(dialog)
+        result = dialog.run()
+        dialog.hide()
+        self.remove_visible_dialog(dialog)
+
+        if result != 1:
+            return
+
+        name = dialog_name_entry.get_text()
+        version = dialog_version_entry.get_text()
+        short = dialog_short_entry.get_text()
+        buffer = dialog_desc_text.get_buffer()
+        desc = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), False)
+        target = DEFAULT_POLICY_TARGET if policy else "default"
+        if not dialog_target_check.get_active():
+            target = dialog_target_combobox.get_active_text()
+            if target == "REJECT":
+                target = "%%REJECT%%"
+
+        if (
+            old_name == name
+            and old_version == version
+            and old_short == short
+            and old_desc == desc
+            and old_target == target
+        ):
+            # no changes
+            return
+
+        if not add:
+            if policy:
+                selected_policy = self.get_selected_policy()
+                zp = self.fw.config().getPolicyByName(selected_policy)
+            else:
+                selected_zone = self.get_selected_zone()
+                zp = self.fw.config().getZoneByName(selected_zone)
+            settings = zp.getSettings()
+        else:
+            if policy:
+                settings = client.FirewallClientPolicySettings()
+            else:
+                settings = client.FirewallClientZoneSettings()
+
+        if (
+            old_version != version
+            or old_short != short
+            or old_desc != desc
+            or old_target != target
+        ):
+            # settings
+            settings.setVersion(version)
+            settings.setShort(short)
+            settings.setDescription(desc)
+            settings.setTarget(target)
+            if not add:
+                zp.update(settings)
+
+        if not add:
+            if old_name == name:
+                return
+            zp.rename(name)
+        else:
+            if policy:
+                self.fw.config().addPolicy(name, settings)
+            else:
+                self.fw.config().addZone(name, settings)
+        self.changes_applied()
 
     def entry_changed(self, entry, allowed_chars, modify=None):
         "Remove all disallowed characters and truncate length."
@@ -3224,124 +3428,28 @@ class FirewallConfig:
         val = check.get_active()
         self.zoneBaseDialogTargetCombobox.set_sensitive(not val)
 
-    def add_edit_zone(self, add):
-        l = functions.max_zone_name_len()
-        self.zoneBaseDialogNameEntry.set_max_length(l)
-        self.zoneBaseDialogNameEntry.set_width_chars(l)
-        self.zoneBaseDialogNameEntry.set_max_width_chars(l)
+    def onPolicyBaseDialogNameChanged(self, *args):
+        def check_policy_name(policy):
+            max_len = functions.max_policy_name_len()
+            parts = policy.split("/")
+            if len(parts) < 2:
+                return (True, policy)
+            if len(parts[0]) > max_len:
+                parts[0] = parts[0][:max_len]
+            policy = "/".join(parts[:2])
+            OK = len(policy) > 1 and policy[0] != "/" and policy[-1] != "/"
+            return (OK, policy)
 
-        if add:
-            default = True
-            builtin = False
-            old_name = None
-            old_version = None
-            old_short = None
-            old_desc = None
-            old_target = None
+        OK = True
+        if args and (args[0] == self.policyBaseDialogNameEntry):
+            additional_chars = "".join(Policy.ADDITIONAL_ALNUM_CHARS)
+            allowed_chars = string.ascii_letters + string.digits + additional_chars
+            OK = self.entry_changed(args[0], allowed_chars, check_policy_name)
+        self.policyBaseDialogOkButton.set_sensitive(OK)
 
-            self.zoneBaseDialogNameEntry.set_text("")
-            self.zoneBaseDialogVersionEntry.set_text("")
-            self.zoneBaseDialogShortEntry.set_text("")
-            self.zoneBaseDialogDescText.get_buffer().set_text("")
-            self.zoneBaseDialogTargetCheck.set_active(True)
-            self.zoneBaseDialogTargetCombobox.set_active(0)
-        else:
-            selected_zone = self.get_selected_zone()
-            zone = self.fw.config().getZoneByName(selected_zone)
-            settings = zone.getSettings()
-            props = zone.get_properties()
-            default = props["default"]
-            builtin = props["builtin"]
-
-            old_name = zone.get_property("name")
-            old_version = settings.getVersion()
-            old_short = settings.getShort()
-            old_desc = settings.getDescription()
-            old_target = settings.getTarget()
-
-            self.zoneBaseDialogNameEntry.set_text(old_name)
-            self.zoneBaseDialogVersionEntry.set_text(old_version)
-            self.zoneBaseDialogShortEntry.set_text(old_short)
-            self.zoneBaseDialogDescText.get_buffer().set_text(old_desc)
-            if old_target == "default" or old_target == DEFAULT_ZONE_TARGET:
-                self.zoneBaseDialogTargetCheck.set_active(True)
-                self.zoneBaseDialogTargetCombobox.set_active(0)
-            else:
-                self.zoneBaseDialogTargetCheck.set_active(False)
-                combobox_select_text(
-                    self.zoneBaseDialogTargetCombobox,
-                    old_target if old_target != "%%REJECT%%" else "REJECT",
-                )
-
-        self.zoneBaseDialogOkButton.set_sensitive(False)
-        if builtin:
-            self.zoneBaseDialogNameEntry.set_tooltip_markup(
-                _("Built-in zone, rename not supported.")
-            )
-        else:
-            self.zoneBaseDialogNameEntry.set_tooltip_markup("")
-        self.zoneBaseDialogNameEntry.set_sensitive(not builtin and default)
-
-        self.zoneBaseDialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
-        self.zoneBaseDialog.set_transient_for(self.mainWindow)
-        self.zoneBaseDialog.show_all()
-        self.add_visible_dialog(self.zoneBaseDialog)
-        result = self.zoneBaseDialog.run()
-        self.zoneBaseDialog.hide()
-        self.remove_visible_dialog(self.zoneBaseDialog)
-
-        if result != 1:
-            return
-
-        name = self.zoneBaseDialogNameEntry.get_text()
-        version = self.zoneBaseDialogVersionEntry.get_text()
-        short = self.zoneBaseDialogShortEntry.get_text()
-        buffer = self.zoneBaseDialogDescText.get_buffer()
-        desc = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), False)
-        target = "default"  # this has been DEFAULT_ZONE_TARGET before
-        if not self.zoneBaseDialogTargetCheck.get_active():
-            target = self.zoneBaseDialogTargetCombobox.get_active_text()
-            if target == "REJECT":
-                target = "%%REJECT%%"
-
-        if (
-            old_name == name
-            and old_version == version
-            and old_short == short
-            and old_desc == desc
-            and old_target == target
-        ):
-            # no changes
-            return
-
-        if not add:
-            selected_zone = self.get_selected_zone()
-            zone = self.fw.config().getZoneByName(selected_zone)
-            settings = zone.getSettings()
-        else:
-            settings = client.FirewallClientZoneSettings()
-
-        if (
-            old_version != version
-            or old_short != short
-            or old_desc != desc
-            or old_target != target
-        ):
-            # settings
-            settings.setVersion(version)
-            settings.setShort(short)
-            settings.setDescription(desc)
-            settings.setTarget(target)
-            if not add:
-                zone.update(settings)
-
-        if not add:
-            if old_name == name:
-                return
-            zone.rename(name)
-        else:
-            self.fw.config().addZone(name, settings)
-        self.changes_applied()
+    def onPolicyBaseDialogTargetCheckToggled(self, check):
+        val = check.get_active()
+        self.policyBaseDialogTargetCombobox.set_sensitive(not val)
 
     def onAddRichRule(self, *args):
         self.add_edit_rich_rule(True)

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1340,8 +1340,20 @@ class FirewallConfig:
         self.policyPortStore.set_sort_column_id(1, Gtk.SortType.ASCENDING)
         self.policyPortView.get_selection().connect("changed", self.change_policy_port_selection_cb)
 
-        self.policyEditPortButton = builder.get_object("editPolicyPortButton")
-        self.policyRemovePortButton = builder.get_object("removePolicyPortButton")
+        self.editPolicyPortButton = builder.get_object("editPolicyPortButton")
+        self.removePolicyPortButton = builder.get_object("removePolicyPortButton")
+
+        self.policyProtocolView = builder.get_object("policyProtocolView")
+        self.policyProtocolStore = Gtk.ListStore(GObject.TYPE_STRING)
+        self.policyProtocolView.append_column(
+            Gtk.TreeViewColumn(_("Protocol"), Gtk.CellRendererText(), text=0)
+        )
+        self.policyProtocolView.set_model(self.policyProtocolStore)
+        self.policyProtocolStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+        self.policyProtocolView.get_selection().connect("changed", self.change_policy_protocol_selection_cb)
+
+        self.editPolicyProtocolButton = builder.get_object("editPolicyProtocolButton")
+        self.removePolicyProtocolButton = builder.get_object("removePolicyProtocolButton")
 
         # firewall client
 
@@ -2054,11 +2066,11 @@ class FirewallConfig:
     def change_policy_port_selection_cb(self, selection):
         (model, iter) = selection.get_selected()
         if iter:
-            self.policyEditPortButton.set_sensitive(True)
-            self.policyRemovePortButton.set_sensitive(True)
+            self.editPolicyPortButton.set_sensitive(True)
+            self.removePolicyPortButton.set_sensitive(True)
         else:
-            self.policyEditPortButton.set_sensitive(False)
-            self.policyRemovePortButton.set_sensitive(False)
+            self.editPolicyPortButton.set_sensitive(False)
+            self.removePolicyPortButton.set_sensitive(False)
 
     def change_port_selection_cb(self, selection):
         (model, iter) = selection.get_selected()
@@ -2077,6 +2089,15 @@ class FirewallConfig:
         else:
             self.editSourcePortButton.set_sensitive(False)
             self.removeSourcePortButton.set_sensitive(False)
+
+    def change_policy_protocol_selection_cb(self, selection):
+        (model, iter) = selection.get_selected()
+        if iter:
+            self.editPolicyProtocolButton.set_sensitive(True)
+            self.removePolicyProtocolButton.set_sensitive(True)
+        else:
+            self.editPolicyProtocolButton.set_sensitive(False)
+            self.removePolicyProtocolButton.set_sensitive(False)
 
     def change_protocol_selection_cb(self, selection):
         (model, iter) = selection.get_selected()
@@ -3134,6 +3155,7 @@ class FirewallConfig:
         selected_policy = self.get_selected_policy()
 
         self.policyPortStore.clear()
+        self.policyProtocolStore.clear()
 
         if not selected_policy:
             self.policyIngressHostButton.set_sensitive(False)
@@ -3158,6 +3180,7 @@ class FirewallConfig:
                 iter = self.serviceStore.iter_next(iter)
 
             self.policyPortView.set_sensitive(False)
+            self.policyProtocolView.set_sensitive(False)
 
             return
 
@@ -3172,6 +3195,7 @@ class FirewallConfig:
         self.policyServiceView.set_sensitive(True)
 
         self.policyPortView.set_sensitive(True)
+        self.policyProtocolView.set_sensitive(True)
 
         iter = self.zoneStore.get_iter_first()
         while iter:
@@ -3248,10 +3272,14 @@ class FirewallConfig:
         for item in settings["ports"]:
             self.policyPortStore.append(item)
 
+        for item in settings["protocols"]:
+            self.policyProtocolStore.append([item])
+
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyPortView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policyProtocolView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
     def onAddZone(self, *args):
         if self.runtime_view:
@@ -5238,14 +5266,10 @@ class FirewallConfig:
             iter = self.sourcePortStore.iter_next(iter)
 
     def onAddProtocol(self, *args):
-        self.add_edit_protocol(True)
+        self.add_edit_protocol(False, True)
 
     def onEditProtocol(self, *args):
-        self.add_edit_protocol(False)
-
-    def onProtocolClicked(self, widget, event):
-        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
-            self.add_edit_protocol(False)
+        self.add_edit_protocol(False, False)
 
     def onRemoveProtocol(self, *args):
         selected_zone = self.get_selected_zone()
@@ -5262,16 +5286,54 @@ class FirewallConfig:
             zone.removeProtocol(proto)
         self.changes_applied()
 
-    def add_edit_protocol(self, add):
-        selected_zone = self.get_selected_zone()
+    def onProtocolClicked(self, widget, event):
+        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            self.add_edit_protocol(False, False)
+
+    def onAddPolicyProtocol(self, *args):
+        self.add_edit_protocol(True, True)
+
+    def onEditPolicyProtocol(self, *args):
+        self.add_edit_protocol(True, False)
+
+    def onRemovePolicyProtocol(self, *args):
+        selected_policy = self.get_selected_policy()
+        selection = self.policyProtocolView.get_selection()
+        (model, iter) = selection.get_selected()
+        if iter is None:
+            return
+        proto = self.policyProtocolStore.get_value(iter, 0)
+
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy)
+            settings.removeProtocol(proto)
+            self.fw.setPolicySettings(selected_policy, settings)
+        else:
+            policy = self.fw.config().getPolicyByName(selected_policy)
+            settings = policy.getSettings()
+            settings.removeProtocol(proto)
+            policy.update(settings)
+        self.changes_applied()
+
+    def onPolicyProtocolClicked(self, widget, event):
+        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            self.add_edit_protocol(True, False)
+
+    def add_edit_protocol(self, policy, add):
+        if policy:
+            selected = self.get_selected_policy()
+            protocol_view = self.policyProtocolView
+        else:
+            selected = self.get_selected_zone()
+            protocol_view = self.protocolView
 
         old_proto = None
         if not add:
-            selection = self.protocolView.get_selection()
+            selection = protocol_view.get_selection()
             (model, iter) = selection.get_selected()
             if iter is None:
                 return
-            old_proto = self.protocolStore.get_value(iter, 0)
+            old_proto = model.get_value(iter, 0)
 
         self.protoDialogProtoCombobox.set_active(0)
         self.protoDialogOtherProtoCheck.set_active(False)
@@ -5302,17 +5364,31 @@ class FirewallConfig:
             return
 
         if self.runtime_view:
-            if not self.fw.queryProtocol(selected_zone, proto):
-                self.fw.addProtocol(selected_zone, proto)
-                if not add:
-                    self.fw.removeProtocol(selected_zone, old_proto)
-                self.changes_applied()
+            if policy:
+                settings = self.fw.getPolicySettings(selected)
+                if not settings.queryProtocol(proto):
+                    settings.addProtocol(proto)
+                    if not add:
+                        settings.removeProtocol(old_proto)
+                    self.fw.setPolicySettings(selected, settings)
+                    self.changes_applied()
+            else:
+                if not self.fw.queryProtocol(selected, proto):
+                    self.fw.addProtocol(selected, proto)
+                    if not add:
+                        self.fw.removeProtocol(selected, old_proto)
+                    self.changes_applied()
         else:
-            zone = self.fw.config().getZoneByName(selected_zone)
-            if not zone.queryProtocol(proto):
+            if policy:
+                zp = self.fw.config().getPolicyByName(selected)
+            else:
+                zp = self.fw.config().getZoneByName(selected)
+            settings = zp.getSettings()
+            if not settings.queryProtocol(proto):
                 if not add:
-                    zone.removeProtocol(old_proto)
-                zone.addProtocol(proto)
+                    settings.removeProtocol(old_proto)
+                settings.addProtocol(proto)
+                zp.update(settings)
                 self.changes_applied()
 
     def service_conf_add_edit_protocol(self, add):

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1257,7 +1257,7 @@ class FirewallConfig:
         )
 
         self.policyView = builder.get_object("policyView")
-        self.policyStore = Gtk.ListStore(GObject.TYPE_STRING)
+        self.policyStore = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING) # name, tooltip
         self.policyView.append_column(Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0))
         self.policyView.set_model(self.policyStore)
         self.policyStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
@@ -1846,7 +1846,12 @@ class FirewallConfig:
 
         # policies
         for item in policies:
-            self.policyStore.append([item])
+            if self.runtime_view:
+                settings = self.fw.getPolicySettings(item)
+            else:
+                settings = self.fw.config().getPolicyByName(item).getSettings()
+
+            self.policyStore.append([item, settings.getDescription()])
 
         if selected_policy in policies:
             _policy = selected_policy
@@ -8343,7 +8348,7 @@ class FirewallConfig:
             if self.policyStore.get_value(iter, 0) == policy:
                 return
             iter = self.policyStore.iter_next(iter)
-        self.policyStore.append([policy])
+        self.policyStore.append([policy, self.fw.config().getPolicyByName(policy).getSettings().getDescription()])
         selection = self.policyView.get_selection()
         if selection.count_selected_rows() == 0:
             selection.select_path(0)

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -3127,6 +3127,7 @@ class FirewallConfig:
                     while iter:
                         if self.policyIngressZoneStore.get_value(iter, 1) == item:
                             self.policyIngressZoneStore.set_value(iter, 0, True)
+                            break
                         iter = self.policyIngressZoneStore.iter_next(iter)
                     self.policyIngressZonesButton.set_active(True)
                     self.policyIngressZoneView.set_sensitive(True)
@@ -3148,6 +3149,7 @@ class FirewallConfig:
                     while iter:
                         if self.policyEgressZoneStore.get_value(iter, 1) == item:
                             self.policyEgressZoneStore.set_value(iter, 0, True)
+                            break
                         iter = self.policyEgressZoneStore.iter_next(iter)
                     self.policyEgressZonesButton.set_active(True)
                     self.policyEgressZoneView.set_sensitive(True)

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -517,7 +517,7 @@ class FirewallConfig:
         self.forwardView.set_model(self.forwardStore)
         self.forwardStore.set_sort_column_id(1, Gtk.SortType.ASCENDING)
         self.forwardView.get_selection().connect(
-            "changed", self.change_forward_selection_cb
+            "changed", self.change_zone_forward_selection_cb
         )
 
         self.editForwardButton = builder.get_object("editForwardButton")
@@ -1374,6 +1374,34 @@ class FirewallConfig:
 
         self.policyMasqueradeCheck = builder.get_object("policyMasqueradeCheck")
 
+        self.policyForwardView = builder.get_object("policyForwardView")
+        self.policyForwardStore = Gtk.ListStore(
+            GObject.TYPE_STRING,
+            GObject.TYPE_STRING,
+            GObject.TYPE_STRING,
+            GObject.TYPE_STRING,
+        )
+        self.policyForwardView.append_column(
+            Gtk.TreeViewColumn(_("Port"), Gtk.CellRendererText(), text=0)
+        )
+        self.policyForwardView.append_column(
+            Gtk.TreeViewColumn(_("Protocol"), Gtk.CellRendererText(), text=1)
+        )
+        self.policyForwardView.append_column(
+            Gtk.TreeViewColumn(_("To Port"), Gtk.CellRendererText(), text=2)
+        )
+        self.policyForwardView.append_column(
+            Gtk.TreeViewColumn(_("To Address"), Gtk.CellRendererText(), text=3)
+        )
+        self.policyForwardView.set_model(self.policyForwardStore)
+        self.policyForwardStore.set_sort_column_id(1, Gtk.SortType.ASCENDING)
+        self.policyForwardView.get_selection().connect(
+            "changed", self.change_policy_forward_selection_cb
+        )
+
+        self.editPolicyForwardButton = builder.get_object("editPolicyForwardButton")
+        self.removePolicyForwardButton = builder.get_object("removePolicyForwardButton")
+
         # firewall client
 
         self.fw = client.FirewallClient(wait=1)
@@ -2136,14 +2164,27 @@ class FirewallConfig:
             self.editProtocolButton.set_sensitive(False)
             self.removeProtocolButton.set_sensitive(False)
 
-    def change_forward_selection_cb(self, selection):
+    def change_forward_selection_cb(self, policy, selection):
+        if policy:
+            edit_button = self.editPolicyForwardButton
+            remove_button = self.removePolicyForwardButton
+        else:
+            edit_button = self.editForwardButton
+            remove_button = self.removeForwardButton
+
         (model, iter) = selection.get_selected()
         if iter:
-            self.editForwardButton.set_sensitive(True)
-            self.removeForwardButton.set_sensitive(True)
+            edit_button.set_sensitive(True)
+            remove_button.set_sensitive(True)
         else:
-            self.editForwardButton.set_sensitive(False)
-            self.removeForwardButton.set_sensitive(False)
+            edit_button.set_sensitive(False)
+            remove_button.set_sensitive(False)
+
+    def change_zone_forward_selection_cb(self, selection):
+        self.change_forward_selection_cb(False, selection)
+
+    def change_policy_forward_selection_cb(self, selection):
+        self.change_forward_selection_cb(True, selection)
 
     def masquerade_check_cb(self, policy):
         if policy:
@@ -3215,6 +3256,7 @@ class FirewallConfig:
         self.policyPortStore.clear()
         self.policyProtocolStore.clear()
         self.policySourcePortStore.clear()
+        self.policyForwardStore.clear()
 
         if not selected_policy:
             self.policyIngressHostButton.set_sensitive(False)
@@ -3242,6 +3284,7 @@ class FirewallConfig:
             self.policyProtocolView.set_sensitive(False)
             self.policySourcePortView.set_sensitive(False)
             self.policyMasqueradeCheck.set_active(False)
+            self.policyForwardView.set_sensitive(False)
 
             return
 
@@ -3258,6 +3301,7 @@ class FirewallConfig:
         self.policyPortView.set_sensitive(True)
         self.policyProtocolView.set_sensitive(True)
         self.policySourcePortView.set_sensitive(True)
+        self.policyForwardView.set_sensitive(True)
 
         iter = self.zoneStore.get_iter_first()
         while iter:
@@ -3275,6 +3319,7 @@ class FirewallConfig:
         self.policyPortView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyProtocolView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policySourcePortView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+        self.policyForwardView.get_selection().set_mode(Gtk.SelectionMode.NONE)
 
         if self.runtime_view:
             settings = self.fw.getPolicySettings(selected_policy).getSettingsDict()
@@ -3344,12 +3389,16 @@ class FirewallConfig:
 
         self.policyMasqueradeCheck.set_active(settings["masquerade"])
 
+        for item in settings["forward_ports"]:
+            self.policyForwardStore.append(item)
+
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyPortView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyProtocolView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policySourcePortView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policyForwardView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
     def onAddZone(self, *args):
         if self.runtime_view:
@@ -5647,14 +5696,64 @@ class FirewallConfig:
         self.forwardDialogOkButton.set_sensitive(ok)
 
     def onAddForwardPort(self, *args):
-        self.add_edit_forward_port(True)
+        self.add_edit_forward_port(False, True)
 
     def onEditForwardPort(self, *args):
-        self.add_edit_forward_port(False)
+        self.add_edit_forward_port(False, False)
+
+    def onRemoveForwardPort(self, *args):
+        selected_zone = self.get_selected_zone()
+        selection = self.forwardView.get_selection()
+        (model, iter) = selection.get_selected()
+        if iter is None:
+            return
+        port = self.forwardStore.get_value(iter, 0)
+        proto = self.forwardStore.get_value(iter, 1)
+        to_port = self.forwardStore.get_value(iter, 2)
+        to_addr = self.forwardStore.get_value(iter, 3)
+
+        if self.runtime_view:
+            self.fw.removeForwardPort(selected_zone, port, proto, to_port, to_addr)
+        else:
+            zone = self.fw.config().getZoneByName(selected_zone)
+            zone.removeForwardPort(port, proto, to_port, to_addr)
+        self.changes_applied()
 
     def onForwardPortClicked(self, widget, event):
         if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
-            self.add_edit_forward_port(False)
+            self.add_edit_forward_port(False, False)
+
+    def onAddPolicyForwardPort(self, *args):
+        self.add_edit_forward_port(True, True)
+
+    def onEditPolicyForwardPort(self, *args):
+        self.add_edit_forward_port(True, False)
+
+    def onRemovePolicyForwardPort(self, *args):
+        selected_policy = self.get_selected_policy()
+        selection = self.policyForwardView.get_selection()
+        (model, iter) = selection.get_selected()
+        if iter is None:
+            return
+        port = model.get_value(iter, 0)
+        proto = model.get_value(iter, 1)
+        to_port = model.get_value(iter, 2)
+        to_addr = model.get_value(iter, 3)
+
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy)
+            settings.removeForwardPort(port, proto, to_port, to_addr)
+            self.fw.setPolicySettings(selected_policy, settings)
+        else:
+            policy = self.fw.config().getPolicyByName(selected_zone)
+            settings = policy.getSettings()
+            settings.removeForwardPort(port, proto, to_port, to_addr)
+            policy.update(settings)
+        self.changes_applied()
+
+    def onPolicyForwardPortClicked(self, widget, event):
+        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            self.add_edit_forward_port(True, False)
 
     def forwardport_select_dialog(self, family, old_value=None):
         self.forwardDialogOkButton.set_sensitive(False)
@@ -5710,8 +5809,13 @@ class FirewallConfig:
 
         return value
 
-    def add_edit_forward_port(self, add):
-        selected_zone = self.get_selected_zone()
+    def add_edit_forward_port(self, policy, add):
+        if policy:
+            selected = self.get_selected_policy()
+            forward_view = self.policyForwardView
+        else:
+            selected = self.get_selected_zone()
+            forward_view = self.forwardView
 
         self.forwardDialogOkButton.set_sensitive(False)
         self.forwardDialogLocalCheck.set_active(True)
@@ -5730,14 +5834,14 @@ class FirewallConfig:
             self.forwardDialogToPortEntry.set_text("")
             self.forwardDialogToAddrEntry.set_text("")
         else:
-            selection = self.forwardView.get_selection()
+            selection = forward_view.get_selection()
             (model, iter) = selection.get_selected()
             if iter is None:
                 return
-            old_port = self.forwardStore.get_value(iter, 0)
-            old_proto = self.forwardStore.get_value(iter, 1)
-            old_to_port = self.forwardStore.get_value(iter, 2)
-            old_to_addr = self.forwardStore.get_value(iter, 3)
+            old_port = model.get_value(iter, 0)
+            old_proto = model.get_value(iter, 1)
+            old_to_port = model.get_value(iter, 2)
+            old_to_addr = model.get_value(iter, 3)
 
             self.forwardDialogPortEntry.set_text(old_port)
             combobox_select_text(self.forwardDialogProtoCombobox, old_proto)
@@ -5780,29 +5884,50 @@ class FirewallConfig:
             return
 
         if self.runtime_view:
-            if not self.fw.queryForwardPort(
-                selected_zone, port, proto, to_port, to_addr
-            ):
-                self.fw.addForwardPort(selected_zone, port, proto, to_port, to_addr)
-                if not add:
-                    self.fw.removeForwardPort(
-                        selected_zone, old_port, old_proto, old_to_port, old_to_addr
-                    )
-                if add and to_addr and not self.fw.queryMasquerade(selected_zone):
-                    if self.masqueradeQueryDialog() == Gtk.ResponseType.YES:
-                        self.fw.addMasquerade(selected_zone)
-                self.changes_applied()
+            if policy:
+                settings = self.fw.getPolicySettings(selected)
+                if not settings.queryForwardPort(
+                    port, proto, to_port, to_addr
+                ):
+                    settings.addForwardPort(port, proto, to_port, to_addr)
+                    if not add:
+                        settings.removeForwardPort(
+                            old_port, old_proto, old_to_port, old_to_addr
+                        )
+                    if add and to_addr and not settings.queryMasquerade():
+                        if self.masqueradeQueryDialog() == Gtk.ResponseType.YES:
+                            settings.addMasquerade()
+                    self.fw.setPolicySettings(selected, settings)
+                    self.changes_applied()
+            else:
+                if not self.fw.queryForwardPort(
+                    selected, port, proto, to_port, to_addr
+                ):
+                    self.fw.addForwardPort(selected, port, proto, to_port, to_addr)
+                    if not add:
+                        self.fw.removeForwardPort(
+                            selected, old_port, old_proto, old_to_port, old_to_addr
+                        )
+                    if add and to_addr and not self.fw.queryMasquerade(selected):
+                        if self.masqueradeQueryDialog() == Gtk.ResponseType.YES:
+                            self.fw.addMasquerade(selected)
+                    self.changes_applied()
         else:
-            zone = self.fw.config().getZoneByName(selected_zone)
-            if not zone.queryForwardPort(port, proto, to_port, to_addr):
+            if policy:
+                pz = self.fw.config().getPolicyByName(selected)
+            else:
+                pz = self.fw.config().getZoneByName(selected)
+            settings = pz.getSettings()
+            if not settings.queryForwardPort(port, proto, to_port, to_addr):
                 if not add:
-                    zone.removeForwardPort(
+                    settings.removeForwardPort(
                         old_port, old_proto, old_to_port, old_to_addr
                     )
-                zone.addForwardPort(port, proto, to_port, to_addr)
-                if add and to_addr and not zone.getMasquerade():
+                settings.addForwardPort(port, proto, to_port, to_addr)
+                if add and to_addr and not settings.getMasquerade():
                     if self.masqueradeQueryDialog() == Gtk.ResponseType.YES:
-                        zone.setMasquerade(True)
+                        settings.setMasquerade(True)
+                pz.update(settings)
                 self.changes_applied()
 
     def masqueradeQueryDialog(self):
@@ -5854,24 +5979,6 @@ class FirewallConfig:
                 self.forwardStore.remove(iter)
                 break
             iter = self.forwardStore.iter_next(iter)
-
-    def onRemoveForwardPort(self, *args):
-        selected_zone = self.get_selected_zone()
-        selection = self.forwardView.get_selection()
-        (model, iter) = selection.get_selected()
-        if iter is None:
-            return
-        port = self.forwardStore.get_value(iter, 0)
-        proto = self.forwardStore.get_value(iter, 1)
-        to_port = self.forwardStore.get_value(iter, 2)
-        to_addr = self.forwardStore.get_value(iter, 3)
-
-        if self.runtime_view:
-            self.fw.removeForwardPort(selected_zone, port, proto, to_port, to_addr)
-        else:
-            zone = self.fw.config().getZoneByName(selected_zone)
-            zone.removeForwardPort(port, proto, to_port, to_addr)
-        self.changes_applied()
 
     def onChangeService(self, *args):
         active_service = self.get_active_service()

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -8130,8 +8130,27 @@ class FirewallConfig:
             iter = self.policyStore.iter_next(iter)
 
     def conf_policy_renamed_cb(self, policy):
-        return
+        if self.runtime_view:
+            return
 
+        # Get all zones, renamed the one that is missing.
+        # If more or less than one is missing, update zone store.
+
+        policies = self.fw.config().getPolicyNames()
+
+        use_iter = None
+        iter = self.policyStore.get_iter_first()
+        while iter:
+            if self.policyStore.get_value(iter, 0) not in policies:
+                if use_iter is not None:
+                    return self.load_policies()
+                use_iter = iter
+            iter = self.policyStore.iter_next(iter)
+
+        if use_iter is None:
+            return self.load_policies()
+
+        self.policyStore.set_value(use_iter, 0, policy)
 
 def combobox_select_text(combobox, value, insensitive=False):
     model = combobox.get_model()

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -416,16 +416,16 @@ class FirewallConfig:
 
         self.serviceView = builder.get_object("serviceView")
         self.serviceStore = Gtk.ListStore(
-            GObject.TYPE_BOOLEAN, GObject.TYPE_STRING  # checked
+            GObject.TYPE_BOOLEAN, GObject.TYPE_BOOLEAN, GObject.TYPE_STRING  # zone-checked, policy-checked
         )  # name
         toggle = Gtk.CellRendererToggle()
         toggle.connect("toggled", self.service_toggle_cb, self.serviceStore, 0)
         self.serviceView.append_column(Gtk.TreeViewColumn("", toggle, active=0))
         self.serviceView.append_column(
-            Gtk.TreeViewColumn(_("Service"), Gtk.CellRendererText(), text=1)
+            Gtk.TreeViewColumn(_("Service"), Gtk.CellRendererText(), text=2)
         )
         self.serviceView.set_model(self.serviceStore)
-        self.serviceStore.set_sort_column_id(1, Gtk.SortType.ASCENDING)
+        self.serviceStore.set_sort_column_id(2, Gtk.SortType.ASCENDING)
 
         self.portView = builder.get_object("portView")
         self.portStore = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)
@@ -1787,9 +1787,9 @@ class FirewallConfig:
         self.automatic_helpers = self.fw.getAutomaticHelpers()
         self.set_automaticHelpersLabel(self.automatic_helpers)
         self.load_ipsets()
+        self.load_services()
         self.load_zones()
         self.load_policies()
-        self.load_services()
         self.load_icmps()
         self.load_helpers()
         self.load_direct()
@@ -1877,12 +1877,12 @@ class FirewallConfig:
 
         if self.runtime_view:
             for item in self.fw.listServices():
-                self.serviceStore.append([False, item])
+                self.serviceStore.append([False, False, item])
             for item in self.fw.listIcmpTypes():
                 self.icmpStore.append([False, item])
         else:
             for item in self.fw.config().getServiceNames():
-                self.serviceStore.append([False, item])
+                self.serviceStore.append([False, False, item])
             for item in self.fw.config().getIcmpTypeNames():
                 self.icmpStore.append([False, item])
 
@@ -1974,7 +1974,7 @@ class FirewallConfig:
             return
         iter = self.serviceStore.get_iter_first()
         while iter:
-            if self.serviceStore.get_value(iter, 1) == service:
+            if self.serviceStore.get_value(iter, 2) == service:
                 self.serviceStore.set_value(iter, 0, True)
                 break
             iter = self.serviceStore.iter_next(iter)
@@ -1984,7 +1984,7 @@ class FirewallConfig:
             return
         iter = self.serviceStore.get_iter_first()
         while iter:
-            if self.serviceStore.get_value(iter, 1) == service:
+            if self.serviceStore.get_value(iter, 2) == service:
                 self.serviceStore.set_value(iter, 0, False)
                 break
             iter = self.serviceStore.iter_next(iter)
@@ -2997,7 +2997,7 @@ class FirewallConfig:
         _services = services[:]
         iter = self.serviceStore.get_iter_first()
         while iter:
-            name = self.serviceStore.get_value(iter, 1)
+            name = self.serviceStore.get_value(iter, 2)
             if name in _services:
                 self.serviceStore.set_value(iter, 0, True)
                 _services.remove(name)
@@ -3143,8 +3143,14 @@ class FirewallConfig:
             self.zoneStore.set(iter, 3, False, 4, False)
             iter = self.zoneStore.iter_next(iter)
 
+        iter = self.serviceStore.get_iter_first()
+        while iter:
+            self.serviceStore.set_value(iter, 1, False)
+            iter = self.serviceStore.iter_next(iter)
+
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+        self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.NONE)
 
         if self.runtime_view:
             settings = self.fw.getPolicySettings(selected_policy).getSettingsDict()
@@ -3195,8 +3201,17 @@ class FirewallConfig:
                     self.policyEgressZonesButton.set_active(True)
                     self.policyEgressZoneView.set_sensitive(True)
 
+        for item in settings["services"]:
+            iter = self.serviceStore.get_iter_first()
+            while iter:
+                if self.serviceStore.get_value(iter, 2) == item:
+                    self.serviceStore.set_value(iter, 1, True)
+                    break
+                iter = self.serviceStore.iter_next(iter)
+
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
     def onAddZone(self, *args):
         if self.runtime_view:

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1251,6 +1251,49 @@ class FirewallConfig:
             "changed", self.change_icmptype_selection_cb
         )
 
+        self.policyView = builder.get_object("policyView")
+        self.policyStore = Gtk.ListStore(GObject.TYPE_STRING)
+        self.policyView.append_column(Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0))
+        self.policyView.set_model(self.policyStore)
+        self.policyStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+        self.policyView.get_selection().connect("changed", self.onChangePolicy)
+
+        self.policyIngressHostButton = builder.get_object("policyIngressHostButton")
+        self.policyIngressHostEventBox = builder.get_object("policyIngressHostEventBox")
+        self.policyIngressHostEventBox.connect("button-press-event", self.policy_ingress_host_toggle_cb)
+        self.policyIngressAnyButton = builder.get_object("policyIngressAnyButton")
+        self.policyIngressAnyEventBox = builder.get_object("policyIngressAnyEventBox")
+        self.policyIngressAnyEventBox.connect("button-press-event", self.policy_ingress_any_toggle_cb)
+        self.policyIngressZonesButton = builder.get_object("policyIngressZonesButton")
+        self.policyIngressZonesEventBox = builder.get_object("policyIngressZonesEventBox")
+        self.policyIngressZonesEventBox.connect("button-press-event", self.policy_ingress_zones_toggle_cb)
+
+        self.policyIngressZoneView = builder.get_object("policyIngressZoneView")
+        self.policyIngressZoneStore = Gtk.ListStore(GObject.TYPE_BOOLEAN, GObject.TYPE_STRING)
+        toggle = Gtk.CellRendererToggle()
+        toggle.connect("toggled", self.policy_ingress_zone_toggle_cb)
+        self.policyIngressZoneView.append_column(Gtk.TreeViewColumn("", toggle, active=0))
+        self.policyIngressZoneView.append_column(Gtk.TreeViewColumn(_("Zone"), Gtk.CellRendererText(), text=1))
+        self.policyIngressZoneView.set_model(self.policyIngressZoneStore)
+
+        self.policyEgressHostButton = builder.get_object("policyEgressHostButton")
+        self.policyEgressHostEventBox = builder.get_object("policyEgressHostEventBox")
+        self.policyEgressHostEventBox.connect("button-press-event", self.policy_egress_host_toggle_cb)
+        self.policyEgressAnyButton = builder.get_object("policyEgressAnyButton")
+        self.policyEgressAnyEventBox = builder.get_object("policyEgressAnyEventBox")
+        self.policyEgressAnyEventBox.connect("button-press-event", self.policy_egress_any_toggle_cb)
+        self.policyEgressZonesButton = builder.get_object("policyEgressZonesButton")
+        self.policyEgressZonesEventBox = builder.get_object("policyEgressZonesEventBox")
+        self.policyEgressZonesEventBox.connect("button-press-event", self.policy_egress_zones_toggle_cb)
+
+        self.policyEgressZoneView = builder.get_object("policyEgressZoneView")
+        self.policyEgressZoneStore = Gtk.ListStore(GObject.TYPE_BOOLEAN, GObject.TYPE_STRING)
+        toggle = Gtk.CellRendererToggle()
+        toggle.connect("toggled", self.policy_egress_zone_toggle_cb)
+        self.policyEgressZoneView.append_column(Gtk.TreeViewColumn("", toggle, active=0))
+        self.policyEgressZoneView.append_column(Gtk.TreeViewColumn(_("Zone"), Gtk.CellRendererText(), text=1))
+        self.policyEgressZoneView.set_model(self.policyEgressZoneStore)
+
         # firewall client
 
         self.fw = client.FirewallClient(wait=1)
@@ -1326,6 +1369,11 @@ class FirewallConfig:
         self.fw.connect("config:helper-updated", self.conf_helper_updated_cb)
         self.fw.connect("config:helper-removed", self.conf_helper_removed_cb)
         self.fw.connect("config:helper-renamed", self.conf_helper_renamed_cb)
+        self.fw.connect("policy-updated", self.policy_updated_cb)
+        self.fw.connect("config:policy-added", self.conf_policy_added_cb)
+        self.fw.connect("config:policy-updated", self.conf_policy_updated_cb)
+        self.fw.connect("config:policy-removed", self.conf_policy_removed_cb)
+        self.fw.connect("config:policy-renamed", self.conf_policy_renamed_cb)
 
         # settings
 
@@ -1706,6 +1754,7 @@ class FirewallConfig:
         self.set_automaticHelpersLabel(self.automatic_helpers)
         self.load_ipsets()
         self.load_zones()
+        self.load_policies()
         self.load_services()
         self.load_icmps()
         self.load_helpers()
@@ -1731,6 +1780,47 @@ class FirewallConfig:
 
         self.zoneStore.append([zone, weight, desc])
 
+    def load_policies(self):
+        selected_policy = self.get_selected_policy()
+
+        if self.runtime_view:
+            policies = self.fw.getPolicies()
+        else:
+            policies = self.fw.config().getPolicyNames()
+
+        # reset and fill notebook content according to view
+
+        selection = self.policyView.get_selection()
+        selection.set_mode(Gtk.SelectionMode.NONE)
+
+        self.policyStore.clear()
+        # self.policyServiceStore.clear()
+        # self.policyPortStore.clear()
+        # self.policyProtocolStore.clear()
+        # self.policyForwardStore.clear()
+        # self.policyIcmpStore.clear()
+        # self.policyRichRuleStore.clear()
+
+        # policies
+        for item in policies:
+            self.policyStore.append([item])
+
+        if selected_policy in policies:
+            _policy = selected_policy
+        else:
+            _policy = None
+
+        selection.set_mode(Gtk.SelectionMode.SINGLE)
+
+        iter = self.policyStore.get_iter_first()
+        while iter:
+            if self.policyStore.get_value(iter, 0) == _policy:
+                selection.select_iter(iter)
+                return
+            iter = self.policyStore.iter_next(iter)
+        # fallback
+        selection.select_path(0)
+
     def load_zones(self):
         selected_zone = self.get_selected_zone()
 
@@ -1744,6 +1834,9 @@ class FirewallConfig:
         selection = self.zoneView.get_selection()
         selection.set_mode(Gtk.SelectionMode.NONE)
 
+        self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+        self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+
         self.zoneStore.clear()
         self.serviceStore.clear()
         self.portStore.clear()
@@ -1753,6 +1846,8 @@ class FirewallConfig:
         self.richRuleStore.clear()
         self.interfaceStore.clear()
         self.sourceStore.clear()
+        self.policyEgressZoneStore.clear()
+        self.policyIngressZoneStore.clear()
 
         if self.runtime_view:
             for item in self.fw.listServices():
@@ -1764,6 +1859,18 @@ class FirewallConfig:
                 self.serviceStore.append([False, item])
             for item in self.fw.config().getIcmpTypeNames():
                 self.icmpStore.append([False, item])
+
+        # policies
+        self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+
+        for zone in zones:
+            self.policyIngressZoneStore.append([False, zone])
+
+        self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+
+        for zone in zones:
+            self.policyEgressZoneStore.append([False, zone])
 
         # zones
         active_zones = self.active_zones.keys()
@@ -2284,6 +2391,13 @@ class FirewallConfig:
         else:
             self._error(exception_message)
 
+    def get_selected_policy(self):
+        selection = self.policyView.get_selection()
+        (model, iter) = selection.get_selected()
+        if iter:
+            return model.get_value(iter, 0)
+        return None
+
     def get_selected_zone(self):
         selection = self.zoneView.get_selection()
         (model, iter) = selection.get_selected()
@@ -2352,6 +2466,7 @@ class FirewallConfig:
 
         self.load_ipsets()
         self.load_zones()
+        self.load_policies()
         self.load_services()
         self.load_icmps()
         self.load_helpers()
@@ -2942,6 +3057,103 @@ class FirewallConfig:
         self.richRuleView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.interfaceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.sourceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+
+    def onChangePolicy(self, *args):
+        selected_policy = self.get_selected_policy()
+
+        if not selected_policy:
+            self.policyIngressHostButton.set_sensitive(False)
+            self.policyIngressAnyButton.set_sensitive(False)
+            self.policyIngressZonesButton.set_sensitive(False)
+            self.policyIngressZoneView.set_sensitive(False)
+
+            iter = self.policyIngressZoneStore.get_iter_first()
+            while iter:
+                self.policyIngressZoneStore.set_value(iter, 0, False)
+                iter = self.policyIngressZoneStore.iter_next(iter)
+
+            self.policyEgressHostButton.set_sensitive(False)
+            self.policyEgressAnyButton.set_sensitive(False)
+            self.policyEgressZonesButton.set_sensitive(False)
+            self.policyEgressZoneView.set_sensitive(False)
+
+            iter = self.policyEgressZoneStore.get_iter_first()
+            while iter:
+                self.policyEgressZoneStore.set_value(iter, 0, False)
+                iter = self.policyEgressZoneStore.iter_next(iter)
+
+            return
+
+        self.policyIngressAnyButton.set_sensitive(True)
+        self.policyIngressZonesButton.set_sensitive(True)
+        self.policyIngressZoneView.set_sensitive(True)
+
+        self.policyEgressAnyButton.set_sensitive(True)
+        self.policyEgressZonesButton.set_sensitive(True)
+        self.policyEgressZoneView.set_sensitive(True)
+
+        iter = self.policyIngressZoneStore.get_iter_first()
+        while iter:
+            self.policyIngressZoneStore.set_value(iter, 0, False)
+            iter = self.policyIngressZoneStore.iter_next(iter)
+
+        iter = self.policyEgressZoneStore.get_iter_first()
+        while iter:
+            self.policyEgressZoneStore.set_value(iter, 0, False)
+            iter = self.policyEgressZoneStore.iter_next(iter)
+
+        self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+        self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy).getSettingsDict()
+        else:
+            settings = self.fw.config().getPolicyByName(selected_policy).getSettings().getSettingsDict()
+
+        self.policyEgressHostButton.set_sensitive(True)
+        if not settings["ingress_zones"]:
+            self.policyIngressZonesButton.set_active(True)
+            self.policyIngressZoneView.set_sensitive(True)
+        else:
+            self.policyIngressZoneView.set_sensitive(False)
+            for item in settings["ingress_zones"]:
+                if item == "HOST":
+                    self.policyIngressHostButton.set_active(True)
+                    self.policyEgressHostButton.set_sensitive(False)
+                elif item == "ANY":
+                    self.policyIngressAnyButton.set_active(True)
+                else:
+                    iter = self.policyIngressZoneStore.get_iter_first()
+                    while iter:
+                        if self.policyIngressZoneStore.get_value(iter, 1) == item:
+                            self.policyIngressZoneStore.set_value(iter, 0, True)
+                        iter = self.policyIngressZoneStore.iter_next(iter)
+                    self.policyIngressZonesButton.set_active(True)
+                    self.policyIngressZoneView.set_sensitive(True)
+
+        self.policyIngressHostButton.set_sensitive(True)
+        if not settings["egress_zones"]:
+            self.policyEgressZonesButton.set_active(True)
+            self.policyEgressZoneView.set_sensitive(True)
+        else:
+            self.policyEgressZoneView.set_sensitive(False)
+            for item in settings["egress_zones"]:
+                if item == "HOST":
+                    self.policyEgressHostButton.set_active(True)
+                    self.policyIngressHostButton.set_sensitive(False)
+                elif item == "ANY":
+                    self.policyEgressAnyButton.set_active(True)
+                else:
+                    iter = self.policyEgressZoneStore.get_iter_first()
+                    while iter:
+                        if self.policyEgressZoneStore.get_value(iter, 1) == item:
+                            self.policyEgressZoneStore.set_value(iter, 0, True)
+                        iter = self.policyEgressZoneStore.iter_next(iter)
+                    self.policyEgressZonesButton.set_active(True)
+                    self.policyEgressZoneView.set_sensitive(True)
+
+        self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
     def onAddZone(self, *args):
         if self.runtime_view:
@@ -7666,6 +7878,259 @@ class FirewallConfig:
                     entries.append(line)
             f.close()
         return entries
+
+    def policy_ingress_host_toggle_cb(self, *args):
+        if not self.policyIngressHostButton.get_active():
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["ingress_zones"].clear()
+            settings["ingress_zones"].append("HOST")
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+
+            self.changes_applied()
+
+    def policy_ingress_any_toggle_cb(self, *args):
+        if not self.policyIngressAnyButton.get_active():
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["ingress_zones"].clear()
+            settings["ingress_zones"].append("ANY")
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+
+            self.changes_applied()
+
+    def policy_ingress_zones_toggle_cb(self, *args):
+        if not self.policyIngressZonesButton.get_active():
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["ingress_zones"].clear()
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+            self.changes_applied()
+
+    def policy_ingress_zone_toggle_cb(self, toggle, row):
+        iter = self.policyIngressZoneStore.get_iter(row)
+        active = self.policyIngressZoneStore.get_value(iter, 0)
+        zone = self.policyIngressZoneStore.get_value(iter, 1)
+        if active:
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["ingress_zones"].remove(zone)
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+        else:
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["ingress_zones"].append(zone)
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+
+        self.changes_applied()
+
+    def policy_egress_host_toggle_cb(self, *args):
+        if not self.policyEgressHostButton.get_active():
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["egress_zones"].clear()
+            settings["egress_zones"].append("HOST")
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+
+            self.changes_applied()
+
+    def policy_egress_any_toggle_cb(self, *args):
+        if not self.policyEgressAnyButton.get_active():
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["egress_zones"].clear()
+            settings["egress_zones"].append("ANY")
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+
+            self.changes_applied()
+
+    def policy_egress_zones_toggle_cb(self, *args):
+        if not self.policyEgressZonesButton.get_active():
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["egress_zones"].clear()
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+            self.changes_applied()
+
+    def policy_egress_zone_toggle_cb(self, toggle, row):
+        iter = self.policyEgressZoneStore.get_iter(row)
+        active = self.policyEgressZoneStore.get_value(iter, 0)
+        zone = self.policyEgressZoneStore.get_value(iter, 1)
+        if active:
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["egress_zones"].remove(zone)
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+        else:
+            selected_policy = self.get_selected_policy()
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(selected_policy)
+                policy_settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(selected_policy)
+                policy_settings = policy.getSettings()
+
+            settings = policy_settings.getSettingsDict()
+
+            settings["egress_zones"].append(zone)
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(selected_policy, policy_settings)
+            else:
+                policy.update(policy_settings)
+
+        self.changes_applied()
+
+
+    def policy_updated_cb(self, policy, settings):
+        if not self.runtime_view:
+            return
+
+        if self.get_selected_policy() == policy:
+            self.onChangePolicy()
+
+    def conf_policy_added_cb(self, policy):
+        if self.runtime_view:
+            return
+        # check if zone is in store
+        iter = self.policyStore.get_iter_first()
+        while iter:
+            if self.policyStore.get_value(iter, 0) == policy:
+                return
+            iter = self.policyStore.iter_next(iter)
+        self.policyStore.append([policy])
+        selection = self.policyView.get_selection()
+        if selection.count_selected_rows() == 0:
+            selection.select_path(0)
+
+
+    def conf_policy_updated_cb(self, policy):
+        if self.runtime_view:
+            return
+
+        if self.get_selected_policy() == policy:
+            self.onChangePolicy()
+
+    def conf_policy_removed_cb(self, policy):
+        if self.runtime_view:
+            return
+        iter = self.policyStore.get_iter_first()
+        while iter:
+            if self.policyStore.get_value(iter, 0) == policy:
+                self.policyStore.remove(iter)
+                break
+            iter = self.policyStore.iter_next(iter)
+
+    def conf_policy_renamed_cb(self, policy):
+        return
 
 
 def combobox_select_text(combobox, value, insensitive=False):

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1355,6 +1355,23 @@ class FirewallConfig:
         self.editPolicyProtocolButton = builder.get_object("editPolicyProtocolButton")
         self.removePolicyProtocolButton = builder.get_object("removePolicyProtocolButton")
 
+        self.policySourcePortView = builder.get_object("policySourcePortView")
+        self.policySourcePortStore = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)
+        self.policySourcePortView.append_column(
+            Gtk.TreeViewColumn(_("Port"), Gtk.CellRendererText(), text=0)
+        )
+        self.policySourcePortView.append_column(
+            Gtk.TreeViewColumn(_("Protocol"), Gtk.CellRendererText(), text=1)
+        )
+        self.policySourcePortView.set_model(self.policySourcePortStore)
+        self.policySourcePortStore.set_sort_column_id(1, Gtk.SortType.ASCENDING)
+        self.policySourcePortView.get_selection().connect(
+            "changed", self.change_policy_source_port_selection_cb
+        )
+
+        self.editPolicySourcePortButton = builder.get_object("editPolicySourcePortButton")
+        self.removePolicySourcePortButton = builder.get_object("removePolicySourcePortButton")
+
         # firewall client
 
         self.fw = client.FirewallClient(wait=1)
@@ -2089,6 +2106,15 @@ class FirewallConfig:
         else:
             self.editSourcePortButton.set_sensitive(False)
             self.removeSourcePortButton.set_sensitive(False)
+
+    def change_policy_source_port_selection_cb(self, selection):
+        (model, iter) = selection.get_selected()
+        if iter:
+            self.editPolicySourcePortButton.set_sensitive(True)
+            self.removePolicySourcePortButton.set_sensitive(True)
+        else:
+            self.editPolicySourcePortButton.set_sensitive(False)
+            self.removePolicySourcePortButton.set_sensitive(False)
 
     def change_policy_protocol_selection_cb(self, selection):
         (model, iter) = selection.get_selected()
@@ -3156,6 +3182,7 @@ class FirewallConfig:
 
         self.policyPortStore.clear()
         self.policyProtocolStore.clear()
+        self.policySourcePortStore.clear()
 
         if not selected_policy:
             self.policyIngressHostButton.set_sensitive(False)
@@ -3181,6 +3208,7 @@ class FirewallConfig:
 
             self.policyPortView.set_sensitive(False)
             self.policyProtocolView.set_sensitive(False)
+            self.policySourcePortView.set_sensitive(False)
 
             return
 
@@ -3196,6 +3224,7 @@ class FirewallConfig:
 
         self.policyPortView.set_sensitive(True)
         self.policyProtocolView.set_sensitive(True)
+        self.policySourcePortView.set_sensitive(True)
 
         iter = self.zoneStore.get_iter_first()
         while iter:
@@ -3211,6 +3240,8 @@ class FirewallConfig:
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyPortView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+        self.policyProtocolView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+        self.policySourcePortView.get_selection().set_mode(Gtk.SelectionMode.NONE)
 
         if self.runtime_view:
             settings = self.fw.getPolicySettings(selected_policy).getSettingsDict()
@@ -3275,11 +3306,15 @@ class FirewallConfig:
         for item in settings["protocols"]:
             self.policyProtocolStore.append([item])
 
+        for item in settings["source_ports"]:
+            self.policySourcePortStore.append(item)
+
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyPortView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyProtocolView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policySourcePortView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
     def onAddZone(self, *args):
         if self.runtime_view:
@@ -3379,12 +3414,12 @@ class FirewallConfig:
         else:
             if policy:
                 selected = self.get_selected_policy()
-                zp = self.fw.config().getPolicyByName(selected)
+                pz = self.fw.config().getPolicyByName(selected)
             else:
                 selected = self.get_selected_zone()
-                zp = self.fw.config().getZoneByName(selected)
-            settings = zp.getSettings()
-            props = zp.get_properties()
+                pz = self.fw.config().getZoneByName(selected)
+            settings = pz.getSettings()
+            props = pz.get_properties()
             default = props["default"]
             builtin = props["builtin"]
 
@@ -3453,11 +3488,11 @@ class FirewallConfig:
         if not add:
             if policy:
                 selected_policy = self.get_selected_policy()
-                zp = self.fw.config().getPolicyByName(selected_policy)
+                pz = self.fw.config().getPolicyByName(selected_policy)
             else:
                 selected_zone = self.get_selected_zone()
-                zp = self.fw.config().getZoneByName(selected_zone)
-            settings = zp.getSettings()
+                pz = self.fw.config().getZoneByName(selected_zone)
+            settings = pz.getSettings()
         else:
             if policy:
                 settings = client.FirewallClientPolicySettings()
@@ -3476,12 +3511,12 @@ class FirewallConfig:
             settings.setDescription(desc)
             settings.setTarget(target)
             if not add:
-                zp.update(settings)
+                pz.update(settings)
 
         if not add:
             if old_name == name:
                 return
-            zp.rename(name)
+            pz.rename(name)
         else:
             if policy:
                 self.fw.config().addPolicy(name, settings)
@@ -5109,14 +5144,10 @@ class FirewallConfig:
             iter = self.portStore.iter_next(iter)
 
     def onAddSourcePort(self, *args):
-        self.add_edit_source_port(True)
+        self.add_edit_source_port(False, True)
 
     def onEditSourcePort(self, *args):
-        self.add_edit_source_port(False)
-
-    def onSourcePortClicked(self, widget, event):
-        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
-            self.add_edit_source_port(False)
+        self.add_edit_source_port(False, False)
 
     def onRemoveSourcePort(self, *args):
         selected_zone = self.get_selected_zone()
@@ -5134,18 +5165,57 @@ class FirewallConfig:
             zone.removeSourcePort(port, proto)
         self.changes_applied()
 
-    def add_edit_source_port(self, add):
-        selected_zone = self.get_selected_zone()
+    def onSourcePortClicked(self, widget, event):
+        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            self.add_edit_source_port(False, False)
+
+    def onAddPolicySourcePort(self, *args):
+        self.add_edit_source_port(True, True)
+
+    def onEditPolicySourcePort(self, *args):
+        self.add_edit_source_port(True, False)
+
+    def onRemovePolicySourcePort(self, *args):
+        selected_policy = self.get_selected_policy()
+        selection = self.policySourcePortView.get_selection()
+        (model, iter) = selection.get_selected()
+        if iter is None:
+            return
+        port = self.policySourcePortStore.get_value(iter, 0)
+        proto = self.policySourcePortStore.get_value(iter, 1)
+
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy)
+            settings.removeSourcePort(port, proto)
+            self.fw.setPolicySettings(selected_policy, settings)
+        else:
+            policy = self.fw.config().getPolicyByName(selected_policy)
+            settings = policy.getSettings()
+            settings.removeSourcePort(port, proto)
+            policy.update(settings)
+        self.changes_applied()
+
+    def onPolicySourcePortClicked(self, widget, event):
+        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            self.add_edit_source_port(True, False)
+
+    def add_edit_source_port(self, policy, add):
+        if policy:
+            selected = self.get_selected_policy()
+            source_port_view = self.policySourcePortView
+        else:
+            selected = self.get_selected_zone()
+            source_port_view = self.sourcePortView
 
         old_port = None
         old_proto = None
         if not add:
-            selection = self.sourcePortView.get_selection()
+            selection = source_port_view.get_selection()
             (model, iter) = selection.get_selected()
             if iter is None:
                 return
-            old_port = self.sourcePortStore.get_value(iter, 0)
-            old_proto = self.sourcePortStore.get_value(iter, 1)
+            old_port = model.get_value(iter, 0)
+            old_proto = model.get_value(iter, 1)
 
         self.portDialogPortEntry.set_text("")
         self.portDialogProtoCombobox.set_active(0)
@@ -5175,17 +5245,31 @@ class FirewallConfig:
             return
 
         if self.runtime_view:
-            if not self.fw.querySourcePort(selected_zone, port, proto):
-                self.fw.addSourcePort(selected_zone, port, proto)
-                if not add:
-                    self.fw.removeSourcePort(selected_zone, old_port, old_proto)
-                self.changes_applied()
+            if policy:
+                settings = self.fw.getPolicySettings(selected)
+                if not settings.querySourcePort(port, proto):
+                    settings.addSourcePort(port, proto)
+                    if not add:
+                        settings.removeSourcePort(old_port, old_proto)
+                    self.fw.setPolicySettings(selected, settings)
+                    self.changes_applied()
+            else:
+                if not self.fw.querySourcePort(selected, port, proto):
+                    self.fw.addSourcePort(selected, port, proto)
+                    if not add:
+                        self.fw.removeSourcePort(selected, old_port, old_proto)
+                    self.changes_applied()
         else:
-            zone = self.fw.config().getZoneByName(selected_zone)
-            if not zone.querySourcePort(port, proto):
+            if policy:
+                pz = self.fw.config().getPolicyByName(selected)
+            else:
+                pz = self.fw.config().getZoneByName(selected)
+            settings = pz.getSettings()
+            if not settings.querySourcePort(port, proto):
                 if not add:
-                    zone.removeSourcePort(old_port, old_proto)
-                zone.addSourcePort(port, proto)
+                    settings.removeSourcePort(old_port, old_proto)
+                settings.addSourcePort(port, proto)
+                pz.update(settings)
                 self.changes_applied()
 
     def service_conf_add_edit_source_port(self, add):
@@ -5380,15 +5464,15 @@ class FirewallConfig:
                     self.changes_applied()
         else:
             if policy:
-                zp = self.fw.config().getPolicyByName(selected)
+                pz = self.fw.config().getPolicyByName(selected)
             else:
-                zp = self.fw.config().getZoneByName(selected)
-            settings = zp.getSettings()
+                pz = self.fw.config().getZoneByName(selected)
+            settings = pz.getSettings()
             if not settings.queryProtocol(proto):
                 if not add:
                     settings.removeProtocol(old_proto)
                 settings.addProtocol(proto)
-                zp.update(settings)
+                pz.update(settings)
                 self.changes_applied()
 
     def service_conf_add_edit_protocol(self, add):

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -493,7 +493,7 @@ class FirewallConfig:
 
         self.masqueradeCheck = builder.get_object("masqueradeCheck")
         self.masqueradeEventbox = builder.get_object("masqueradeEventbox")
-        self.masqueradeEventbox.connect("button-press-event", self.masquerade_check_cb)
+        self.masqueradeEventbox.connect("button-press-event", self.zone_masquerade_check_cb)
 
         self.forwardView = builder.get_object("forwardView")
         self.forwardStore = Gtk.ListStore(
@@ -1372,6 +1372,8 @@ class FirewallConfig:
         self.editPolicySourcePortButton = builder.get_object("editPolicySourcePortButton")
         self.removePolicySourcePortButton = builder.get_object("removePolicySourcePortButton")
 
+        self.policyMasqueradeCheck = builder.get_object("policyMasqueradeCheck")
+
         # firewall client
 
         self.fw = client.FirewallClient(wait=1)
@@ -2143,21 +2145,51 @@ class FirewallConfig:
             self.editForwardButton.set_sensitive(False)
             self.removeForwardButton.set_sensitive(False)
 
-    def masquerade_check_cb(self, *args):
-        selected_zone = self.get_selected_zone()
-        if self.runtime_view:
-            if not self.masqueradeCheck.get_active():
-                if not self.fw.queryMasquerade(selected_zone):
-                    self.fw.addMasquerade(selected_zone)
-                    self.changes_applied()
-            else:
-                if self.fw.queryMasquerade(selected_zone):
-                    self.fw.removeMasquerade(selected_zone)
-                    self.changes_applied()
+    def masquerade_check_cb(self, policy):
+        if policy:
+            selected = self.get_selected_policy()
+            check = self.policyMasqueradeCheck
         else:
-            zone = self.fw.config().getZoneByName(selected_zone)
-            zone.setMasquerade(not self.masqueradeCheck.get_active())
+            selected = self.get_selected_zone()
+            check = self.masqueradeCheck
+
+        if self.runtime_view:
+            if policy:
+                settings = self.fw.getPolicySettings(selected)
+                if not check.get_active():
+                    if not settings.queryMasquerade():
+                        settings.addMasquerade()
+                        self.fw.setPolicySettings(selected, settings)
+                        self.changes_applied()
+                else:
+                    if settings.queryMasquerade():
+                        settings.removeMasquerade()
+                        self.fw.setPolicySettings(selected, settings)
+                        self.changes_applied()
+            else:
+                if not check.get_active():
+                    if not self.fw.queryMasquerade(selected):
+                        self.fw.addMasquerade(selected)
+                        self.changes_applied()
+                else:
+                    if self.fw.queryMasquerade(selected):
+                        self.fw.removeMasquerade(selected)
+                        self.changes_applied()
+        else:
+            if policy:
+                pz = self.fw.config().getPolicyByName(selected)
+            else:
+                pz = self.fw.config().getZoneByName(selected)
+            settings = pz.getSettings()
+            settings.setMasquerade(not check.get_active())
+            pz.update(settings)
             self.changes_applied()
+
+    def zone_masquerade_check_cb(self, *args):
+        self.masquerade_check_cb(False)
+
+    def policy_masquerade_check_cb(self, *args):
+        self.masquerade_check_cb(True)
 
     def masquerade_added_cb(self, zone, timeout):
         if not self.runtime_view or zone != self.get_selected_zone():
@@ -3209,6 +3241,7 @@ class FirewallConfig:
             self.policyPortView.set_sensitive(False)
             self.policyProtocolView.set_sensitive(False)
             self.policySourcePortView.set_sensitive(False)
+            self.policyMasqueradeCheck.set_active(False)
 
             return
 
@@ -3308,6 +3341,8 @@ class FirewallConfig:
 
         for item in settings["source_ports"]:
             self.policySourcePortStore.append(item)
+
+        self.policyMasqueradeCheck.set_active(settings["masquerade"])
 
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -340,8 +340,12 @@ class FirewallConfig:
 
         self.zoneView = builder.get_object("zoneView")
         self.zoneStore = Gtk.ListStore(
-            GObject.TYPE_STRING, GObject.TYPE_INT, GObject.TYPE_STRING  # name  # weight
-        )  # tooltip
+            GObject.TYPE_STRING, # name
+            GObject.TYPE_INT, # weight
+            GObject.TYPE_STRING,  # tooltip
+            GObject.TYPE_BOOLEAN,  # ingress
+            GObject.TYPE_BOOLEAN  # egress
+        )
         self.zoneView.append_column(
             Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0, weight=1)
         )
@@ -1292,12 +1296,11 @@ class FirewallConfig:
         self.policyIngressZonesEventBox.connect("button-press-event", self.policy_ingress_zones_toggle_cb)
 
         self.policyIngressZoneView = builder.get_object("policyIngressZoneView")
-        self.policyIngressZoneStore = Gtk.ListStore(GObject.TYPE_BOOLEAN, GObject.TYPE_STRING)
         toggle = Gtk.CellRendererToggle()
         toggle.connect("toggled", self.policy_ingress_zone_toggle_cb)
-        self.policyIngressZoneView.append_column(Gtk.TreeViewColumn("", toggle, active=0))
-        self.policyIngressZoneView.append_column(Gtk.TreeViewColumn(_("Zone"), Gtk.CellRendererText(), text=1))
-        self.policyIngressZoneView.set_model(self.policyIngressZoneStore)
+        self.policyIngressZoneView.append_column(Gtk.TreeViewColumn("", toggle, active=3))
+        self.policyIngressZoneView.append_column(Gtk.TreeViewColumn(_("Zone"), Gtk.CellRendererText(), text=0))
+        self.policyIngressZoneView.set_model(self.zoneStore)
 
         self.policyEgressHostButton = builder.get_object("policyEgressHostButton")
         self.policyEgressHostEventBox = builder.get_object("policyEgressHostEventBox")
@@ -1310,12 +1313,20 @@ class FirewallConfig:
         self.policyEgressZonesEventBox.connect("button-press-event", self.policy_egress_zones_toggle_cb)
 
         self.policyEgressZoneView = builder.get_object("policyEgressZoneView")
-        self.policyEgressZoneStore = Gtk.ListStore(GObject.TYPE_BOOLEAN, GObject.TYPE_STRING)
         toggle = Gtk.CellRendererToggle()
         toggle.connect("toggled", self.policy_egress_zone_toggle_cb)
-        self.policyEgressZoneView.append_column(Gtk.TreeViewColumn("", toggle, active=0))
-        self.policyEgressZoneView.append_column(Gtk.TreeViewColumn(_("Zone"), Gtk.CellRendererText(), text=1))
-        self.policyEgressZoneView.set_model(self.policyEgressZoneStore)
+        self.policyEgressZoneView.append_column(Gtk.TreeViewColumn("", toggle, active=4))
+        self.policyEgressZoneView.append_column(Gtk.TreeViewColumn(_("Zone"), Gtk.CellRendererText(), text=0))
+        self.policyEgressZoneView.set_model(self.zoneStore)
+
+        self.policyServiceView = builder.get_object("policyServiceView")
+        toggle = Gtk.CellRendererToggle()
+        toggle.connect("toggled", self.policy_service_toggle_cb)
+        self.policyServiceView.append_column(Gtk.TreeViewColumn("", toggle, active=1))
+        self.policyServiceView.append_column(
+            Gtk.TreeViewColumn(_("Service"), Gtk.CellRendererText(), text=2)
+        )
+        self.policyServiceView.set_model(self.serviceStore)
 
         # firewall client
 
@@ -1801,7 +1812,7 @@ class FirewallConfig:
 
                     desc = re.sub(r"\s+", " ", desc)
 
-        self.zoneStore.append([zone, weight, desc])
+        self.zoneStore.append([zone, weight, desc, False, False])
 
     def load_policies(self):
         selected_policy = self.get_selected_policy()
@@ -1817,12 +1828,6 @@ class FirewallConfig:
         selection.set_mode(Gtk.SelectionMode.NONE)
 
         self.policyStore.clear()
-        # self.policyServiceStore.clear()
-        # self.policyPortStore.clear()
-        # self.policyProtocolStore.clear()
-        # self.policyForwardStore.clear()
-        # self.policyIcmpStore.clear()
-        # self.policyRichRuleStore.clear()
 
         # policies
         for item in policies:
@@ -1869,8 +1874,6 @@ class FirewallConfig:
         self.richRuleStore.clear()
         self.interfaceStore.clear()
         self.sourceStore.clear()
-        self.policyEgressZoneStore.clear()
-        self.policyIngressZoneStore.clear()
 
         if self.runtime_view:
             for item in self.fw.listServices():
@@ -1886,14 +1889,6 @@ class FirewallConfig:
         # policies
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
-
-        for zone in zones:
-            self.policyIngressZoneStore.append([False, zone])
-
-        self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
-
-        for zone in zones:
-            self.policyEgressZoneStore.append([False, zone])
 
         # zones
         active_zones = self.active_zones.keys()
@@ -2011,6 +2006,29 @@ class FirewallConfig:
                 zone.addService(name)
             else:
                 zone.removeService(name)
+            self.changes_applied()
+
+    def policy_service_toggle_cb(self, toggle, row):
+        iter = self.serviceStore.get_iter(row)
+        old_val = self.serviceStore.get_value(iter, 1)
+        name = self.serviceStore.get_value(iter, 2)
+        selected_policy = self.get_selected_policy()
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy)
+            if not old_val:
+                settings.addService(name)
+            else:
+                settings.removeService(name)
+            self.fw.setPolicySettings(selected_policy, settings)
+            self.changes_applied()
+        else:
+            policy = self.fw.config().getPolicyByName(selected_policy)
+            settings = policy.getSettings()
+            if not old_val:
+                settings.addService(name)
+            else:
+                settings.removeService(name)
+            policy.update(settings)
             self.changes_applied()
 
     def change_port_selection_cb(self, selection):
@@ -2491,8 +2509,8 @@ class FirewallConfig:
 
         self.load_ipsets()
         self.load_zones()
-        self.load_policies()
         self.load_services()
+        self.load_policies()
         self.load_icmps()
         self.load_helpers()
         self.load_direct()
@@ -3091,21 +3109,22 @@ class FirewallConfig:
             self.policyIngressAnyButton.set_sensitive(False)
             self.policyIngressZonesButton.set_sensitive(False)
             self.policyIngressZoneView.set_sensitive(False)
+            self.policyServiceView.set_sensitive(False)
 
-            iter = self.policyIngressZoneStore.get_iter_first()
+            iter = self.zoneStore.get_iter_first()
             while iter:
-                self.policyIngressZoneStore.set_value(iter, 0, False)
-                iter = self.policyIngressZoneStore.iter_next(iter)
+                self.zoneStore.set(iter, 3, False, 4, False)
+                iter = self.zoneStore.iter_next(iter)
 
             self.policyEgressHostButton.set_sensitive(False)
             self.policyEgressAnyButton.set_sensitive(False)
             self.policyEgressZonesButton.set_sensitive(False)
             self.policyEgressZoneView.set_sensitive(False)
 
-            iter = self.policyEgressZoneStore.get_iter_first()
+            iter = self.serviceStore.get_iter_first()
             while iter:
-                self.policyEgressZoneStore.set_value(iter, 0, False)
-                iter = self.policyEgressZoneStore.iter_next(iter)
+                self.serviceStore.set_value(iter, 1, False)
+                iter = self.serviceStore.iter_next(iter)
 
             return
 
@@ -3117,15 +3136,12 @@ class FirewallConfig:
         self.policyEgressZonesButton.set_sensitive(True)
         self.policyEgressZoneView.set_sensitive(True)
 
-        iter = self.policyIngressZoneStore.get_iter_first()
-        while iter:
-            self.policyIngressZoneStore.set_value(iter, 0, False)
-            iter = self.policyIngressZoneStore.iter_next(iter)
+        self.policyServiceView.set_sensitive(True)
 
-        iter = self.policyEgressZoneStore.get_iter_first()
+        iter = self.zoneStore.get_iter_first()
         while iter:
-            self.policyEgressZoneStore.set_value(iter, 0, False)
-            iter = self.policyEgressZoneStore.iter_next(iter)
+            self.zoneStore.set(iter, 3, False, 4, False)
+            iter = self.zoneStore.iter_next(iter)
 
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
@@ -3148,12 +3164,12 @@ class FirewallConfig:
                 elif item == "ANY":
                     self.policyIngressAnyButton.set_active(True)
                 else:
-                    iter = self.policyIngressZoneStore.get_iter_first()
+                    iter = self.zoneStore.get_iter_first()
                     while iter:
-                        if self.policyIngressZoneStore.get_value(iter, 1) == item:
-                            self.policyIngressZoneStore.set_value(iter, 0, True)
+                        if self.zoneStore.get_value(iter, 0) == item:
+                            self.zoneStore.set_value(iter, 3, True)
                             break
-                        iter = self.policyIngressZoneStore.iter_next(iter)
+                        iter = self.zoneStore.iter_next(iter)
                     self.policyIngressZonesButton.set_active(True)
                     self.policyIngressZoneView.set_sensitive(True)
 
@@ -3170,12 +3186,12 @@ class FirewallConfig:
                 elif item == "ANY":
                     self.policyEgressAnyButton.set_active(True)
                 else:
-                    iter = self.policyEgressZoneStore.get_iter_first()
+                    iter = self.zoneStore.get_iter_first()
                     while iter:
-                        if self.policyEgressZoneStore.get_value(iter, 1) == item:
-                            self.policyEgressZoneStore.set_value(iter, 0, True)
+                        if self.zoneStore.get_value(iter, 0) == item:
+                            self.zoneStore.set_value(iter, 4, True)
                             break
-                        iter = self.policyEgressZoneStore.iter_next(iter)
+                        iter = self.zoneStore.iter_next(iter)
                     self.policyEgressZonesButton.set_active(True)
                     self.policyEgressZoneView.set_sensitive(True)
 
@@ -8054,9 +8070,9 @@ class FirewallConfig:
             self.changes_applied()
 
     def policy_ingress_zone_toggle_cb(self, toggle, row):
-        iter = self.policyIngressZoneStore.get_iter(row)
-        active = self.policyIngressZoneStore.get_value(iter, 0)
-        zone = self.policyIngressZoneStore.get_value(iter, 1)
+        iter = self.zoneStore.get_iter(row)
+        active = self.zoneStore.get_value(iter, 3)
+        zone = self.zoneStore.get_value(iter, 0)
         if active:
             selected_policy = self.get_selected_policy()
             if self.runtime_view:
@@ -8159,9 +8175,9 @@ class FirewallConfig:
             self.changes_applied()
 
     def policy_egress_zone_toggle_cb(self, toggle, row):
-        iter = self.policyEgressZoneStore.get_iter(row)
-        active = self.policyEgressZoneStore.get_value(iter, 0)
-        zone = self.policyEgressZoneStore.get_value(iter, 1)
+        iter = self.zoneStore.get_iter(row)
+        active = self.zoneStore.get_value(iter, 4)
+        zone = self.zoneStore.get_value(iter, 0)
         if active:
             selected_policy = self.get_selected_policy()
             if self.runtime_view:

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1328,6 +1328,21 @@ class FirewallConfig:
         )
         self.policyServiceView.set_model(self.serviceStore)
 
+        self.policyPortView = builder.get_object("policyPortView")
+        self.policyPortStore = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)
+        self.policyPortView.append_column(
+            Gtk.TreeViewColumn(_("Port"), Gtk.CellRendererText(), text=0)
+        )
+        self.policyPortView.append_column(
+            Gtk.TreeViewColumn(_("Protocol"), Gtk.CellRendererText(), text=1)
+        )
+        self.policyPortView.set_model(self.policyPortStore)
+        self.policyPortStore.set_sort_column_id(1, Gtk.SortType.ASCENDING)
+        self.policyPortView.get_selection().connect("changed", self.change_policy_port_selection_cb)
+
+        self.policyEditPortButton = builder.get_object("editPolicyPortButton")
+        self.policyRemovePortButton = builder.get_object("removePolicyPortButton")
+
         # firewall client
 
         self.fw = client.FirewallClient(wait=1)
@@ -2030,6 +2045,15 @@ class FirewallConfig:
                 settings.removeService(name)
             policy.update(settings)
             self.changes_applied()
+
+    def change_policy_port_selection_cb(self, selection):
+        (model, iter) = selection.get_selected()
+        if iter:
+            self.policyEditPortButton.set_sensitive(True)
+            self.policyRemovePortButton.set_sensitive(True)
+        else:
+            self.policyEditPortButton.set_sensitive(False)
+            self.policyRemovePortButton.set_sensitive(False)
 
     def change_port_selection_cb(self, selection):
         (model, iter) = selection.get_selected()
@@ -3104,6 +3128,8 @@ class FirewallConfig:
     def onChangePolicy(self, *args):
         selected_policy = self.get_selected_policy()
 
+        self.policyPortStore.clear()
+
         if not selected_policy:
             self.policyIngressHostButton.set_sensitive(False)
             self.policyIngressAnyButton.set_sensitive(False)
@@ -3126,6 +3152,8 @@ class FirewallConfig:
                 self.serviceStore.set_value(iter, 1, False)
                 iter = self.serviceStore.iter_next(iter)
 
+            self.policyPortView.set_sensitive(False)
+
             return
 
         self.policyIngressAnyButton.set_sensitive(True)
@@ -3137,6 +3165,8 @@ class FirewallConfig:
         self.policyEgressZoneView.set_sensitive(True)
 
         self.policyServiceView.set_sensitive(True)
+
+        self.policyPortView.set_sensitive(True)
 
         iter = self.zoneStore.get_iter_first()
         while iter:
@@ -3151,6 +3181,7 @@ class FirewallConfig:
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+        self.policyPortView.get_selection().set_mode(Gtk.SelectionMode.NONE)
 
         if self.runtime_view:
             settings = self.fw.getPolicySettings(selected_policy).getSettingsDict()
@@ -3209,9 +3240,13 @@ class FirewallConfig:
                     break
                 iter = self.serviceStore.iter_next(iter)
 
+        for item in settings["ports"]:
+            self.policyPortStore.append(item)
+
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policyPortView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
     def onAddZone(self, *args):
         if self.runtime_view:
@@ -3247,6 +3282,11 @@ class FirewallConfig:
             return
         self.add_edit_zone_policy(True, True)
 
+    def onEditPolicy(self, *args):
+        if self.runtime_view:
+            return
+        self.add_edit_zone_policy(True, False)
+
     def onRemovePolicy(self, *args):
         if self.runtime_view:
             return
@@ -3254,11 +3294,6 @@ class FirewallConfig:
         policy = self.fw.config().getPolicyByName(selected_policy)
         policy.remove()
         self.changes_applied()
-
-    def onEditPolicy(self, *args):
-        if self.runtime_view:
-            return
-        self.add_edit_zone_policy(True, False)
 
     def onLoadPolicyDefaults(self, *args):
         if self.runtime_view:
@@ -4805,14 +4840,14 @@ class FirewallConfig:
         return source
 
     def onAddPort(self, *args):
-        self.add_edit_port(True)
+        self.add_edit_port(False, True)
 
     def onEditPort(self, *args):
-        self.add_edit_port(False)
+        self.add_edit_port(False, False)
 
     def onPortClicked(self, widget, event):
         if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
-            self.add_edit_port(False)
+            self.add_edit_port(False, False)
 
     def onRemovePort(self, *args):
         selected_zone = self.get_selected_zone()
@@ -4830,6 +4865,36 @@ class FirewallConfig:
             zone.removePort(port, proto)
         self.changes_applied()
 
+    def onAddPolicyPort(self, *args):
+        self.add_edit_port(True, True)
+
+    def onEditPolicyPort(self, *args):
+        self.add_edit_port(True, False)
+
+    def onPolicyPortClicked(self, widget, event):
+        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            self.add_edit_port(True, False)
+
+    def onRemovePolicyPort(self, *args):
+        selected_policy = self.get_selected_policy()
+        selection = self.policyPortView.get_selection()
+        (model, iter) = selection.get_selected()
+        if iter is None:
+            return
+        port = model.get_value(iter, 0)
+        proto = model.get_value(iter, 1)
+
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy)
+            settings.removePort(port, proto)
+            self.fw.setPolicySettings(selected_policy, settings)
+        else:
+            policy = self.fw.config().getPolicyByName(selected_policy)
+            settings = policy.getSettings()
+            settings.removePort(port, proto)
+            policy.update(settings)
+        self.changes_applied()
+
     def onPortChanged(self, *args):
         ports = functions.getPortRange(self.portDialogPortEntry.get_text())
         if not ports or not (isinstance(ports, list) or isinstance(ports, tuple)):
@@ -4837,58 +4902,89 @@ class FirewallConfig:
         else:
             self.portDialogOkButton.set_sensitive(True)
 
-    def add_edit_port(self, add):
-        selected_zone = self.get_selected_zone()
+    def add_edit_port(self, policy, add):
+        if policy:
+            selected = self.get_selected_policy()
+            port_view = self.policyPortView
+            port_dialog = self.portDialog
+            port_dialog_port_entry = self.portDialogPortEntry
+            port_dialog_proto_combobox = self.portDialogProtoCombobox
+            port_dialog_ok_button = self.portDialogOkButton
+        else:
+            selected = self.get_selected_zone()
+            port_view = self.portView
+            port_dialog = self.portDialog
+            port_dialog_port_entry = self.portDialogPortEntry
+            port_dialog_proto_combobox = self.portDialogProtoCombobox
+            port_dialog_ok_button = self.portDialogOkButton
 
         old_port = None
         old_proto = None
         if not add:
-            selection = self.portView.get_selection()
+            selection = port_view.get_selection()
             (model, iter) = selection.get_selected()
             if iter is None:
                 return
-            old_port = self.portStore.get_value(iter, 0)
-            old_proto = self.portStore.get_value(iter, 1)
+            old_port = model.get_value(iter, 0)
+            old_proto = model.get_value(iter, 1)
 
-        self.portDialogPortEntry.set_text("")
-        self.portDialogProtoCombobox.set_active(0)
+        port_dialog_port_entry.set_text("")
+        port_dialog_proto_combobox.set_active(0)
 
         if old_port:
-            self.portDialogPortEntry.set_text(old_port)
+            port_dialog_port_entry.set_text(old_port)
         if old_proto:
-            combobox_select_text(self.portDialogProtoCombobox, old_proto)
+            combobox_select_text(port_dialog_proto_combobox, old_proto)
 
-        self.portDialogOkButton.set_sensitive(False)
+        port_dialog_ok_button.set_sensitive(False)
 
-        self.portDialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
-        self.portDialog.set_transient_for(self.mainWindow)
-        self.portDialog.show_all()
-        self.add_visible_dialog(self.portDialog)
-        result = self.portDialog.run()
-        self.portDialog.hide()
-        self.remove_visible_dialog(self.portDialog)
+        port_dialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
+        port_dialog.set_transient_for(self.mainWindow)
+        port_dialog.show_all()
+        self.add_visible_dialog(port_dialog)
+        result = port_dialog.run()
+        port_dialog.hide()
+        self.remove_visible_dialog(port_dialog)
 
         if result != 1:
             return
 
-        port = self.portDialogPortEntry.get_text()
-        proto = self.portDialogProtoCombobox.get_active_text()
+        port = port_dialog_port_entry.get_text()
+        proto = port_dialog_proto_combobox.get_active_text()
         if old_port == port and old_proto == proto:
             # nothing to change
             return
 
         if self.runtime_view:
-            if not self.fw.queryPort(selected_zone, port, proto):
-                self.fw.addPort(selected_zone, port, proto)
-                if not add:
-                    self.fw.removePort(selected_zone, old_port, old_proto)
+            if policy:
+                settings = self.fw.getPolicySettings(selected)
+                if not settings.queryPort(port, proto):
+                    settings.addPort(port, proto)
+                    if not add:
+                        settings.removePort(old_port, old_proto)
+
+                    if policy:
+                        self.fw.setPolicySettings(selected, settings)
+                    else:
+                        self.fw.setZoneSettings(selected, settings)
+            else:
+                if not self.fw.queryPort(selected, port, proto):
+                    self.fw.addPort(selected, port, proto)
+                    if not add:
+                        self.fw.removePort(selected, old_port, old_proto)
+
                 self.changes_applied()
         else:
-            zone = self.fw.config().getZoneByName(selected_zone)
-            if not zone.queryPort(port, proto):
+            if policy:
+                pz = self.fw.config().getPolicyByName(selected)
+            else:
+                pz = self.fw.config().getZoneByName(selected)
+            settings = pz.getSettings()
+            if not settings.queryPort(port, proto):
                 if not add:
-                    zone.removePort(old_port, old_proto)
-                zone.addPort(port, proto)
+                    settings.removePort(old_port, old_proto)
+                settings.addPort(port, proto)
+                pz.update(settings)
                 self.changes_applied()
 
     def onPortProtoChanged(self, *args):

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -153,6 +153,8 @@ class FirewallConfig:
         self.helpersMenuitem = builder.get_object("helpersMenuitem")
         self.directBox = builder.get_object("directBox")
         self.directMenuitem = builder.get_object("directMenuitem")
+        self.policiesBox = builder.get_object("policiesBox")
+        self.policiesMenuitem = builder.get_object("policiesMenuitem")
         self.activeBindingsMenuitem = builder.get_object("activeBindingsMenuitem")
 
         self.changeZonesConnectionMenuitem = builder.get_object(
@@ -1558,6 +1560,9 @@ class FirewallConfig:
         self.settings.connect("changed::show-direct", self.settings_show_direct_changed)
         self.settings_show_direct_changed(self.settings, "show-direct")
 
+        self.settings.connect("changed::show-policies", self.settings_show_policies_changed)
+        self.settings_show_policies_changed(self.settings, "show-policies")
+
         self.settings.connect(
             "changed::show-helpers", self.settings_show_helpers_changed
         )
@@ -1711,6 +1716,9 @@ class FirewallConfig:
     def onViewDirect_toggled(self, button):
         self.settings.set_boolean("show-direct", button.get_active())
 
+    def onViewPolicies_toggled(self, button):
+        self.settings.set_boolean("show-policies", button.get_active())
+
     def settings_show_direct_changed(self, settings, key):
         self.show_direct = settings.get_boolean(key)
         self.directBox.set_visible(self.show_direct)
@@ -1723,6 +1731,22 @@ class FirewallConfig:
             self.directChainStore.clear()
             self.directRuleStore.clear()
             self.directPassthroughStore.clear()
+
+    def settings_show_policies_changed(self, settings, key):
+        self.show_policies = settings.get_boolean(key)
+        self.policiesBox.set_visible(self.show_policies)
+        self.policiesMenuitem.set_active(self.show_policies)
+
+        if self.show_policies:
+            if self.fw.connected:
+                self.load_policies()
+        else:
+            self.policyStore.clear()
+            self.policyPortStore.clear()
+            self.policyProtocolStore.clear()
+            self.policySourcePortStore.clear()
+            self.policyForwardStore.clear()
+            self.policyRichRuleStore.clear()
 
     def settings_show_active_bindings_changed(self, settings, key):
         self.show_active_bindings = settings.get_boolean(key)

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -813,7 +813,6 @@ class FirewallConfig:
             "changed", self.change_rich_rule_selection_cb
         )
 
-        self.addRichRuleButton = builder.get_object("addRichRuleButton")
         self.editRichRuleButton = builder.get_object("editRichRuleButton")
         self.removeRichRuleButton = builder.get_object("removeRichRuleButton")
 
@@ -1410,6 +1409,53 @@ class FirewallConfig:
             Gtk.TreeViewColumn(_("Icmp Type"), Gtk.CellRendererText(), text=2)
         )
         self.policyIcmpView.set_model(self.icmpStore)
+
+        self.policyRichRuleView = builder.get_object("policyRichRuleView")
+        self.policyRichRuleStore = Gtk.ListStore(
+            GObject.TYPE_PYOBJECT,  # the rule obj
+            GObject.TYPE_STRING,  # ipv4/ipv6
+            GObject.TYPE_INT,  # priority
+            GObject.TYPE_STRING,  # action
+            GObject.TYPE_STRING,  # element
+            GObject.TYPE_STRING,  # source
+            GObject.TYPE_STRING,  # destination
+            GObject.TYPE_STRING,  # log
+            GObject.TYPE_STRING,
+        )  # audit
+
+        self.policyRichRuleView.append_column(
+            Gtk.TreeViewColumn(_("Family"), Gtk.CellRendererText(), text=1)
+        )
+        self.policyRichRuleView.append_column(
+            Gtk.TreeViewColumn(_("Priority"), Gtk.CellRendererText(), text=2)
+        )
+        self.policyRichRuleView.append_column(
+            Gtk.TreeViewColumn(_("Action"), Gtk.CellRendererText(), text=3)
+        )
+        self.policyRichRuleView.append_column(
+            Gtk.TreeViewColumn(_("Element"), Gtk.CellRendererText(), text=4)
+        )
+        self.policyRichRuleView.append_column(
+            Gtk.TreeViewColumn(_("Src"), Gtk.CellRendererText(), text=5)
+        )
+        self.policyRichRuleView.append_column(
+            Gtk.TreeViewColumn(_("Dest"), Gtk.CellRendererText(), text=6)
+        )
+        self.policyRichRuleView.append_column(
+            Gtk.TreeViewColumn(_("log"), Gtk.CellRendererText(), text=7)
+        )
+        self.policyRichRuleView.append_column(
+            Gtk.TreeViewColumn(_("Audit"), Gtk.CellRendererText(), text=8)
+        )
+        self.policyRichRuleView.set_model(self.policyRichRuleStore)
+        self.policyRichRuleStore.set_sort_column_id(2, Gtk.SortType.ASCENDING)
+
+        self.policyRichRuleView.get_selection().connect(
+            "changed", self.change_policy_rich_rule_selection_cb
+        )
+
+        self.editPolicyRichRuleButton = builder.get_object("editPolicyRichRuleButton")
+        self.removePolicyRichRuleButton = builder.get_object("removePolicyRichRuleButton")
 
         # firewall client
 
@@ -2057,6 +2103,15 @@ class FirewallConfig:
             self.editRichRuleButton.set_sensitive(False)
             self.removeRichRuleButton.set_sensitive(False)
 
+    def change_policy_rich_rule_selection_cb(self, selection):
+        (model, iter) = selection.get_selected()
+        if iter:
+            self.editPolicyRichRuleButton.set_sensitive(True)
+            self.removePolicyRichRuleButton.set_sensitive(True)
+        else:
+            self.editPolicyRichRuleButton.set_sensitive(False)
+            self.removePolicyRichRuleButton.set_sensitive(False)
+
     def service_added_cb(self, zone, service, timeout):
         if not self.runtime_view or zone != self.get_selected_zone():
             return
@@ -2358,7 +2413,7 @@ class FirewallConfig:
             return
         self.icmpBlockInversionCheck.set_active(False)
 
-    def _add_rich_rule(self, obj):
+    def _add_rich_rule(self, policy, obj):
         family = "all"
         priority = 0
         src = ""
@@ -2442,9 +2497,14 @@ class FirewallConfig:
             if audit == "":
                 audit = _("yes")
 
-        self.richRuleStore.append(
-            [obj, family, priority, action, elem, src, dest, log, audit]
-        )
+        if policy:
+            self.policyRichRuleStore.append(
+                [obj, family, priority, action, elem, src, dest, log, audit]
+            )
+        else:
+            self.richRuleStore.append(
+                [obj, family, priority, action, elem, src, dest, log, audit]
+            )
 
     def richrule_added_cb(self, zone, rule, timeout):
         if not self.runtime_view or zone != self.get_selected_zone():
@@ -2457,7 +2517,7 @@ class FirewallConfig:
                 return
             iter = self.richRuleStore.iter_next(iter)
         # nothing found, so add it
-        self._add_rich_rule(obj)
+        self._add_rich_rule(False, obj)
 
     def richrule_removed_cb(self, zone, rule):
         if not self.runtime_view or zone != self.get_selected_zone():
@@ -3282,7 +3342,7 @@ class FirewallConfig:
         # set rich rules
         for item in rules:
             rule = rich.Rich_Rule(rule_str=item)
-            self._add_rich_rule(rule)
+            self._add_rich_rule(False, rule)
 
         # set interfaces
         for item in interfaces:
@@ -3309,6 +3369,7 @@ class FirewallConfig:
         self.policyProtocolStore.clear()
         self.policySourcePortStore.clear()
         self.policyForwardStore.clear()
+        self.policyRichRuleStore.clear()
 
         if not selected_policy:
             self.policyIngressHostButton.set_sensitive(False)
@@ -3338,6 +3399,7 @@ class FirewallConfig:
             self.policyMasqueradeCheck.set_active(False)
             self.policyForwardView.set_sensitive(False)
             self.policyIcmpView.set_sensitive(False)
+            self.policyRichRuleView.set_sensitive(False)
 
             return
 
@@ -3355,6 +3417,7 @@ class FirewallConfig:
         self.policySourcePortView.set_sensitive(True)
         self.policyForwardView.set_sensitive(True)
         self.policyIcmpView.set_sensitive(True)
+        self.policyRichRuleView.set_sensitive(True)
 
         iter = self.zoneStore.get_iter_first()
         while iter:
@@ -3378,6 +3441,7 @@ class FirewallConfig:
         self.policyProtocolView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policySourcePortView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyForwardView.get_selection().set_mode(Gtk.SelectionMode.NONE)
+        self.policyRichRuleView.get_selection().set_mode(Gtk.SelectionMode.NONE)
 
         if self.runtime_view:
             settings = self.fw.getPolicySettings(selected_policy).getSettingsDict()
@@ -3458,6 +3522,10 @@ class FirewallConfig:
                     break
                 iter = self.icmpStore.iter_next(iter)
 
+        for item in settings["rich_rules"]:
+            rule = rich.Rich_Rule(rule_str=item)
+            self._add_rich_rule(True, rule)
+
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
@@ -3466,6 +3534,7 @@ class FirewallConfig:
         self.policySourcePortView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyForwardView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyIcmpView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policyRichRuleView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
     def onAddZone(self, *args):
         if self.runtime_view:
@@ -3737,14 +3806,10 @@ class FirewallConfig:
         self.policyBaseDialogTargetCombobox.set_sensitive(not val)
 
     def onAddRichRule(self, *args):
-        self.add_edit_rich_rule(True)
+        self.add_edit_rich_rule(False, True)
 
     def onEditRichRule(self, *args):
-        self.add_edit_rich_rule(False)
-
-    def onRichRuleClicked(self, widget, event):
-        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
-            self.add_edit_rich_rule(False)
+        self.add_edit_rich_rule(False, False)
 
     def onRemoveRichRule(self, *args):
         selected_zone = self.get_selected_zone()
@@ -3761,7 +3826,47 @@ class FirewallConfig:
             zone.removeRichRule(str(obj))
         self.changes_applied()
 
-    def add_edit_rich_rule(self, add):
+    def onRichRuleClicked(self, widget, event):
+        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            self.add_edit_rich_rule(False, False)
+
+    def onAddPolicyRichRule(self, *args):
+        self.add_edit_rich_rule(True, True)
+
+    def onEditPolicyRichRule(self, *args):
+        self.add_edit_rich_rule(True, False)
+
+    def onRemovePolicyRichRule(self, *args):
+        selected_policy = self.get_selected_policy()
+        selection = self.policyRichRuleView.get_selection()
+        (model, iter) = selection.get_selected()
+        if iter is None:
+            return
+        obj = self.policyRichRuleStore.get_value(iter, 0)
+
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy)
+            settings.removeRichRule(str(obj))
+            self.fw.setPolicySettings(selected_policy, settings)
+        else:
+            policy = self.fw.config().getPolicyByName(selected_policy)
+            settings = policy.getSettings()
+            settings.removeRichRule(str(obj))
+            policy.update(settings)
+        self.changes_applied()
+
+    def onPolicyRichRuleClicked(self, widget, event):
+        if event.type == Gdk.EventType.DOUBLE_BUTTON_PRESS:
+            self.add_edit_rich_rule(True, False)
+
+    def add_edit_rich_rule(self, policy, add):
+        if policy:
+            selected = self.get_selected_policy()
+            rich_rule_view = self.policyRichRuleView
+        else:
+            selected = self.get_selected_zone()
+            rich_rule_view = self.richRuleView
+
         self.richRuleDialogFamilyCombobox.set_active(0)
         self.richRuleDialogPriorityEntry.set_value(0)
         self.richRuleDialogElementCheck.set_active(False)
@@ -3804,16 +3909,14 @@ class FirewallConfig:
             "debug": _("debug"),
         }
 
-        selected_zone = self.get_selected_zone()
-
         old_obj = None
         iter = None
         if not add:
-            selection = self.richRuleView.get_selection()
+            selection = rich_rule_view.get_selection()
             (model, iter) = selection.get_selected()
             if iter is None:
                 return
-            old_obj = self.richRuleStore.get_value(iter, 0)
+            old_obj = model.get_value(iter, 0)
 
         self.richRuleDialog.old_obj = old_obj
 
@@ -3990,17 +4093,31 @@ class FirewallConfig:
             return
 
         if self.runtime_view:
-            if not self.fw.queryRichRule(selected_zone, rule):
-                self.fw.addRichRule(selected_zone, rule)
-                if not add:
-                    self.fw.removeRichRule(selected_zone, old_rule)
-                self.changes_applied()
+            if policy:
+                settings = self.fw.getPolicySettings(selected)
+                if not settings.queryRichRule(rule):
+                    settings.addRichRule(rule)
+                    if not add:
+                        settings.removeRichRule(old_rule)
+                    self.fw.setPolicySettings(selected, settings)
+                    self.changes_applied()
+            else:
+                if not self.fw.queryRichRule(selected, rule):
+                    self.fw.addRichRule(selected, rule)
+                    if not add:
+                        self.fw.removeRichRule(selected, old_rule)
+                    self.changes_applied()
         else:
-            zone = self.fw.config().getZoneByName(selected_zone)
-            if not zone.queryRichRule(rule):
+            if policy:
+                pz = self.fw.config().getPolicyByName(selected)
+            else:
+                pz = self.fw.config().getZoneByName(selected)
+            settings = pz.getSettings()
+            if not settings.queryRichRule(rule):
                 if not add:
-                    zone.removeRichRule(old_rule)
-                zone.addRichRule(rule)
+                    settings.removeRichRule(old_rule)
+                settings.addRichRule(rule)
+                pz.update(settings)
                 self.changes_applied()
 
     def on_richRuleDialogElementChooser_clicked(self, *args):

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1256,7 +1256,13 @@ class FirewallConfig:
         )
 
         self.policyView = builder.get_object("policyView")
-        self.policyStore = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING) # name, tooltip
+        self.policyStore = Gtk.ListStore(
+                GObject.TYPE_STRING, # name
+                GObject.TYPE_STRING, # tooltip
+                GObject.TYPE_BOOLEAN) # enabled
+        toggle = Gtk.CellRendererToggle()
+        toggle.connect("toggled", self.policy_enable_toggle_cb)
+        self.policyView.append_column(Gtk.TreeViewColumn("", toggle, active=2))
         self.policyView.append_column(Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0))
         self.policyView.set_model(self.policyStore)
         self.policyStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
@@ -1965,7 +1971,7 @@ class FirewallConfig:
             else:
                 settings = self.fw.config().getPolicyByName(item).getSettings()
 
-            self.policyStore.append([item, settings.getDescription()])
+            self.policyStore.append([item, settings.getDescription(), not settings.getDisable()])
 
         if selected_policy in policies:
             _policy = selected_policy
@@ -8607,6 +8613,41 @@ class FirewallConfig:
             f.close()
         return entries
 
+    def policy_enable_toggle_cb(self, toggle, row):
+        iter = self.policyStore.get_iter(row)
+        enabled = self.policyStore.get_value(iter, 2)
+        name = self.policyStore.get_value(iter, 0)
+        if enabled:
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(name)
+                settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(name)
+                settings = policy.getSettings()
+
+            settings.addDisable()
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(name, settings)
+            else:
+                policy.update(settings)
+        else:
+            if self.runtime_view:
+                policy = self.fw.getPolicySettings(name)
+                settings = policy
+            else:
+                policy = self.fw.config().getPolicyByName(name)
+                settings = policy.getSettings()
+
+            settings.removeDisable()
+
+            if self.runtime_view:
+                self.fw.setPolicySettings(name, settings)
+            else:
+                policy.update(settings)
+
+        self.changes_applied()
+
     def policy_ingress_host_toggle_cb(self, *args):
         if not self.policyIngressHostButton.get_active():
             selected_policy = self.get_selected_policy()
@@ -8822,6 +8863,13 @@ class FirewallConfig:
         if not self.runtime_view:
             return
 
+        iter = self.policyStore.get_iter_first()
+        while iter:
+            if self.policyStore.get_value(iter, 0) == policy:
+                self.policyStore.set_value(iter, 2, not settings["disable"])
+                break
+            iter = self.policyStore.iter_next(iter)
+
         if self.get_selected_policy() == policy:
             self.onChangePolicy()
 
@@ -8834,7 +8882,8 @@ class FirewallConfig:
             if self.policyStore.get_value(iter, 0) == policy:
                 return
             iter = self.policyStore.iter_next(iter)
-        self.policyStore.append([policy, self.fw.config().getPolicyByName(policy).getSettings().getDescription()])
+        settings = self.fw.config().getPolicyByName(policy).getSettings()
+        self.policyStore.append([policy, settings.getDescription(), not settings.getDisable()])
         selection = self.policyView.get_selection()
         if selection.count_selected_rows() == 0:
             selection.select_path(0)
@@ -8843,6 +8892,14 @@ class FirewallConfig:
     def conf_policy_updated_cb(self, policy):
         if self.runtime_view:
             return
+
+        settings = self.fw.config().getPolicyByName(policy).getSettings()
+        iter = self.policyStore.get_iter_first()
+        while iter:
+            if self.policyStore.get_value(iter, 0) == policy:
+                self.policyStore.set_value(iter, 2, not settings.getDisable())
+                break
+            iter = self.policyStore.iter_next(iter)
 
         if self.get_selected_policy() == policy:
             self.onChangePolicy()

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1259,11 +1259,12 @@ class FirewallConfig:
         self.policyStore = Gtk.ListStore(
                 GObject.TYPE_STRING, # name
                 GObject.TYPE_STRING, # tooltip
-                GObject.TYPE_BOOLEAN) # enabled
+                GObject.TYPE_BOOLEAN, # enabled
+                GObject.TYPE_INT) # active
         toggle = Gtk.CellRendererToggle()
         toggle.connect("toggled", self.policy_enable_toggle_cb)
         self.policyView.append_column(Gtk.TreeViewColumn("", toggle, active=2))
-        self.policyView.append_column(Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0))
+        self.policyView.append_column(Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0, weight=3))
         self.policyView.set_model(self.policyStore)
         self.policyStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
         self.policyView.get_selection().connect("changed", self.onChangePolicy)
@@ -1954,8 +1955,10 @@ class FirewallConfig:
 
         if self.runtime_view:
             policies = self.fw.getPolicies()
+            active_policies = self.fw.getActivePolicies()
         else:
             policies = self.fw.config().getPolicyNames()
+            active_policies = {}
 
         # reset and fill notebook content according to view
 
@@ -1971,7 +1974,11 @@ class FirewallConfig:
             else:
                 settings = self.fw.config().getPolicyByName(item).getSettings()
 
-            self.policyStore.append([item, settings.getDescription(), not settings.getDisable()])
+            self.policyStore.append([item,
+                                     settings.getDescription(),
+                                     not settings.getDisable(),
+                                     Pango.Weight.BOLD if item in active_policies else Pango.Weight.NORMAL])
+            active_policies.pop(item, None)
 
         if selected_policy in policies:
             _policy = selected_policy
@@ -2803,8 +2810,10 @@ class FirewallConfig:
 
         if self.fw.connected:
             self.active_zones = self.fw.getActiveZones()
+            active_policies = self.fw.getActivePolicies()
         else:
             self.active_zones = {}
+            active_policies = {}
 
         # clean bindingsView, leave connections, interfaces and sources entries
         self.bindingsView.get_selection().set_mode(Gtk.SelectionMode.NONE)
@@ -3002,6 +3011,15 @@ class FirewallConfig:
             else:
                 self.zoneStore.set_value(iter, 1, Pango.Weight.NORMAL)
             iter = self.zoneStore.iter_next(iter)
+
+        # A Change in zone activity may affect policy activity
+        iter = self.policyStore.get_iter_first()
+        while iter:
+            if self.policyStore.get_value(iter, 0) in active_policies:
+                self.policyStore.set_value(iter, 3, Pango.Weight.BOLD)
+            else:
+                self.policyStore.set_value(iter, 3, Pango.Weight.NORMAL)
+            iter = self.policyStore.iter_next(iter)
 
     def onChangeDefaultZone(self, *args):
         self.defaultZoneStore.clear()
@@ -8863,10 +8881,13 @@ class FirewallConfig:
         if not self.runtime_view:
             return
 
+        active_policies = self.fw.getActivePolicies()
+
         iter = self.policyStore.get_iter_first()
         while iter:
             if self.policyStore.get_value(iter, 0) == policy:
                 self.policyStore.set_value(iter, 2, not settings["disable"])
+                self.policyStore.set_value(iter, 3, Pango.Weight.BOLD if policy in active_policies else Pango.Weight.NORMAL)
                 break
             iter = self.policyStore.iter_next(iter)
 
@@ -8883,7 +8904,7 @@ class FirewallConfig:
                 return
             iter = self.policyStore.iter_next(iter)
         settings = self.fw.config().getPolicyByName(policy).getSettings()
-        self.policyStore.append([policy, settings.getDescription(), not settings.getDisable()])
+        self.policyStore.append([policy, settings.getDescription(), not settings.getDisable(), Pango.Weight.NORMAL])
         selection = self.policyView.get_selection()
         if selection.count_selected_rows() == 0:
             selection.select_path(0)

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -723,16 +723,16 @@ class FirewallConfig:
 
         self.icmpView = builder.get_object("icmpView")
         self.icmpStore = Gtk.ListStore(
-            GObject.TYPE_BOOLEAN, GObject.TYPE_STRING  # checked
+            GObject.TYPE_BOOLEAN, GObject.TYPE_BOOLEAN, GObject.TYPE_STRING  # zone-checked, policy-checked
         )  # name
         toggle = Gtk.CellRendererToggle()
         toggle.connect("toggled", self.icmp_toggle_cb, self.icmpStore, 0)
         self.icmpView.append_column(Gtk.TreeViewColumn("", toggle, active=0))
         self.icmpView.append_column(
-            Gtk.TreeViewColumn(_("Icmp Type"), Gtk.CellRendererText(), text=1)
+            Gtk.TreeViewColumn(_("Icmp Type"), Gtk.CellRendererText(), text=2)
         )
         self.icmpView.set_model(self.icmpStore)
-        self.icmpStore.set_sort_column_id(1, Gtk.SortType.ASCENDING)
+        self.icmpStore.set_sort_column_id(2, Gtk.SortType.ASCENDING)
 
         self.icmpBlockInversionCheck = builder.get_object("icmpBlockInversionCheck")
         self.icmpBlockInversionEventbox = builder.get_object(
@@ -1402,6 +1402,15 @@ class FirewallConfig:
         self.editPolicyForwardButton = builder.get_object("editPolicyForwardButton")
         self.removePolicyForwardButton = builder.get_object("removePolicyForwardButton")
 
+        self.policyIcmpView = builder.get_object("policyIcmpView")
+        toggle = Gtk.CellRendererToggle()
+        toggle.connect("toggled", self.policy_icmp_toggle_cb)
+        self.policyIcmpView.append_column(Gtk.TreeViewColumn("", toggle, active=1))
+        self.policyIcmpView.append_column(
+            Gtk.TreeViewColumn(_("Icmp Type"), Gtk.CellRendererText(), text=2)
+        )
+        self.policyIcmpView.set_model(self.icmpStore)
+
         # firewall client
 
         self.fw = client.FirewallClient(wait=1)
@@ -1958,12 +1967,12 @@ class FirewallConfig:
             for item in self.fw.listServices():
                 self.serviceStore.append([False, False, item])
             for item in self.fw.listIcmpTypes():
-                self.icmpStore.append([False, item])
+                self.icmpStore.append([False, False, item])
         else:
             for item in self.fw.config().getServiceNames():
                 self.serviceStore.append([False, False, item])
             for item in self.fw.config().getIcmpTypeNames():
-                self.icmpStore.append([False, item])
+                self.icmpStore.append([False, False, item])
 
         # policies
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
@@ -2244,8 +2253,8 @@ class FirewallConfig:
 
     def icmp_toggle_cb(self, toggle, row, model, col):
         iter = model.get_iter(row)
-        old_val = model.get(iter, col)[0]
-        name = model.get(iter, 1)[0]
+        old_val = model.get_value(iter, col)
+        name = model.get_value(iter, 2)
         selected_zone = self.get_selected_zone()
         if self.runtime_view:
             if not old_val:
@@ -2260,12 +2269,34 @@ class FirewallConfig:
                 zone.removeIcmpBlock(name)
         self.changes_applied()
 
+    def policy_icmp_toggle_cb(self, toggle, row):
+        iter = self.icmpStore.get_iter(row)
+        old_val = self.icmpStore.get_value(iter, 1)
+        name = self.icmpStore.get_value(iter, 2)
+        selected_policy = self.get_selected_policy()
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy)
+            if not old_val:
+                settings.addIcmpBlock(name)
+            else:
+                settings.removeIcmpBlock(name)
+            self.fw.setPolicySettings(selected_policy, settings)
+        else:
+            policy = self.fw.config().getPolicyByName(selected_policy)
+            settings = policy.getSettings()
+            if not old_val:
+                settings.addIcmpBlock(name)
+            else:
+                settings.removeIcmpBlock(name)
+            policy.update(settings)
+        self.changes_applied()
+
     def icmp_added_cb(self, zone, icmp, timeout):
         if not self.runtime_view or zone != self.get_selected_zone():
             return
         iter = self.icmpStore.get_iter_first()
         while iter:
-            if self.icmpStore.get_value(iter, 1) == icmp:
+            if self.icmpStore.get_value(iter, 2) == icmp:
                 self.icmpStore.set_value(iter, 0, True)
                 break
             iter = self.icmpStore.iter_next(iter)
@@ -2275,7 +2306,7 @@ class FirewallConfig:
             return
         iter = self.icmpStore.get_iter_first()
         while iter:
-            if self.icmpStore.get_value(iter, 1) == icmp:
+            if self.icmpStore.get_value(iter, 2) == icmp:
                 self.icmpStore.set_value(iter, 0, False)
                 break
             iter = self.icmpStore.iter_next(iter)
@@ -2294,6 +2325,27 @@ class FirewallConfig:
         else:
             zone = self.fw.config().getZoneByName(selected_zone)
             zone.setIcmpBlockInversion(not self.icmpBlockInversionCheck.get_active())
+            self.changes_applied()
+
+    def policy_icmp_block_inversion_check_cb(self, *args):
+        selected_policy = self.get_selected_policy()
+        if self.runtime_view:
+            settings = self.fw.getPolicySettings(selected_policy)
+            if not self.policyIcmpBlockInversionCheck.get_active():
+                if not settings.queryIcmpBlockInversion():
+                    settings.addIcmpBlockInversion()
+                    self.fw.setPolicySettings(selected_policy, settings)
+                    self.changes_applied()
+            else:
+                if settings.queryIcmpBlockInversion():
+                    settings.removeIcmpBlockInversion()
+                    self.fw.setPolicySettings(selected_policy, settings)
+                    self.changes_applied()
+        else:
+            policy = self.fw.config().getPolicyByName(selected_policy)
+            settings = policy.getSettings()
+            settings.setIcmpBlockInversion(not self.policyIcmpBlockInversionCheck.get_active())
+            policy.update(settings)
             self.changes_applied()
 
     def icmp_inversion_added_cb(self, zone):
@@ -3197,7 +3249,7 @@ class FirewallConfig:
         _icmpblocks = icmpblocks[:]
         iter = self.icmpStore.get_iter_first()
         while iter:
-            name = self.icmpStore.get_value(iter, 1)
+            name = self.icmpStore.get_value(iter, 2)
             if name in _icmpblocks:
                 self.icmpStore.set_value(iter, 0, True)
                 _icmpblocks.remove(name)
@@ -3285,6 +3337,7 @@ class FirewallConfig:
             self.policySourcePortView.set_sensitive(False)
             self.policyMasqueradeCheck.set_active(False)
             self.policyForwardView.set_sensitive(False)
+            self.policyIcmpView.set_sensitive(False)
 
             return
 
@@ -3297,11 +3350,11 @@ class FirewallConfig:
         self.policyEgressZoneView.set_sensitive(True)
 
         self.policyServiceView.set_sensitive(True)
-
         self.policyPortView.set_sensitive(True)
         self.policyProtocolView.set_sensitive(True)
         self.policySourcePortView.set_sensitive(True)
         self.policyForwardView.set_sensitive(True)
+        self.policyIcmpView.set_sensitive(True)
 
         iter = self.zoneStore.get_iter_first()
         while iter:
@@ -3312,6 +3365,11 @@ class FirewallConfig:
         while iter:
             self.serviceStore.set_value(iter, 1, False)
             iter = self.serviceStore.iter_next(iter)
+
+        iter = self.icmpStore.get_iter_first()
+        while iter:
+            self.icmpStore.set_value(iter, 1, False)
+            iter = self.icmpStore.iter_next(iter)
 
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.NONE)
@@ -3392,6 +3450,14 @@ class FirewallConfig:
         for item in settings["forward_ports"]:
             self.policyForwardStore.append(item)
 
+        for item in settings["icmp_blocks"]:
+            iter = self.icmpStore.get_iter_first()
+            while iter:
+                if self.icmpStore.get_value(iter, 2) == item:
+                    self.icmpStore.set_value(iter, 1, True)
+                    break
+                iter = self.icmpStore.iter_next(iter)
+
         self.policyIngressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyEgressZoneView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyServiceView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
@@ -3399,6 +3465,7 @@ class FirewallConfig:
         self.policyProtocolView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policySourcePortView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
         self.policyForwardView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+        self.policyIcmpView.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
     def onAddZone(self, *args):
         if self.runtime_view:


### PR DESCRIPTION
This will be a series of patches to implement policy management in the firewall-config gui tool.

This first patch implements a policy view (both runtime and permenant) with the ability to change ingress/egress zones for each policy.

It will will be very helpful if someone can write the various explanation labels as English isn't my first language.

Fixes #1281 