### PR TITLE
fix: Drop dependency on dbus-x11

### DIFF
--- a/contrib/fw-in-container/fw-in-container
+++ b/contrib/fw-in-container/fw-in-container
@@ -364,7 +364,6 @@ RUN dnf install -y \\
     cscope \\
     dbus-broker \\
     dbus-devel \\
-    dbus-x11 \\
     desktop-file-utils \\
     dhclient \\
     dhcp-client \\

--- a/firewalld.spec
+++ b/firewalld.spec
@@ -71,7 +71,6 @@ Requires: python3-qt5
 Requires: python3-gobject
 Requires: libnotify
 Requires: NetworkManager-libnm
-Requires: dbus-x11
 
 %description -n firewall-applet
 The firewall panel applet provides a status information of firewalld and also
@@ -85,7 +84,6 @@ Requires: hicolor-icon-theme
 Requires: gtk3
 Requires: python3-gobject
 Requires: NetworkManager-libnm
-Requires: dbus-x11
 Recommends: polkit
 
 %description -n firewall-config


### PR DESCRIPTION
This was added to fix [1] but it's not clear why this is really needed. Remove it as firewalld only uses the system bus.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1281416

Fixes: https://github.com/firewalld/firewalld/issues/1543