### PR TITLE
fix(nftables): batch ipset elements in set_restore to avoid O(n²) insertion cost

### DIFF
--- a/src/firewall/core/nftables.py
+++ b/src/firewall/core/nftables.py
@@ -2874,9 +2874,14 @@ class nftables:
                 fragment.append(entry_tokens[i])
         return [{"concat": fragment}] if len(type_format) > 1 else fragment
 
-    def build_set_add_rules(self, name, entry):
+    def build_set_add_rules(self, name, entries):
         rules = []
-        element = self._set_entry_fragment(name, entry)
+        elements = []
+        if not isinstance(entries, (list, tuple)):
+            entries = [entries]
+        for element in entries:
+            elements.extend(self._set_entry_fragment(name, element))
+
         rules.append(
             {
                 "add": {
@@ -2884,7 +2889,7 @@ class nftables:
                         "family": "inet",
                         "table": TABLE_NAME,
                         "name": name,
-                        "elem": element,
+                        "elem": elements,
                     }
                 }
             }
@@ -2942,8 +2947,9 @@ class nftables:
         rules.extend(self.build_set_flush_rules(set_name))
         self.set_rules(rules, self._fw.get_log_denied())
 
-        def _idle_set_add_entries(rules):
+        def _idle_set_add_entries(entries):
             try:
+                rules = self.build_set_add_rules(set_name, entries)
                 self.set_rules(rules, self._fw.get_log_denied())
             except Exception as e:
                 log.error("While restoring ipset entries the following Error occurred:")
@@ -2953,14 +2959,5 @@ class nftables:
         # the entries from the GLib main loop when it's idle. This avoids
         # blocking the main loop for too long.
         #
-        chunk = 0
-        rules = []
-        for entry in entries:
-            rules.extend(self.build_set_add_rules(set_name, entry))
-            chunk += 1
-            if chunk >= 1000:
-                GLib.idle_add(lambda x: _idle_set_add_entries(x), rules)
-                rules = []
-                chunk = 0
-        else:
-            GLib.idle_add(lambda x: _idle_set_add_entries(x), rules)
+        for i in range(0, len(entries), 1000):
+            GLib.idle_add(lambda x: _idle_set_add_entries(x), entries[i : i + 1000])


### PR DESCRIPTION
## Summary

`set_restore()` currently creates one `{"add": {"element": ...}}` nft operation per ipset entry, then sends them in chunks of 1000 to `set_rules()` via `GLib.idle_add`. On older nftables/kernel combinations (e.g. nftables 1.0.4 / kernel 4.18 shipped in RHEL/AlmaLinux 8), each incremental element insertion into an interval set has O(n) cost proportional to the current set size, making the overall complexity O(n²).

With 12,000 ipset entries this causes `firewall-cmd --reload` to take **~80 seconds** on RHEL 8 with the nftables backend. Even on newer systems (nftables 1.0.9 / kernel 5.14), batching yields a ~20% improvement.

This patch accumulates all element fragments and sends batched `"add element"` operations — one per chunk of 1000 elements — instead of one per entry. This reduces nft operations from N to ceil(N/1000), letting nftables handle bulk element insertion efficiently.

## Benchmark (12k ipset entries, nftables backend)

| | Before | After |
|---|---:|---:|
| RHEL/AL 8 (nftables 1.0.4, kernel 4.18) | ~82,600 ms | ~2,600 ms |
| RHEL/AL 9 (nftables 1.0.9, kernel 5.14) | ~1,560 ms | ~1,240 ms |

## Root cause detail

Profiling `json_cmd` calls inside `set_restore()` showed each successive chunk taking progressively longer on RHEL 8:

```
Chunk  1 (1000 entries): 0.29s
Chunk  6 (1000 entries): 4.70s
Chunk 12 (1000 entries): 15.71s
Total:                   80.54s
```

The raw libnftables API on the same machine can add all 12k elements in 0.14s when done in a single batch, confirming the bottleneck is incremental per-element insertion, not the nftables library itself.

Fixes #933

## Test plan

- Tested on AlmaLinux 8.10 (nftables 1.0.4, kernel 4.18) and AlmaLinux 9.7 (nftables 1.0.9, kernel 5.14) with 12,000 random /24 ipset entries
- Verified all entries load correctly after reload via `firewall-cmd --ipset=<name> --get-entries` and `nft list set`
- Verified empty ipsets and small ipsets (100 entries) work correctly