### PR TITLE
Add missing policy xml schema to package

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -34,7 +34,8 @@ dist_xmlschema_DATA = \
 	xmlschema/icmptype.xsd \
 	xmlschema/ipset.xsd \
 	xmlschema/service.xsd \
-	xmlschema/zone.xsd
+	xmlschema/zone.xsd \
+	xmlschema/policy.xsd
 dist_xmlschema_SCRIPTS = xmlschema/check.sh
 
 BUILT_SOURCES = \


### PR DESCRIPTION
Currently policy.xsd is not getting shipped in RPMs as its missing from the distribution.

Pretty please could this be backported into 2.3 and 2.4. aka fedora 43/44