### PR TITLE
Tilde expansion support for --add-entries-from-file

### DIFF
--- a/src/firewall-cmd.in
+++ b/src/firewall-cmd.in
@@ -1676,6 +1676,7 @@ if a.permanent:
 
             for filename in a.add_entries_from_file:
                 try:
+                    filename = os.path.expanduser(filename)
                     entries = cmd.get_ipset_entries_from_file(filename)
                 except IOError as msg:
                     message = "Failed to read file '%s': %s" % (filename, msg)
@@ -3429,6 +3430,7 @@ elif a.add_entries_from_file:
 
     for filename in a.add_entries_from_file:
         try:
+            filename = os.path.expanduser(filename)
             entries = cmd.get_ipset_entries_from_file(filename)
         except IOError as msg:
             message = "Failed to read file '%s': %s" % (filename, msg)

--- a/src/firewall-offline-cmd.in
+++ b/src/firewall-offline-cmd.in
@@ -2285,6 +2285,7 @@ try:
 
             for filename in a.add_entries_from_file:
                 try:
+                    filename = os.path.expanduser(filename)
                     entries = cmd.get_ipset_entries_from_file(filename)
                 except IOError as msg:
                     message = "Failed to read file '%s': %s" % (filename, msg)


### PR DESCRIPTION
The following patches make firewall-cmd honor bash tilde expansion for the --add-entries-from-file option, so that one can run:

sudo firewall-cmd [--permanent] --ipset=ipset --add-entries-from-file=~/new-ips.txt

or even:

sudo firewall-cmd [--permanent] --ipset=ipset --add-entries-from-file=~user/new-ips.txt