### PR TITLE
test: fix tests that trigger out-of-band config detected

### DIFF
--- a/src/tests/features/service_include.at
+++ b/src/tests/features/service_include.at
@@ -1,6 +1,7 @@
 FWD_START_TEST([service include])
 AT_KEYWORDS(service xml gh273 rhbz1720300 gh707 gh1075)
 
+FWD_STOP_FIREWALLD()
 AT_CHECK([cat <<HERE > ./services/my-service-with-include.xml
 <?xml version="1.0" encoding="utf-8"?>
 <service>
@@ -22,7 +23,7 @@ AT_CHECK([cat <<HERE > ./services/recursive-service.xml
 </service>
 HERE
 ])
-FWD_RELOAD
+FWD_START_FIREWALLD()
 
 FWD_CHECK([-q --zone=drop --add-interface=foobar0])
 FWD_CHECK([-q --zone=drop --add-service=my-service-with-include])
@@ -114,6 +115,7 @@ my-service-with-include
 ])])
 
 dnl firewall-offline-cmd
+FWD_STOP_FIREWALLD()
 FWD_OFFLINE_CHECK([--service=my-service-with-include --query-include=recursive-service], 0, [ignore], [ignore])
 FWD_OFFLINE_CHECK([-q --service=my-service-with-include --add-include=ssh])
 FWD_OFFLINE_CHECK([--service=my-service-with-include --query-include=ssh], 0, [ignore], [ignore])
@@ -134,6 +136,7 @@ my-service-with-include
   includes: mdns recursive-service ssdp
   helpers:
 ])])
+FWD_START_FIREWALLD()
 
 dnl negative test for including service that doesn't exist
 FWD_CHECK([--permanent --service=my-service-with-include --add-include=does-not-exist], 101, [ignore], [ignore])

--- a/src/tests/features/service_include.at
+++ b/src/tests/features/service_include.at
@@ -2,7 +2,7 @@ FWD_START_TEST([service include])
 AT_KEYWORDS(service xml gh273 rhbz1720300 gh707 gh1075)
 
 FWD_STOP_FIREWALLD()
-AT_CHECK([cat <<HERE > ./services/my-service-with-include.xml
+AT_DATA([./services/my-service-with-include.xml], [dnl
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>my-service-with-include</short>
@@ -12,16 +12,14 @@ AT_CHECK([cat <<HERE > ./services/my-service-with-include.xml
   <include service="mdns"/>
   <include service="recursive-service"/>
 </service>
-HERE
 ])
-AT_CHECK([cat <<HERE > ./services/recursive-service.xml
+AT_DATA([./services/recursive-service.xml], [dnl
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <short>recursive-service</short>
   <description>Include a service that included us</description>
   <include service="my-service-with-include"/>
 </service>
-HERE
 ])
 FWD_START_FIREWALLD()
 

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -1,4 +1,5 @@
 m4_define([FWD_STOP_FIREWALLD], [
+    m4_ifdef([TESTING_FIREWALL_OFFLINE_CMD], [], [
     pid=$(cat firewalld.pid)
     kill $pid
     for I in 1 2 3 4 5 6 7 8 9 0; do
@@ -6,9 +7,11 @@ m4_define([FWD_STOP_FIREWALLD], [
         sleep 1
     done
     test $pid -eq 0 || { kill -9 $pid; sleep 3; }
+    ])
 ])
 
 m4_define([FWD_START_FIREWALLD], [
+    m4_ifdef([TESTING_FIREWALL_OFFLINE_CMD], [], [
     FIREWALLD_ARGS="--nofork --nopid --log-file ./firewalld.log --log-target file --system-config ./"
     dnl if testsuite ran with debug flag, add debug output
     ${at_debug_p} && FIREWALLD_ARGS="--debug=9 ${FIREWALLD_ARGS}"
@@ -36,6 +39,7 @@ m4_define([FWD_START_FIREWALLD], [
         sleep 1
     done
     AT_FAIL_IF([test $up -ne 1])
+    ])
 ])
 
 m4_define([START_NETWORKMANAGER], [

--- a/src/tests/functions.at
+++ b/src/tests/functions.at
@@ -291,6 +291,10 @@ m4_define([FWD_START_TEST], [
 ])
 
 m4_define([FWD_END_TEST], [
+    dnl Give watcher time to detect out-of-band config changes.
+    dnl See commit 133d38fff480 ("test(functions): fail test if out-of-band configuration changes detected")
+    ${at_debug_p} && sleep 10
+
     m4_ifdef([TESTING_FIREWALL_OFFLINE_CMD], [], [
         if test x"$1" != x"ignore"; then
             AT_FAIL_IF([cat ./firewalld.log | dnl

--- a/src/tests/regression/RHEL-67103.at
+++ b/src/tests/regression/RHEL-67103.at
@@ -31,4 +31,5 @@ AT_DATA([./zones/broken.xml], [m4_strip([dnl
 ])])
 FWD_RELOAD(135, [ignore], [ignore])
 
-FWD_END_TEST([-e '/ERROR: INVALID_IPSET/d'])
+FWD_END_TEST([-e '/ERROR: INVALID_IPSET/d'
+              -e '/Detected permanent.* configuration change/d'])

--- a/src/tests/regression/rhbz1871298.at
+++ b/src/tests/regression/rhbz1871298.at
@@ -3,6 +3,7 @@ AT_KEYWORDS(rich offline rhbz1871298 scale)
 
 AT_SKIP_IF([! NS_CMD([which timeout >/dev/null 2>&1])])
 
+FWD_STOP_FIREWALLD()
 NS_CHECK([echo '<?xml version="1.0" encoding="utf-8"?>' > ./zones/foobar.xml])
 NS_CHECK([echo "<zone>" >> ./zones/foobar.xml])
 NS_CHECK([echo "<short>foobar</short>" >> ./zones/foobar.xml])


### PR DESCRIPTION
    test(functions): sleep when test ends

    Sleep when the test ends to give the config watcher a chance to detect
    configuration that was done out-of-band.

    The end test macros fail the test if this scenario is detected. It does
    that to verify firewalld does not generate false positives in the config
    watcher.

    We only sleep when debug is enabled. The justification is:

      - most of the time this log indicates a test bug and not an issue in
        firewalld
      - it slows down the testsuite considerably