### PR TITLE
Refactor zone combining code

### DIFF
--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -1659,7 +1659,7 @@ try:
 
     # zones
     elif a.get_zones:
-        zones = fw.config.get_zones()
+        zones = fw.config.get_zones(select=lambda z: not z.combined)
         cmd.print_and_exit(" ".join(zones))
 
     elif a.new_zone:
@@ -1696,7 +1696,7 @@ try:
         fw.config.load_zone_defaults(obj)
 
     elif a.info_zone:
-        zone = fw.config.get_zone(a.info_zone)
+        zone = fw.config.get_zone(a.info_zone, select=lambda z: not z.combined)
         settings = FirewallClientZoneSettings(fw.config.get_zone_config_dict(zone))
         cmd.print_zone_info(a.info_zone, settings, default_zone=fw.get_default_zone())
         sys.exit(0)

--- a/src/firewall/core/fw.py
+++ b/src/firewall/core/fw.py
@@ -34,12 +34,12 @@ from firewall.core.io.firewalld_conf import firewalld_conf
 from firewall.core.io.direct import Direct
 from firewall.core.io.service import service_reader
 from firewall.core.io.icmptype import icmptype_reader
-from firewall.core.io.zone import zone_reader, Zone
+from firewall.core.io.zone import zone_reader
 from firewall.core.io.ipset import ipset_reader
 from firewall.core.ipset import IPSET_TYPES
 from firewall.core.io.helper import helper_reader
 from firewall.core.io.policy import policy_reader
-from firewall.core.io.functions import check_on_disk_config
+from firewall.core.io.functions import check_on_disk_config, list_zone_files
 from firewall.core.rich import Rich_Rule
 from firewall import errors
 from firewall.errors import FirewallError
@@ -514,37 +514,8 @@ class Firewall:
 
         self.direct.set_permanent_config(copy.deepcopy(self.config.get_direct()))
 
-        # copy combined permanent zones to runtime
-        # zones with a '/' in the name will be combined into one runtime zone
-        combined_zones = {}
-        for zone in self.config.get_zones():
-            z_obj = self.config.get_zone(zone)
-            if "/" not in z_obj.name:
-                self.zone.add_zone(copy.deepcopy(self.config.get_zone(zone)))
-                continue
-
-            combined_name = os.path.basename(z_obj.path)
-            if combined_name not in combined_zones:
-                combined_zone = Zone()
-                combined_zone.name = combined_name
-                combined_zone.check_name(combined_zone.name)
-                combined_zone.path = z_obj.path
-                combined_zone.default = False
-                combined_zone.forward = False  # see note in zone_reader()
-
-                combined_zones[combined_name] = combined_zone
-
-            log.debug1(
-                "Combining zone '%s' using '%s%s%s'",
-                combined_name,
-                z_obj.path,
-                os.sep,
-                z_obj.filename,
-            )
-            combined_zones[combined_name].combine(z_obj)
-
-        for zone in combined_zones:
-            self.zone.add_zone(combined_zones[zone])
+        for zone in self.config.get_zones(select=lambda z: "/" not in z.name):
+            self.zone.add_zone(copy.deepcopy(self.config.get_zone(zone)))
 
     def _start_load_direct_rules(self):
         # load direct rules
@@ -834,33 +805,12 @@ class Firewall:
 
             self.config.add_icmptype(obj)
 
-    def _loader_zones(self, path, combine=False):
-        if not os.path.isdir(path):
-            return
-
-        for filename in sorted(os.listdir(path)):
-            if not filename.endswith(".xml"):
-                if path.startswith(config.ETC_FIREWALLD) and os.path.isdir(
-                    "%s/%s" % (path, filename)
-                ):
-                    # Combined zones are added to permanent config
-                    # individually. They're coalesced into one object when
-                    # added to the runtime
-                    self._loader_zones("%s/%s" % (path, filename), combine=True)
-                continue
-
+    def _loader_zones(self, path):
+        for filename in list_zone_files(path):
             name = "%s/%s" % (path, filename)
             log.debug1("Loading zone file '%s'", name)
 
-            obj = zone_reader(filename, path, no_check_name=combine)
-            if combine:
-                # Change name for permanent configuration
-                obj.name = "%s/%s" % (
-                    os.path.basename(path),
-                    os.path.basename(filename)[0:-4],
-                )
-                obj.check_name(obj.name)
-
+            obj = zone_reader(filename, path)
             if obj.name in self.config.get_zones():
                 orig_obj = self.config.get_zone(obj.name)
                 log.debug1(
@@ -868,7 +818,6 @@ class Firewall:
                 )
             elif obj.path.startswith(config.ETC_FIREWALLD):
                 obj.default = True
-
             self.config.add_zone(obj)
 
     def cleanup(self):
@@ -1071,9 +1020,11 @@ class Firewall:
             log.debug1(
                 "Setting policy to '%s'%s",
                 policy,
-                f" (ReloadPolicy={firewalld_conf._unparse_reload_policy(policy_details)})"
-                if policy == "DROP"
-                else "",
+                (
+                    f" (ReloadPolicy={firewalld_conf._unparse_reload_policy(policy_details)})"
+                    if policy == "DROP"
+                    else ""
+                ),
             )
 
             for backend in self.enabled_backends():

--- a/src/firewall/core/fw_config.py
+++ b/src/firewall/core/fw_config.py
@@ -797,14 +797,50 @@ class FirewallConfig:
 
     # zones
 
-    def get_zones(self):
-        return sorted(set(list(self._zones.keys()) + list(self._builtin_zones.keys())))
+    def get_zones(self, select=lambda zone: True):
+        return sorted(
+            set(
+                [zone.name for zone in self._zones.values() if select(zone)]
+                + list(self._builtin_zones.keys())
+            )
+        )
 
     def add_zone(self, obj):
         if obj.builtin:
             self._builtin_zones[obj.name] = obj
         else:
             self._zones[obj.name] = obj
+        if "/" in obj.name:
+            name = obj.name.split("/")[0]
+            combined = None
+            if name in self._zones:
+                if self._zones[name].combined:
+                    combined = self._zones[name]
+                else:
+                    log.debug1(
+                        "'%s' can't be combined with '%s'"
+                        % (self._zones[name].filename, obj.filename)
+                    )
+            if not combined:
+                log.debug1("Creating combined zone '%s'", name)
+                combined = Zone()
+                combined.name = name
+                combined.filename = ""
+                combined.check_name(combined.name)
+                combined.path = obj.path
+                combined.default = obj.path.startswith(config.ETC_FIREWALLD)
+                combined.forward = False  # see note in zone_reader()
+                self._zones[name] = combined
+            log.debug1(
+                "Combining zone '%s' using '%s%s%s'",
+                name,
+                os.path.dirname(obj.path),
+                os.sep,
+                obj.name,
+            )
+            filename = ",".join(combined.filename.split(",") + [obj.filename])
+            combined.combine(obj)
+            combined.filename = filename
 
     def forget_zone(self, name):
         if name in self._builtin_zones:
@@ -812,9 +848,10 @@ class FirewallConfig:
         if name in self._zones:
             del self._zones[name]
 
-    def get_zone(self, name):
+    def get_zone(self, name, select=lambda z: True):
         if name in self._zones:
-            return self._zones[name]
+            if select(self._zones[name]):
+                return self._zones[name]
         elif name in self._builtin_zones:
             return self._builtin_zones[name]
         raise FirewallError(errors.INVALID_ZONE, "get_zone(): %s" % name)
@@ -987,7 +1024,9 @@ class FirewallConfig:
 
     def check_builtin_zone(self, obj):
         if obj.builtin or not obj.default:
-            raise FirewallError(errors.BUILTIN_ZONE, "'%s' is built-in zone" % obj.name)
+            raise FirewallError(
+                errors.BUILTIN_ZONE, "'%s' is built-in zone " % obj.name
+            )
 
     def remove_zone(self, obj):
         self.check_builtin_zone(obj)

--- a/src/firewall/core/io/functions.py
+++ b/src/firewall/core/io/functions.py
@@ -21,6 +21,28 @@ from firewall.core.io.direct import Direct
 from firewall.core.io.firewalld_conf import firewalld_conf
 
 
+def list_xml_files(_dir):
+    if not os.path.isdir(_dir):
+        return []
+    return [name for name in sorted(os.listdir(_dir)) if name.endswith(".xml")]
+
+
+def list_zone_files(_dir):
+    if not os.path.isdir(_dir):
+        return []
+    result = list_xml_files(_dir)
+    if _dir.startswith(config.ETC_FIREWALLD):
+        # Add zone files that should be combined
+        result.extend(
+            [
+                os.path.join(zone, file)
+                for zone in sorted(os.listdir(_dir))
+                for file in list_xml_files(os.path.join(_dir, zone))
+            ]
+        )
+    return result
+
+
 def check_on_disk_config(fw):
     fw_config = FirewallConfig(fw)
 
@@ -41,41 +63,44 @@ def check_on_disk_config(fw):
             "reader": ipset_reader,
             "add": fw_config.add_ipset,
             "dirs": [config.FIREWALLD_IPSETS, config.ETC_FIREWALLD_IPSETS],
+            "select": list_xml_files,
         },
         "helper": {
             "reader": helper_reader,
             "add": fw_config.add_helper,
             "dirs": [config.FIREWALLD_HELPERS, config.ETC_FIREWALLD_HELPERS],
+            "select": list_xml_files,
         },
         "icmptype": {
             "reader": icmptype_reader,
             "add": fw_config.add_icmptype,
             "dirs": [config.FIREWALLD_ICMPTYPES, config.ETC_FIREWALLD_ICMPTYPES],
+            "select": list_xml_files,
         },
         "service": {
             "reader": service_reader,
             "add": fw_config.add_service,
             "dirs": [config.FIREWALLD_SERVICES, config.ETC_FIREWALLD_SERVICES],
+            "select": list_xml_files,
         },
         "zone": {
             "reader": zone_reader,
             "add": fw_config.add_zone,
             "dirs": [config.FIREWALLD_ZONES, config.ETC_FIREWALLD_ZONES],
+            "select": list_zone_files,
         },
         "policy": {
             "reader": policy_reader,
             "add": fw_config.add_policy_object,
             "dirs": [config.FIREWALLD_POLICIES, config.ETC_FIREWALLD_POLICIES],
+            "select": list_xml_files,
         },
     }
     for reader in readers.keys():
         for _dir in readers[reader]["dirs"]:
-            if not os.path.isdir(_dir):
-                continue
-            for file in sorted(os.listdir(_dir)):
-                if file.endswith(".xml"):
-                    obj = readers[reader]["reader"](file, _dir)
-                    readers[reader]["add"](obj)
+            for selected in readers[reader]["select"](_dir):
+                obj = readers[reader]["reader"](selected, _dir)
+                readers[reader]["add"](obj)
     fw_config.full_check_config()
 
     if os.path.isfile(config.FIREWALLD_DIRECT):

--- a/src/firewall/server/config.py
+++ b/src/firewall/server/config.py
@@ -1135,7 +1135,8 @@ class FirewallDConfig(DbusServiceObject):
         log.debug1("config.getZoneNames()")
         zones = []
         for obj in self.zones:
-            zones.append(obj.obj.name)
+            if not obj.obj.combined:
+                zones.append(obj.obj.name)
         return sorted(zones)
 
     @dbus_service_method(


### PR DESCRIPTION
core/fw_config.py:
        move combined zone logic to 'add_zone' method
core/fw.py:
        in '_start_copy_config_to_runtime' don't copy zones with '/' in name
        remove combined zone logic from '_loader_zones'
        use 'list_zone_files' to find what files to load
core/io/functions.py:
        add 'list_xml_files' function
        add 'list_zone_files' function
        rewrite 'check_on_disk_config' to use 'list_xml_files' and
                'list_zone_files'
server/config.py:
        don't return combined zones in 'getZoneNames'