### PR TITLE
feat(firewall-cmd): add --list-all-rules option

### DIFF
--- a/doc/xml/firewall-cmd.xml.in
+++ b/doc/xml/firewall-cmd.xml.in
@@ -505,7 +505,13 @@
         <term><optional><option>--permanent</option></optional> <optional><option>--zone</option>=<replaceable>zone</replaceable></optional> <optional><option>--policy</option>=<replaceable>policy</replaceable></optional> <option>--list-all</option></term>
         <listitem>
           <para>
-            List everything added or enabled.
+            List everything. The behavior depends on whether --zone or --policy is specified:
+          </para>
+          <para>
+            With --zone or --policy: Lists all settings for the specified zone or policy.
+          </para>
+          <para>
+            Without --zone or --policy: Lists ALL zones, ALL policies, direct rules, and passthroughs.
           </para>
         </listitem>
       </varlistentry>

--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -2493,6 +2493,46 @@ if a.permanent:
             cmd.print_msg("")
         sys.exit(0)
 
+    elif a.list_all and not zone and not a.policy:
+        # Comprehensive --list-all for permanent config
+        cmd.print_msg("ALL ZONES:")
+        default_zone = fw.getDefaultZone()
+        for zone_name in sorted(fw.config().getZoneNames()):
+            settings = fw.config().getZoneByName(zone_name).getSettings()
+            interfaces = try_nm_get_interfaces_in_zone(zone_name)
+            cmd.print_zone_info(
+                zone_name,
+                settings,
+                default_zone=default_zone,
+                extra_interfaces=interfaces,
+            )
+            cmd.print_msg("")
+
+        cmd.print_msg("ALL POLICIES:")
+        for policy in sorted(fw.config().getPolicyNames()):
+            settings = fw.config().getPolicyByName(policy).getSettings()
+            cmd.print_policy_info(policy, settings)
+            cmd.print_msg("")
+
+        cmd.print_msg("DIRECT RULES:")
+        direct = fw.config().direct()
+        rules = direct.getAllRules()
+        for ipv, table, chain, priority, rule in rules:
+            cmd.print_msg(
+                "%s %s %s %d %s" % (ipv, table, chain, priority, joinArgs(rule))
+            )
+        if not rules:
+            cmd.print_msg("  (none)")
+        cmd.print_msg("")
+
+        cmd.print_msg("DIRECT PASSTHROUGHS:")
+        passthroughs = direct.getAllPassthroughs()
+        for ipv, rule in passthroughs:
+            cmd.print_msg("%s %s" % (ipv, joinArgs(rule)))
+        if not passthroughs:
+            cmd.print_msg("  (none)")
+        sys.exit(0)
+
     elif a.policy_set:
         for _policy in filter(
             lambda x: x[: len(a.policy_set)] == a.policy_set,
@@ -4019,14 +4059,55 @@ elif a.query_icmp_block_inversion:
     cmd.print_query_result(fw.queryIcmpBlockInversion(zone))
 
 # list all
-elif a.list_all:
-    z = zone if zone else fw.getDefaultZone()
+elif a.list_all and zone:
+    # Show specific zone
     cmd.print_zone_info(
-        z,
-        fw.getZoneSettings(z),
+        zone,
+        fw.getZoneSettings(zone),
         default_zone=fw.getDefaultZone(),
         active_zones=fw.getActiveZones(),
     )
+    sys.exit(0)
+
+elif a.list_all:
+    # Comprehensive --list-all when no zone specified
+    cmd.print_msg("ALL ZONES:")
+    default_zone = fw.getDefaultZone()
+    active_zones = fw.getActiveZones()
+
+    for zone_name in sorted(fw.getZones()):
+        cmd.print_zone_info(
+            zone_name,
+            fw.getZoneSettings(zone_name),
+            default_zone=default_zone,
+            active_zones=active_zones,
+        )
+        cmd.print_msg("")
+
+    cmd.print_msg("ALL POLICIES:")
+    active_policies = fw.getActivePolicies()
+    for policy in sorted(fw.getPolicies()):
+        cmd.print_policy_info(
+            policy, fw.getPolicySettings(policy), active_policies=active_policies
+        )
+        cmd.print_msg("")
+
+    cmd.print_msg("DIRECT RULES:")
+    rules = fw.getAllRules()
+    for ipv, table, chain, priority, rule in rules:
+        cmd.print_msg(
+            "%s %s %s %d %s" % (ipv, table, chain, priority, joinArgs(rule))
+        )
+    if not rules:
+        cmd.print_msg("  (none)")
+    cmd.print_msg("")
+
+    cmd.print_msg("DIRECT PASSTHROUGHS:")
+    passthroughs = fw.getAllPassthroughs()
+    for ipv, rule in passthroughs:
+        cmd.print_msg("%s %s" % (ipv, joinArgs(rule)))
+    if not passthroughs:
+        cmd.print_msg("  (none)")
     sys.exit(0)
 
 # list everything

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -2676,6 +2676,47 @@ try:
             cmd.print_msg("")
         sys.exit(0)
 
+    elif a.list_all and not zone and not a.policy:
+        # Comprehensive --list-all for offline config
+        cmd.print_msg("ALL ZONES:")
+        zones = fw.config.get_zones()
+        default_zone = fw.get_default_zone()
+        for zone_name in sorted(zones):
+            fw_zone = fw.config.get_zone(zone_name)
+            fw_settings = FirewallClientZoneSettings(
+                fw.config.get_zone_config_dict(fw_zone)
+            )
+            cmd.print_zone_info(zone_name, fw_settings, default_zone=default_zone)
+            cmd.print_msg("")
+
+        cmd.print_msg("ALL POLICIES:")
+        policies = fw.config.get_policy_objects()
+        for policy in policies:
+            fw_policy = fw.config.get_policy_object(policy)
+            fw_settings = FirewallClientPolicySettings(
+                fw.config.get_policy_object_config_dict(fw_policy)
+            )
+            cmd.print_policy_info(policy, fw_settings)
+            cmd.print_msg("")
+
+        cmd.print_msg("DIRECT RULES:")
+        rules = fw.direct.get_all_rules()
+        for ipv, table, chain, priority, rule in rules:
+            cmd.print_msg(
+                "%s %s %s %d %s" % (ipv, table, chain, priority, joinArgs(rule))
+            )
+        if not rules:
+            cmd.print_msg("  (none)")
+        cmd.print_msg("")
+
+        cmd.print_msg("DIRECT PASSTHROUGHS:")
+        passthroughs = fw.direct.get_all_passthroughs()
+        for ipv, rule in passthroughs:
+            cmd.print_msg("%s %s" % (ipv, joinArgs(rule)))
+        if not passthroughs:
+            cmd.print_msg("  (none)")
+        sys.exit(0)
+
     elif a.policy_set:
         for _policy in filter(
             lambda x: x[: len(a.policy_set)] == a.policy_set,

--- a/src/tests/cli/firewall-cmd.at
+++ b/src/tests/cli/firewall-cmd.at
@@ -2241,3 +2241,538 @@ AT_DATA([./ipsets/foobar.xml], [dnl
     AT_CHECK([rm ./zones/foobar.xml])
 
 FWD_END_TEST([ignore])
+
+FWD_START_TEST([option --list-all])
+    AT_KEYWORDS(zone policy direct)
+
+    dnl create some deviation in the permanent/runtime config
+    FWD_CHECK([--permanent --zone public --add-service https], 0, [ignore])
+
+    dnl Verify output contains expected sections
+    FWD_CHECK([--list-all | TRIM_WHITESPACE], 0, [m4_strip([dnl
+ALL ZONES:
+block
+  target: %%REJECT%%
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: 
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+dmz
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+drop
+  target: DROP
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: 
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+external
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: yes
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+home
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client mdns samba-client ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+internal
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client mdns samba-client ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+public (default, active)
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+trusted
+  target: ACCEPT
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: 
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+work
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+ALL POLICIES:
+allow-host-ipv6 (active)
+  disable: no
+  priority: -15000
+  target: CONTINUE
+  ingress-zones: ANY
+  egress-zones: HOST
+  services: 
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+       rule family="ipv6" icmp-type name="mld-listener-done" accept
+       rule family="ipv6" icmp-type name="mld-listener-query" accept
+       rule family="ipv6" icmp-type name="mld-listener-report" accept
+       rule family="ipv6" icmp-type name="mld2-listener-report" accept
+       rule family="ipv6" icmp-type name="neighbour-advertisement" accept
+       rule family="ipv6" icmp-type name="neighbour-solicitation" accept
+       rule family="ipv6" icmp-type name="redirect" accept
+       rule family="ipv6" icmp-type name="router-advertisement" accept
+gateway-dmz-to-HOST (disabled)
+  disable: yes
+  priority: 1000
+  target: CONTINUE
+  ingress-zones: dmz
+  egress-zones: HOST
+  services: dhcp dns
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+gateway-lan-to-HOST (disabled)
+  disable: yes
+  priority: 1000
+  target: CONTINUE
+  ingress-zones: internal home trusted
+  egress-zones: HOST
+  services: dhcp dns ssh
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+gateway-lan-to-work (disabled)
+  disable: yes
+  priority: 1000
+  target: ACCEPT
+  ingress-zones: internal home trusted
+  egress-zones: work
+  services: ftp tftp
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+gateway-lan-to-world (disabled)
+  disable: yes
+  priority: 1000
+  target: ACCEPT
+  ingress-zones: internal home trusted
+  egress-zones: external public
+  services: ftp tftp
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+gateway-world-to-HOST (disabled)
+  disable: yes
+  priority: 1000
+  target: CONTINUE
+  ingress-zones: external public
+  egress-zones: HOST
+  services: dhcpv6-client
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+DIRECT RULES:
+  (none)
+DIRECT PASSTHROUGHS:
+  (none)
+])])
+    FWD_CHECK([--permanent --list-all | TRIM_WHITESPACE], 0, [m4_strip([dnl
+ALL ZONES:
+block
+  target: %%REJECT%%
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: 
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+dmz
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+drop
+  target: DROP
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: 
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+external
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: yes
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+home
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client mdns samba-client ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+internal
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client mdns samba-client ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+public (default)
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client https ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+trusted
+  target: ACCEPT
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: 
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+work
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+ALL POLICIES:
+allow-host-ipv6
+  disable: no
+  priority: -15000
+  target: CONTINUE
+  ingress-zones: ANY
+  egress-zones: HOST
+  services: 
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+       rule family="ipv6" icmp-type name="mld-listener-done" accept
+       rule family="ipv6" icmp-type name="mld-listener-query" accept
+       rule family="ipv6" icmp-type name="mld-listener-report" accept
+       rule family="ipv6" icmp-type name="mld2-listener-report" accept
+       rule family="ipv6" icmp-type name="neighbour-advertisement" accept
+       rule family="ipv6" icmp-type name="neighbour-solicitation" accept
+       rule family="ipv6" icmp-type name="redirect" accept
+       rule family="ipv6" icmp-type name="router-advertisement" accept
+gateway-dmz-to-HOST
+  disable: yes
+  priority: 1000
+  target: CONTINUE
+  ingress-zones: dmz
+  egress-zones: HOST
+  services: dhcp dns
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+gateway-lan-to-HOST
+  disable: yes
+  priority: 1000
+  target: CONTINUE
+  ingress-zones: internal home trusted
+  egress-zones: HOST
+  services: dhcp dns ssh
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+gateway-lan-to-work
+  disable: yes
+  priority: 1000
+  target: ACCEPT
+  ingress-zones: internal home trusted
+  egress-zones: work
+  services: ftp tftp
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+gateway-lan-to-world
+  disable: yes
+  priority: 1000
+  target: ACCEPT
+  ingress-zones: internal home trusted
+  egress-zones: external public
+  services: ftp tftp
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+gateway-world-to-HOST
+  disable: yes
+  priority: 1000
+  target: CONTINUE
+  ingress-zones: external public
+  egress-zones: HOST
+  services: dhcpv6-client
+  ports: 
+  protocols: 
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+DIRECT RULES:
+  (none)
+DIRECT PASSTHROUGHS:
+  (none)
+])])
+
+    dnl Verify --list-all works with --zone (shows specific zone)
+    FWD_CHECK([--zone=public --list-all | TRIM_WHITESPACE], 0, [m4_strip([dnl
+public (default, active)
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+])])
+    FWD_CHECK([--permanent --zone=public --list-all | TRIM_WHITESPACE], 0, [m4_strip([dnl
+public (default)
+  target: default
+  ingress-priority: 0
+  egress-priority: 0
+  icmp-block-inversion: no
+  interfaces: 
+  sources: 
+  services: dhcpv6-client https ssh
+  ports: 
+  protocols: 
+  forward: yes
+  masquerade: no
+  forward-ports: 
+  source-ports: 
+  icmp-blocks: 
+  rich rules: 
+])])
+FWD_END_TEST()


### PR DESCRIPTION
Add a new option to provide a complete overview of the active firewall configuration by showing zones, policies, direct rules, and passthroughs in a single command.

This replaces the need for running four separate commands (--list-all-zones, --list-all-policies, --direct --get-all-rules, --direct --get-all-passthroughs) to view the complete firewall state. Only active zones and policies are shown to reduce clutter.