### PR TITLE
fix: use config.VERSION for --version in firewall-cmd

### DIFF
--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -25,6 +25,7 @@ from firewall.client import (
     FirewallClientPolicySettings,
 )
 from firewall.errors import FirewallError
+from firewall import config
 from firewall import errors
 from firewall.functions import joinArgs, splitArgs, getPortRange
 from firewall.core.fw_nm import (
@@ -3175,7 +3176,7 @@ if a.permanent:
             fw_zone.update(settings)
 
 elif a.version:
-    cmd.print_and_exit(fw.get_property("version"))
+    cmd.print_and_exit(config.VERSION)
 elif a.state:
     state = fw.get_property("state")
     if state == "RUNNING":


### PR DESCRIPTION
## Summary

Fixes `firewall-cmd --version` requiring root access, which is inconsistent with `firewall-cmd --help` (no root needed) and `firewall-offline-cmd --version` (also no root needed).

The version string is a static compile-time constant (`config.VERSION`) available at build time. The current code calls `fw.get_property("version")` which requires a D-Bus connection to the firewalld daemon, which in turn requires root privileges.

This change makes `firewall-cmd --version` use `config.VERSION` directly, matching the approach already used by `firewall-offline-cmd`.

## Related

Closes #1562
