### PR TITLE
fix(firewall-config): _load_store_append(): properly get runtime zone

### DIFF
--- a/src/firewall-config.in
+++ b/src/firewall-config.in
@@ -9,6 +9,7 @@
 import sys
 import string
 import gi
+import re
 
 try:
     gi.require_version("Gtk", "3.0")
@@ -1718,16 +1719,13 @@ class FirewallConfig:
         else:
             weight = Pango.Weight.NORMAL
 
-        desc = None
-        zone_obj = self.fw.config().getZoneByName(zone)
-        if zone_obj:
-            settings = zone_obj.getSettings()
-            if settings:
-                desc = settings.getDescription()
-                if desc:
-                    import re
+        if self.runtime_view:
+            settings = self.fw.getZoneSettings(zone)
+        else:
+            settings = self.fw.config().getZoneByName(zone).getSettings()
 
-                    desc = re.sub(r"\s+", " ", desc)
+        desc = settings.getDescription()
+        desc = re.sub(r"\s+", " ", desc)
 
         self.zoneStore.append([zone, weight, desc])
 


### PR DESCRIPTION
This function may be passed a runtime or permanent config zone name. In the case of combined zones, the name can vary between these two configs. Lookup using the correct runtime/permanent method.

Fixes: d81485cdf4c1 ("improvement(firewall-config): show zone description as tooltip")
Fixes: #1353
Closes: #1550