### PR TITLE
Collapse some redundant stores into one

### DIFF
--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -978,12 +978,10 @@ class FirewallConfig:
         )
 
         self.serviceConfServiceView = builder.get_object("serviceConfServiceView")
-        self.serviceConfServiceStore = Gtk.ListStore(GObject.TYPE_STRING)
         self.serviceConfServiceView.append_column(
-            Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0)
+            Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=1)
         )
-        self.serviceConfServiceView.set_model(self.serviceConfServiceStore)
-        self.serviceConfServiceStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+        self.serviceConfServiceView.set_model(self.serviceStore)
         self.serviceConfServiceView.get_selection().connect(
             "changed", self.onChangeService
         )
@@ -1222,11 +1220,10 @@ class FirewallConfig:
         self.serviceDialogOkButton = builder.get_object("serviceDialogOkButton")
         self.serviceDialogCancelButton = builder.get_object("serviceDialogCancelButton")
         self.serviceDialogServiceView = builder.get_object("serviceDialogServiceView")
-        self.serviceDialogServiceStore = Gtk.ListStore(GObject.TYPE_STRING)
         self.serviceDialogServiceView.append_column(
-            Gtk.TreeViewColumn("Service", Gtk.CellRendererText(), text=0)
+            Gtk.TreeViewColumn("Service", Gtk.CellRendererText(), text=1)
         )
-        self.serviceDialogServiceView.set_model(self.serviceDialogServiceStore)
+        self.serviceDialogServiceView.set_model(self.serviceStore)
         self.serviceDialogServiceView.get_selection().connect(
             "changed", self.change_service_selection_cb
         )
@@ -1705,9 +1702,9 @@ class FirewallConfig:
         self.automatic_helpers = self.fw.getAutomaticHelpers()
         self.set_automaticHelpersLabel(self.automatic_helpers)
         self.load_ipsets()
-        self.load_zones()
         self.load_services()
         self.load_icmps()
+        self.load_zones()
         self.load_helpers()
         self.load_direct()
         self.update_active_zones()
@@ -1745,7 +1742,6 @@ class FirewallConfig:
         selection.set_mode(Gtk.SelectionMode.NONE)
 
         self.zoneStore.clear()
-        self.serviceStore.clear()
         self.portStore.clear()
         self.protocolStore.clear()
         self.forwardStore.clear()
@@ -1755,13 +1751,9 @@ class FirewallConfig:
         self.sourceStore.clear()
 
         if self.runtime_view:
-            for item in self.fw.listServices():
-                self.serviceStore.append([False, item])
             for item in self.fw.listIcmpTypes():
                 self.icmpStore.append([False, item])
         else:
-            for item in self.fw.config().getServiceNames():
-                self.serviceStore.append([False, item])
             for item in self.fw.config().getIcmpTypeNames():
                 self.icmpStore.append([False, item])
 
@@ -1796,7 +1788,7 @@ class FirewallConfig:
         selection = self.serviceConfServiceView.get_selection()
         (model, iter) = selection.get_selected()
         if iter:
-            return self.serviceConfServiceStore.get_value(iter, 0)
+            return self.serviceStore.get_value(iter, 1)
         return None
 
     def load_services(self):
@@ -1812,21 +1804,21 @@ class FirewallConfig:
 
         # reset and fill notebook content according to view
 
-        self.serviceConfServiceStore.clear()
+        self.serviceStore.clear()
 
         # services
 
         for service in services:
-            self.serviceConfServiceStore.append([service])
+            self.serviceStore.append([False, service])
 
         selection.set_mode(Gtk.SelectionMode.SINGLE)
 
-        iter = self.serviceConfServiceStore.get_iter_first()
+        iter = self.serviceStore.get_iter_first()
         while iter:
-            if self.serviceConfServiceStore.get_value(iter, 0) == active_service:
+            if self.serviceStore.get_value(iter, 1) == active_service:
                 selection.select_iter(iter)
                 return
-            iter = self.serviceConfServiceStore.iter_next(iter)
+            iter = self.serviceStore.iter_next(iter)
         selection.select_path(0)
 
         if not self.get_active_service():
@@ -2351,9 +2343,9 @@ class FirewallConfig:
             self.helperConfPortBox.show()
 
         self.load_ipsets()
-        self.load_zones()
         self.load_services()
         self.load_icmps()
+        self.load_zones()
         self.load_helpers()
         self.load_direct()
 
@@ -3531,23 +3523,19 @@ class FirewallConfig:
             self.serviceDialogOkButton.set_sensitive(False)
 
     def service_select_dialog(self, old_service=""):
-        self.serviceDialogServiceStore.clear()
         if self.runtime_view:
             services = self.fw.listServices()
         else:
             services = self.fw.config().getServiceNames()
 
-        for service in services:
-            self.serviceDialogServiceStore.append([service])
-
         selection = self.serviceDialogServiceView.get_selection()
         selection.set_mode(Gtk.SelectionMode.SINGLE)
         selection.select_path(0)
-        iter = self.serviceDialogServiceStore.get_iter_first()
+        iter = self.serviceStore.get_iter_first()
         while iter:
-            if self.serviceDialogServiceStore.get_value(iter, 0) == old_service:
+            if self.serviceStore.get_value(iter, 1) == old_service:
                 selection.select_iter(iter)
-            iter = self.serviceDialogServiceStore.iter_next(iter)
+            iter = self.serviceStore.iter_next(iter)
 
         if old_service:
             self.serviceDialogOkButton.set_sensitive(False)
@@ -3566,7 +3554,7 @@ class FirewallConfig:
         (model, iter) = selection.get_selected()
         if not iter:
             return None
-        service = self.serviceDialogServiceStore.get_value(iter, 0)
+        service = self.serviceStore.get_value(iter, 1)
         if old_service == service:
             return None
         return service
@@ -5321,13 +5309,13 @@ class FirewallConfig:
         if self.runtime_view:
             return
         # check if service is in store
-        iter = self.serviceConfServiceStore.get_iter_first()
+        iter = self.serviceStore.get_iter_first()
         while iter:
-            if self.serviceConfServiceStore.get_value(iter, 0) == service:
+            if self.serviceStore.get_value(iter, 1) == service:
                 return
-            iter = self.serviceConfServiceStore.iter_next(iter)
+            iter = self.serviceStore.iter_next(iter)
         # not in list, append
-        self.serviceConfServiceStore.append([service])
+        self.serviceStore.append([False, service])
 
     def conf_service_updated_cb(self, service):
         self.onChangeService()
@@ -5335,12 +5323,12 @@ class FirewallConfig:
     def conf_service_removed_cb(self, service):
         if self.runtime_view:
             return
-        iter = self.serviceConfServiceStore.get_iter_first()
+        iter = self.serviceStore.get_iter_first()
         while iter:
-            if self.serviceConfServiceStore.get_value(iter, 0) == service:
-                self.serviceConfServiceStore.remove(iter)
+            if self.serviceStore.get_value(iter, 1) == service:
+                self.serviceStore.remove(iter)
                 break
-            iter = self.serviceConfServiceStore.iter_next(iter)
+            iter = self.serviceStore.iter_next(iter)
 
     def conf_service_renamed_cb(self, service):
         if self.runtime_view:
@@ -5352,18 +5340,18 @@ class FirewallConfig:
         services = self.fw.config().getServiceNames()
 
         use_iter = None
-        iter = self.serviceConfServiceStore.get_iter_first()
+        iter = self.serviceStore.get_iter_first()
         while iter:
-            if self.serviceConfServiceStore.get_value(iter, 0) not in services:
+            if self.serviceStore.get_value(iter, 1) not in services:
                 if use_iter is not None:
                     return self.load_services()
                 use_iter = iter
-            iter = self.serviceConfServiceStore.iter_next(iter)
+            iter = self.serviceStore.iter_next(iter)
 
         if use_iter is None:
             return self.load_services()
 
-        self.serviceConfServiceStore.set_value(use_iter, 0, service)
+        self.serviceStore.set_value(use_iter, 1, service)
 
     def onServiceConfAddService(self, *args):
         self.add_edit_service(True)

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -578,12 +578,12 @@ class FirewallConfig:
         # self.editBindingsButton.connect("clicked", self.onEditBinding)
 
         self.ipsetConfIPSetView = builder.get_object("ipsetConfIPSetView")
-        self.ipsetConfIPSetStore = Gtk.ListStore(GObject.TYPE_STRING)  # name
+        self.ipsetStore = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)  # name, type
         self.ipsetConfIPSetView.append_column(
             Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0)
         )
-        self.ipsetConfIPSetView.set_model(self.ipsetConfIPSetStore)
-        self.ipsetConfIPSetStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+        self.ipsetConfIPSetView.set_model(self.ipsetStore)
+        self.ipsetStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
         self.ipsetConfIPSetView.get_selection().connect("changed", self.onChangeIPSet)
 
         self.ipsetConfNotebook = builder.get_object("ipsetConfNotebook")
@@ -1090,16 +1090,13 @@ class FirewallConfig:
         self.ipsetDialogCancelButton = builder.get_object("ipsetDialogCancelButton")
         self.ipsetDialogIPSetView = builder.get_object("ipsetDialogIPSetView")
 
-        self.ipsetDialogIPSetStore = Gtk.ListStore(
-            GObject.TYPE_STRING, GObject.TYPE_STRING
-        )
         self.ipsetDialogIPSetView.append_column(
             Gtk.TreeViewColumn("IPSet", Gtk.CellRendererText(), text=0)
         )
         self.ipsetDialogIPSetView.append_column(
             Gtk.TreeViewColumn("Type", Gtk.CellRendererText(), text=1)
         )
-        self.ipsetDialogIPSetView.set_model(self.ipsetDialogIPSetStore)
+        self.ipsetDialogIPSetView.set_model(self.ipsetStore)
         self.ipsetDialogIPSetView.get_selection().connect(
             "changed", self.change_ipset_selection_cb
         )
@@ -1456,8 +1453,6 @@ class FirewallConfig:
         if self.show_ipsets:
             if self.fw.connected:
                 self.load_ipsets()
-        else:
-            self.ipsetConfIPSetStore.clear()
 
     def onViewICMPTypes_toggled(self, button):
         self.settings.set_boolean("show-icmp-types", button.get_active())
@@ -4276,55 +4271,14 @@ class FirewallConfig:
             self.ipsetDialogOkButton.set_sensitive(False)
 
     def ipset_select_dialog(self, old_ipset="", ipv=None):
-        self.ipsetDialogIPSetStore.clear()
-
-        ipsets = {}
-        if self.runtime_view:
-            for x in self.fw.getIPSets():
-                self.deactivate_exception_handler()
-                try:
-                    settings = self.fw.getIPSetSettings(x)
-                except (DBusException, Exception) as msg:
-                    self.activate_exception_handler()
-                    if isinstance(msg, DBusException):
-                        msg = msg.get_dbus_message()
-                    else:
-                        msg = str(msg)
-                    code = FirewallError.get_code(msg)
-                    if code == errors.NOT_APPLIED:
-                        continue
-                    raise
-                self.activate_exception_handler()
-                if settings.getType() not in SOURCE_IPSET_TYPES:
-                    continue
-                ipsets[x] = settings
-        else:
-            for i in self.fw.config().listIPSets():
-                obj = self.fw.config().getIPSet(i)
-                ipsets[obj.get_property("name")] = obj.getSettings()
-
-        for i in sorted(ipsets.keys()):
-            # for all hash:ip and hash:net types, ipv has to match the family
-            # of the set
-            ipset_type = ipsets[i].getType()
-            if ipset_type.startswith("hash:ip") or ipset_type.startswith("hash:net"):
-                opts = ipsets[i].getOptions()
-                if "family" in opts:
-                    if opts["family"] == "inet6" and (ipv != "ipv6" and ipv != "all"):
-                        continue
-                else:
-                    if ipv == "ipv6" or ipv is None:
-                        continue
-            self.ipsetDialogIPSetStore.append([i, ipset_type])
-
         selection = self.ipsetDialogIPSetView.get_selection()
         selection.set_mode(Gtk.SelectionMode.SINGLE)
         # selection.select_path(0)
-        iter = self.ipsetDialogIPSetStore.get_iter_first()
+        iter = self.ipsetStore.get_iter_first()
         while iter:
-            if self.ipsetDialogIPSetStore.get_value(iter, 0) == old_ipset:
+            if self.ipsetStore.get_value(iter, 0) == old_ipset:
                 selection.select_iter(iter)
-            iter = self.ipsetDialogIPSetStore.iter_next(iter)
+            iter = self.ipsetStore.iter_next(iter)
 
         self.ipsetDialogOkButton.set_sensitive(False)
         self.ipsetDialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
@@ -4346,7 +4300,7 @@ class FirewallConfig:
         (model, iter) = selection.get_selected()
         if not iter:
             return None
-        ipset = self.ipsetDialogIPSetStore.get_value(iter, 0)
+        ipset = self.ipsetStore.get_value(iter, 0)
         if old_ipset == ipset:
             return None
         return ipset
@@ -5759,7 +5713,7 @@ class FirewallConfig:
         selection = self.ipsetConfIPSetView.get_selection()
         (model, iter) = selection.get_selected()
         if iter:
-            return self.ipsetConfIPSetStore.get_value(iter, 0)
+            return self.ipsetStore.get_value(iter, 0)
         return None
 
     def load_ipsets(self):
@@ -5777,21 +5731,25 @@ class FirewallConfig:
 
         # reset and fill notebook content according to view
 
-        self.ipsetConfIPSetStore.clear()
+        self.ipsetStore.clear()
 
         # ipsets
 
         for ipset in ipsets:
-            self.ipsetConfIPSetStore.append([ipset])
+            if self.runtime_view:
+                settings = self.fw.getIPSetSettings(ipset)
+            else:
+                settings = self.fw.config().getIPSetByName(ipset).getSettings()
+            self.ipsetStore.append([ipset, settings.getType()])
 
         selection.set_mode(Gtk.SelectionMode.SINGLE)
 
-        iter = self.ipsetConfIPSetStore.get_iter_first()
+        iter = self.ipsetStore.get_iter_first()
         while iter:
-            if self.ipsetConfIPSetStore.get_value(iter, 0) == active_ipset:
+            if self.ipsetStore.get_value(iter, 0) == active_ipset:
                 selection.select_iter(iter)
                 return
-            iter = self.ipsetConfIPSetStore.iter_next(iter)
+            iter = self.ipsetStore.iter_next(iter)
         selection.select_path(0)
 
         self.ipsetConfRemoveEntryMenubutton.set_sensitive(
@@ -6280,14 +6238,19 @@ class FirewallConfig:
         if self.runtime_view:
             return
         # check if ipset is in store
-        iter = self.ipsetConfIPSetStore.get_iter_first()
+        iter = self.ipsetStore.get_iter_first()
         while iter:
-            if self.ipsetConfIPSetStore.get_value(iter, 0) == ipset:
+            if self.ipsetStore.get_value(iter, 0) == ipset:
                 return
-            iter = self.ipsetConfIPSetStore.iter_next(iter)
+            iter = self.ipsetStore.iter_next(iter)
         # not in list, append
-        self.ipsetConfIPSetStore.append([ipset])
+        settings = self.fw.config().getIPSetByName(ipset).getSettings()
+        self.ipsetStore.append([ipset, settings.getType()])
         selection = self.ipsetConfIPSetView.get_selection()
+        if selection.count_selected_rows() == 0:
+            selection.select_path(0)
+
+        selection = self.ipsetDialogIPSetView.get_selection()
         if selection.count_selected_rows() == 0:
             selection.select_path(0)
 
@@ -6299,12 +6262,12 @@ class FirewallConfig:
     def conf_ipset_removed_cb(self, ipset):
         if self.runtime_view:
             return
-        iter = self.ipsetConfIPSetStore.get_iter_first()
+        iter = self.ipsetStore.get_iter_first()
         while iter:
-            if self.ipsetConfIPSetStore.get_value(iter, 0) == ipset:
-                self.ipsetConfIPSetStore.remove(iter)
+            if self.ipsetStore.get_value(iter, 0) == ipset:
+                self.ipsetStore.remove(iter)
                 break
-            iter = self.ipsetConfIPSetStore.iter_next(iter)
+            iter = self.ipsetStore.iter_next(iter)
 
     def conf_ipset_renamed_cb(self, ipset):
         if self.runtime_view:
@@ -6316,18 +6279,18 @@ class FirewallConfig:
         ipsets = self.fw.config().getIPSetNames()
 
         use_iter = None
-        iter = self.ipsetConfIPSetStore.get_iter_first()
+        iter = self.ipsetStore.get_iter_first()
         while iter:
-            if self.ipsetConfIPSetStore.get_value(iter, 0) not in ipsets:
+            if self.ipsetStore.get_value(iter, 0) not in ipsets:
                 if use_iter is not None:
                     return self.load_ipsets()
                 use_iter = iter
-            iter = self.ipsetConfIPSetStore.iter_next(iter)
+            iter = self.ipsetStore.iter_next(iter)
 
         if use_iter is None:
             return self.load_ipsets()
 
-        self.ipsetConfIPSetStore.set_value(use_iter, 0, ipset)
+        self.ipsetStore.set_value(use_iter, 0, ipset)
 
     def onChangeIPSet(self, *args):
         active_ipset = self.get_active_ipset()

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1106,11 +1106,10 @@ class FirewallConfig:
         self.helperDialogCancelButton = builder.get_object("helperDialogCancelButton")
         self.helperDialogHelperView = builder.get_object("helperDialogHelperView")
 
-        self.helperDialogHelperStore = Gtk.ListStore(GObject.TYPE_STRING)
         self.helperDialogHelperView.append_column(
             Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0)
         )
-        self.helperDialogHelperView.set_model(self.helperDialogHelperStore)
+        self.helperDialogHelperView.set_model(self.helperConfHelperStore)
         self.helperDialogHelperView.get_selection().connect(
             "changed", self.change_helper_selection_cb
         )
@@ -5530,25 +5529,14 @@ class FirewallConfig:
             self.serviceConfRemoveModuleButton.set_sensitive(False)
 
     def helper_select_dialog(self, old_helper=""):
-        self.helperDialogHelperStore.clear()
-
-        helpers = []
-        if self.runtime_view:
-            helpers = self.fw.getHelpers()
-        else:
-            helpers = self.fw.config().getHelperNames()
-
-        for helper in sorted(helpers):
-            self.helperDialogHelperStore.append([helper])
-
         selection = self.helperDialogHelperView.get_selection()
         selection.set_mode(Gtk.SelectionMode.SINGLE)
 
-        iter = self.helperDialogHelperStore.get_iter_first()
+        iter = self.helperConfHelperStore.get_iter_first()
         while iter:
-            if self.helperDialogHelperStore.get_value(iter, 0) == old_helper:
+            if self.helperConfHelperStore.get_value(iter, 0) == old_helper:
                 selection.select_iter(iter)
-            iter = self.helperDialogHelperStore.iter_next(iter)
+            iter = self.helperConfHelperStore.iter_next(iter)
 
         self.helperDialogOkButton.set_sensitive(False)
         self.helperDialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
@@ -5566,7 +5554,7 @@ class FirewallConfig:
         (model, iter) = selection.get_selected()
         if not iter:
             return None
-        helper = self.helperDialogHelperStore.get_value(iter, 0)
+        helper = self.helperConfHelperStore.get_value(iter, 0)
         if old_helper == helper:
             return None
         return helper

--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -1174,12 +1174,10 @@ class FirewallConfig:
         )
 
         self.icmpDialogIcmpView = builder.get_object("icmpDialogIcmpView")
-        self.icmpDialogIcmpStore = Gtk.ListStore(GObject.TYPE_STRING)
         self.icmpDialogIcmpView.append_column(
-            Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=0)
+            Gtk.TreeViewColumn("", Gtk.CellRendererText(), text=1)
         )
-        self.icmpDialogIcmpView.set_model(self.icmpDialogIcmpStore)
-        self.icmpDialogIcmpStore.set_sort_column_id(0, Gtk.SortType.ASCENDING)
+        self.icmpDialogIcmpView.set_model(self.icmpStore)
         self.icmpDialogIcmpView.get_selection().connect("changed", self.onChangeIcmp)
 
         self.icmpDialogDestIpv4Check = builder.get_object("icmpDialogDestIpv4Check")
@@ -1236,11 +1234,10 @@ class FirewallConfig:
             "icmptypeDialogIcmptypeView"
         )
 
-        self.icmptypeDialogIcmptypeStore = Gtk.ListStore(GObject.TYPE_STRING)
         self.icmptypeDialogIcmptypeView.append_column(
-            Gtk.TreeViewColumn("ICMP Type", Gtk.CellRendererText(), text=0)
+            Gtk.TreeViewColumn("ICMP Type", Gtk.CellRendererText(), text=1)
         )
-        self.icmptypeDialogIcmptypeView.set_model(self.icmptypeDialogIcmptypeStore)
+        self.icmptypeDialogIcmptypeView.set_model(self.icmpStore)
         self.icmptypeDialogIcmptypeView.get_selection().connect(
             "changed", self.change_icmptype_selection_cb
         )
@@ -1465,8 +1462,6 @@ class FirewallConfig:
         if self.show_icmp_types:
             if self.fw.connected:
                 self.load_icmps()
-        else:
-            self.icmpDialogIcmpStore.clear()
 
     def onViewHelpers_toggled(self, button):
         self.settings.set_boolean("show-helpers", button.get_active())
@@ -1740,17 +1735,9 @@ class FirewallConfig:
         self.portStore.clear()
         self.protocolStore.clear()
         self.forwardStore.clear()
-        self.icmpStore.clear()
         self.richRuleStore.clear()
         self.interfaceStore.clear()
         self.sourceStore.clear()
-
-        if self.runtime_view:
-            for item in self.fw.listIcmpTypes():
-                self.icmpStore.append([False, item])
-        else:
-            for item in self.fw.config().getIcmpTypeNames():
-                self.icmpStore.append([False, item])
 
         # zones
         active_zones = self.active_zones.keys()
@@ -3562,23 +3549,14 @@ class FirewallConfig:
             self.icmptypeDialogOkButton.set_sensitive(False)
 
     def icmptype_select_dialog(self, old_icmptype=""):
-        self.icmptypeDialogIcmptypeStore.clear()
-        if self.runtime_view:
-            icmptypes = self.fw.listIcmpTypes()
-        else:
-            icmptypes = self.fw.config().getIcmpTypeNames()
-
-        for icmptype in icmptypes:
-            self.icmptypeDialogIcmptypeStore.append([icmptype])
-
         selection = self.icmptypeDialogIcmptypeView.get_selection()
         selection.set_mode(Gtk.SelectionMode.SINGLE)
         selection.select_path(0)
-        iter = self.icmptypeDialogIcmptypeStore.get_iter_first()
+        iter = self.icmpStore.get_iter_first()
         while iter:
-            if self.icmptypeDialogIcmptypeStore.get_value(iter, 0) == old_icmptype:
+            if self.icmpStore.get_value(iter, 1) == old_icmptype:
                 selection.select_iter(iter)
-            iter = self.icmptypeDialogIcmptypeStore.iter_next(iter)
+            iter = self.icmpStore.iter_next(iter)
 
         self.icmptypeDialogOkButton.set_sensitive(False)
         self.icmptypeDialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
@@ -3596,7 +3574,7 @@ class FirewallConfig:
         (model, iter) = selection.get_selected()
         if not iter:
             return None
-        icmptype = self.icmptypeDialogIcmptypeStore.get_value(iter, 0)
+        icmptype = self.icmpStore.get_value(iter, 1)
         if old_icmptype == icmptype:
             return None
         return icmptype
@@ -6847,7 +6825,7 @@ class FirewallConfig:
         selection = self.icmpDialogIcmpView.get_selection()
         (model, iter) = selection.get_selected()
         if iter:
-            return self.icmpDialogIcmpStore.get_value(iter, 0)
+            return self.icmpStore.get_value(iter, 1)
         return None
 
     def load_icmps(self):
@@ -6865,21 +6843,21 @@ class FirewallConfig:
 
         # reset and fill notebook content according to view
 
-        self.icmpDialogIcmpStore.clear()
+        self.icmpStore.clear()
 
         # icmps
 
         for icmp in icmps:
-            self.icmpDialogIcmpStore.append([icmp])
+            self.icmpStore.append([False, icmp])
 
         selection.set_mode(Gtk.SelectionMode.SINGLE)
 
-        iter = self.icmpDialogIcmpStore.get_iter_first()
+        iter = self.icmpStore.get_iter_first()
         while iter:
-            if self.icmpDialogIcmpStore.get_value(iter, 0) == active_icmp:
+            if self.icmpStore.get_value(iter, 1) == active_icmp:
                 selection.select_iter(iter)
                 return
-            iter = self.icmpDialogIcmpStore.iter_next(iter)
+            iter = self.icmpStore.iter_next(iter)
         selection.select_path(0)
 
         if not self.get_active_icmp():
@@ -7082,16 +7060,14 @@ class FirewallConfig:
     def conf_icmp_added_cb(self, icmp):
         if self.runtime_view:
             return
-        if not self.show_icmp_types:
-            return
         # check if icmp is in store
-        iter = self.icmpDialogIcmpStore.get_iter_first()
+        iter = self.icmpStore.get_iter_first()
         while iter:
-            if self.icmpDialogIcmpStore.get_value(iter, 0) == icmp:
+            if self.icmpStore.get_value(iter, 1) == icmp:
                 return
-            iter = self.icmpDialogIcmpStore.iter_next(iter)
+            iter = self.icmpStore.iter_next(iter)
         # not in list, append
-        self.icmpDialogIcmpStore.append([icmp])
+        self.icmpStore.append([False, icmp])
         selection = self.icmpDialogIcmpView.get_selection()
         if selection.count_selected_rows() == 0:
             selection.select_path(0)
@@ -7099,21 +7075,17 @@ class FirewallConfig:
     def conf_icmp_updated_cb(self, zone):
         if self.runtime_view:
             return
-        if not self.show_icmp_types:
-            return
         self.onChangeIcmp()
 
     def conf_icmp_removed_cb(self, icmp):
         if self.runtime_view:
             return
-        if not self.show_icmp_types:
-            return
-        iter = self.icmpDialogIcmpStore.get_iter_first()
+        iter = self.icmpStore.get_iter_first()
         while iter:
-            if self.icmpDialogIcmpStore.get_value(iter, 0) == icmp:
-                self.icmpDialogIcmpStore.remove(iter)
+            if self.icmpStore.get_value(iter, 1) == icmp:
+                self.icmpStore.remove(iter)
                 break
-            iter = self.icmpDialogIcmpStore.iter_next(iter)
+            iter = self.icmpStore.iter_next(iter)
 
     def conf_icmp_renamed_cb(self, icmp):
         if self.runtime_view:
@@ -7125,18 +7097,18 @@ class FirewallConfig:
         icmps = self.fw.config().getIcmpTypeNames()
 
         use_iter = None
-        iter = self.icmpDialogIcmpStore.get_iter_first()
+        iter = self.icmpStore.get_iter_first()
         while iter:
-            if self.icmpDialogIcmpStore.get_value(iter, 0) not in icmps:
+            if self.icmpStore.get_value(iter, 1) not in icmps:
                 if use_iter is not None:
                     return self.load_icmps()
                 use_iter = iter
-            iter = self.icmpDialogIcmpStore.iter_next(iter)
+            iter = self.icmpStore.iter_next(iter)
 
         if use_iter is None:
             return self.load_icmps()
 
-        self.icmpDialogIcmpStore.set_value(use_iter, 0, icmp)
+        self.icmpStore.set_value(use_iter, 1, icmp)
 
     def panic_check_cb(self, *args):
         if self.fw.queryPanicMode():


### PR DESCRIPTION
There were several GTK `ListStore`s that stored duplicated data. This patch gets rid of them.

The result has several advantages:

* Less memory usage and more performant code as traversals over the list only need to be executed when an object is modified
* Easier management of object changes and immediate reflection of these changes in the UI when an asynchronous update is executed