### PR TITLE
feat(ipsets): support maintaining comments when reading/writing config xml

### DIFF
--- a/src/firewall/client.py
+++ b/src/firewall/client.py
@@ -1740,7 +1740,7 @@ class FirewallClientIPSetSettings:
         if settings:
             self.settings = settings
         else:
-            self.settings = ["", "", "", "", {}, []]
+            self.settings = ["", "", "", "", {}, [], {}]
 
     @handle_exceptions
     def __repr__(self):

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -211,6 +211,41 @@ class IO_Object:
             )
 
 
+class IO_Object_CommentsDict(dict):
+    def __comment_key(self, el_name, el_id=""):
+        return "%s%s%s" % (el_name, "/" if el_id != "" else "", el_id)
+
+    def set_comments(self, el_name, el_id, preceding_comments, closing_comments):
+        key = self.__comment_key(el_name, el_id)
+        if not key in self:
+            self[key] = (preceding_comments, closing_comments)
+        else:
+            if not self[key][0]:
+                self[key][0] = preceding_comments
+            if not self[key][1]:
+                self[key][1] = closing_comments
+
+    def set_preceding_comments(self, el_name, el_id, preceding_comments):
+        key = self.__comment_key(el_name, el_id)
+        if not key in self:
+            self[key] = (preceding_comments, [])
+        elif not self[key][0]:
+            self[key][0] = preceding_comments
+
+    def set_closing_comments(self, el_name, el_id, closing_comments):
+        key = self.__comment_key(el_name, el_id)
+        if not key in self:
+            self[key] = ([], closing_comments)
+        elif not self[key][1]:
+            self[key][1] = closing_comments
+
+    def get_comments(self, cmt_pos, el_name, el_id=""):
+        key = self.__comment_key(el_name, el_id)
+        if key in self and self[key][cmt_pos]:
+            return self[key][cmt_pos]
+        return []
+
+
 # PARSER
 
 
@@ -313,6 +348,12 @@ class IO_Object_XMLGenerator(saxutils.XMLGenerator):
 
     def comment(self, comment):
         self._write("<!--" + comment + "-->")
+
+    def writeComments(self, indent, newline, comments_dict, cmt_pos, el_name, el_inst=""):
+        for comment in comments_dict.get_comments(cmt_pos, el_name, el_inst):
+            self.ignorableWhitespace(indent)
+            self.comment(" " + comment.strip() + " ")
+            self.ignorableWhitespace(newline)
 
 
 def check_port(port):

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -239,10 +239,10 @@ class IO_Object_CommentsDict(dict):
         elif not self[key][1]:
             self[key][1] = closing_comments
 
-    def get_comments(self, cmt_pos, el_name, el_id=""):
+    def get_comments(self, pos, el_name, el_id=""):
         key = self.__comment_key(el_name, el_id)
-        if key in self and self[key][cmt_pos]:
-            return self[key][cmt_pos]
+        if key in self and self[key][pos]:
+            return self[key][pos]
         return []
 
 
@@ -306,6 +306,10 @@ class IO_Object_ContentHandler(sax.handler.ContentHandler):
 
     def comment(self, data):
         if data != "":
+            if data[0].isspace():
+                data = data[1:]
+            if data[-1].isspace():
+                data = data[:-1]
             self._comments.append(data)
 
     def startDTD(self, name, public_id, system_id):
@@ -347,12 +351,12 @@ class IO_Object_XMLGenerator(saxutils.XMLGenerator):
         self._write("/>")
 
     def comment(self, comment):
-        self._write("<!--" + comment + "-->")
+        self._write("<!-- " + comment + " -->")
 
     def writeComments(self, indent, newline, comments_dict, cmt_pos, el_name, el_inst=""):
         for comment in comments_dict.get_comments(cmt_pos, el_name, el_inst):
             self.ignorableWhitespace(indent)
-            self.comment(" " + comment.strip() + " ")
+            self.comment(comment)
             self.ignorableWhitespace(newline)
 
 

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -247,18 +247,28 @@ class IO_Object_ContentHandler(sax.handler.ContentHandler):
     def __init__(self, item):
         self.item = item
         self._element = ""
+        self._comments = []
 
     def startDocument(self):
         self._element = ""
+        self._comments = []
+
+    def comment(self, data):
+        if data != "":
+            self._comments.append(data)
 
     def startElement(self, name, attrs):
         self._element = ""
+        self._precedingComments = self._comments
+        self._comments = []
 
     def endElement(self, name):
         if name == "short":
             self.item.short = self._element
         elif name == "description":
             self.item.description = self._element
+        self._trailingComments = self._comments
+        self._comments = []
 
     def characters(self, content):
         self._element += content.replace("\n", " ")

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -267,7 +267,7 @@ class IO_Object_ContentHandler(sax.handler.ContentHandler):
             self.item.short = self._element
         elif name == "description":
             self.item.description = self._element
-        self._trailingComments = self._comments
+        self._closingComments = self._comments
         self._comments = []
 
     def characters(self, content):

--- a/src/firewall/core/io/io_object.py
+++ b/src/firewall/core/io/io_object.py
@@ -253,10 +253,6 @@ class IO_Object_ContentHandler(sax.handler.ContentHandler):
         self._element = ""
         self._comments = []
 
-    def comment(self, data):
-        if data != "":
-            self._comments.append(data)
-
     def startElement(self, name, attrs):
         self._element = ""
         self._precedingComments = self._comments
@@ -272,6 +268,22 @@ class IO_Object_ContentHandler(sax.handler.ContentHandler):
 
     def characters(self, content):
         self._element += content.replace("\n", " ")
+
+    def comment(self, data):
+        if data != "":
+            self._comments.append(data)
+
+    def startDTD(self, name, public_id, system_id):
+        pass
+
+    def endDTD(self):
+        pass
+
+    def startCDATA(self):
+        pass
+
+    def endCDATA(self):
+        pass
 
 
 class IO_Object_XMLGenerator(saxutils.XMLGenerator):
@@ -298,6 +310,9 @@ class IO_Object_XMLGenerator(saxutils.XMLGenerator):
         for name, value in attrs.items():
             self._write(" %s=%s" % (name, saxutils.quoteattr(value)))
         self._write("/>")
+
+    def comment(self, comment):
+        self._write("<!--" + comment + "-->")
 
 
 def check_port(port):

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -25,6 +25,7 @@ from firewall.functions import (
 )
 from firewall.core.io.io_object import (
     IO_Object,
+    IO_Object_CommentsDict,
     IO_Object_ContentHandler,
     IO_Object_XMLGenerator,
 )
@@ -71,7 +72,7 @@ class IPSet(IO_Object):
         self.description = ""
         self.type = ""
         self.entries = []
-        self.comments = {}
+        self.comments = IO_Object_CommentsDict()
         self.options = {}
         self.applied = False
 
@@ -370,13 +371,13 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
             if "version" in attrs:
                 self.item.version = attrs["version"]
             if self._precedingComments:
-                keep_comments(self.item.comments, name, "", self._precedingComments)
+                self.item.comments.set_preceding_comments(name, "", self._precedingComments)
         elif name == "short":
             if self._precedingComments:
-                keep_comments(self.item.comments, name, "", self._precedingComments)
+                self.item.comments.set_preceding_comments(name, "", self._precedingComments)
         elif name == "description":
             if self._precedingComments:
-                keep_comments(self.item.comments, name, "", self._precedingComments)
+                self.item.comments.set_preceding_comments(name, "", self._precedingComments)
         elif name == "option":
             value = ""
             if "value" in attrs:
@@ -419,7 +420,7 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
             if attrs["name"] not in self.item.options:
                 self.item.options[attrs["name"]] = value
                 if self._precedingComments:
-                    keep_comments(self.item.comments, "option", attrs["name"], self._precedingComments)
+                    self.item.comments.set_preceding_comments("option", attrs["name"], self._precedingComments)
             else:
                 log.warning("Option %s already set, ignoring.", attrs["name"])
         # nothing to do for entry and entries here
@@ -429,10 +430,10 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
         if name == "entry":
             self.item.entries.append(self._element)
             if self._precedingComments or self._closingComments:
-                keep_comments(self.item.comments, "entry", self._element, self._precedingComments, self._closingComments)
+                self.item.comments.set_comments("entry", self._element, self._precedingComments, self._closingComments)
         elif name == "ipset" or name == "short" or name == "description":
             if self._closingComments:
-                keep_comments(self.item.comments, name, "", [], self._closingComments)
+                self.item.comments.set_closing_comments(name, "", self._closingComments)
 
 
 def ipset_reader(filename, path):
@@ -493,30 +494,6 @@ def ipset_reader(filename, path):
     return ipset
 
 
-def comment_key(elname, elid=""):
-    return "%s%s%s" % (elname, "/" if elid != "" else "", elid)
-
-
-def keep_comments(comments, elname, elid, precedingComments, closingComments=[]):
-    cmtkey = comment_key(elname, elid)
-    if cmtkey not in comments:
-        comments[cmtkey] = (precedingComments, closingComments)
-    else:
-        if not comments[cmtkey][0] and precedingComments:
-            comments[cmtkey][0] = precedingComments
-        if not comments[cmtkey][1] and closingComments:
-            comments[cmtkey][1] = closingComments
-
-
-def write_comments(handler, indent, newline, comments, cmtpos, elname, elid=""):
-    cmtkey = comment_key(elname, elid)
-    if cmtkey in comments:
-        for comment in comments[cmtkey][cmtpos]:
-            handler.ignorableWhitespace(indent)
-            handler.comment(comment)
-            handler.ignorableWhitespace(newline)
-
-
 def ipset_writer(ipset, path=None):
     _path = path if path else ipset.path
 
@@ -545,33 +522,33 @@ def ipset_writer(ipset, path=None):
     attrs = {"type": ipset.type}
     if ipset.version and ipset.version != "":
         attrs["version"] = ipset.version
-    write_comments(handler, "", "", ipset.comments, 0, "ipset")
+    handler.writeComments("", "", ipset.comments, 0, "ipset")
     handler.startElement("ipset", attrs)
     handler.ignorableWhitespace("\n")
 
     # short
     if ipset.short and ipset.short != "":
-        write_comments(handler, "  ", "\n", ipset.comments, 0, "short")
+        handler.writeComments("  ", "\n", ipset.comments, 0, "short")
         handler.ignorableWhitespace("  ")
         handler.startElement("short", {})
         handler.characters(ipset.short)
-        write_comments(handler, "", "", ipset.comments, 1, "short")
+        handler.writeComments("", "", ipset.comments, 1, "short")
         handler.endElement("short")
         handler.ignorableWhitespace("\n")
 
     # description
     if ipset.description and ipset.description != "":
-        write_comments(handler, "  ", "\n", ipset.comments, 0, "description")
+        handler.writeComments("  ", "\n", ipset.comments, 0, "description")
         handler.ignorableWhitespace("  ")
         handler.startElement("description", {})
         handler.characters(ipset.description)
-        write_comments(handler, "", "", ipset.comments, 1, "description")
+        handler.writeComments("", "", ipset.comments, 1, "description")
         handler.endElement("description")
         handler.ignorableWhitespace("\n")
 
     # options
     for key, value in ipset.options.items():
-        write_comments(handler, "  ", "\n", ipset.comments, 0, "option", key)
+        handler.writeComments("  ", "\n", ipset.comments, 0, "option", key)
         handler.ignorableWhitespace("  ")
         if value != "":
             handler.simpleElement("option", {"name": key, "value": value})
@@ -581,16 +558,16 @@ def ipset_writer(ipset, path=None):
 
     # entries
     for entry in ipset.entries:
-        write_comments(handler, "  ", "\n", ipset.comments, 0, "entry", entry)
+        handler.writeComments("  ", "\n", ipset.comments, 0, "entry", entry)
         handler.ignorableWhitespace("  ")
         handler.startElement("entry", {})
         handler.characters(entry)
-        write_comments(handler, "", "", ipset.comments, 1, "entry", entry)
+        handler.writeComments("", "", ipset.comments, 1, "entry", entry)
         handler.endElement("entry")
         handler.ignorableWhitespace("\n")
 
     # end ipset element
-    write_comments(handler, "  ", "\n", ipset.comments, 1, "ipset")
+    handler.writeComments("  ", "\n", ipset.comments, 1, "ipset")
     handler.endElement("ipset")
     handler.ignorableWhitespace("\n")
     handler.endDocument()

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -578,4 +578,3 @@ def ipset_writer(ipset, path=None):
     handler.endDocument()
     f.close()
     del handler
-

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -428,11 +428,11 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
         IO_Object_ContentHandler.endElement(self, name)
         if name == "entry":
             self.item.entries.append(self._element)
-            if self._precedingComments or self._trailingComments:
-                keep_comments(self.item.comments, "entry", self._element, self._precedingComments, self._trailingComments)
+            if self._precedingComments or self._closingComments:
+                keep_comments(self.item.comments, "entry", self._element, self._precedingComments, self._closingComments)
         elif name == "ipset" or name == "short" or name == "description":
-            if self._trailingComments:
-                keep_comments(self.item.comments, name, "", [], self._trailingComments)
+            if self._closingComments:
+                keep_comments(self.item.comments, name, "", [], self._closingComments)
 
 
 def ipset_reader(filename, path):
@@ -496,15 +496,15 @@ def comment_key(elname, elid=""):
     return "%s%s%s" % (elname, "/" if elid != "" else "", elid)
 
 
-def keep_comments(comments, elname, elid, precedingComments, trailingComments=[]):
+def keep_comments(comments, elname, elid, precedingComments, closingComments=[]):
     cmtkey = comment_key(elname, elid)
     if cmtkey not in comments:
-        comments[cmtkey] = (precedingComments, trailingComments)
+        comments[cmtkey] = (precedingComments, closingComments)
     else:
         if not comments[cmtkey][0] and precedingComments:
             comments[cmtkey][0] = precedingComments
-        if not comments[cmtkey][1] and trailingComments:
-            comments[cmtkey][1] = trailingComments
+        if not comments[cmtkey][1] and closingComments:
+            comments[cmtkey][1] = closingComments
 
 
 def write_comments(handler, indent, newline, comments, ptidx, elname, elid=""):
@@ -554,6 +554,7 @@ def ipset_writer(ipset, path=None):
         handler.ignorableWhitespace("  ")
         handler.startElement("short", {})
         handler.characters(ipset.short)
+        write_comments(handler, "", "", ipset.comments, 1, "short")
         handler.endElement("short")
         handler.ignorableWhitespace("\n")
 
@@ -563,6 +564,7 @@ def ipset_writer(ipset, path=None):
         handler.ignorableWhitespace("  ")
         handler.startElement("description", {})
         handler.characters(ipset.description)
+        write_comments(handler, "", "", ipset.comments, 1, "description")
         handler.endElement("description")
         handler.ignorableWhitespace("\n")
 

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -578,3 +578,4 @@ def ipset_writer(ipset, path=None):
     handler.endDocument()
     f.close()
     del handler
+

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -48,9 +48,9 @@ class IPSet(IO_Object):
         "type": "",  # s
         "options": {"": ""},  # a{ss}
         "entries": [""],  # as
-        "comments": {("", ""): ([""], [""])},  # a{(ss)(asas)}
+        "comments": {"": ([""], [""])},  # a{s(asas)}
     }
-    DBUS_SIGNATURE = "(ssssa{ss}asa{(ss)(asas)})"
+    DBUS_SIGNATURE = "(ssssa{ss}asa{s(asas)})"
     ADDITIONAL_ALNUM_CHARS = ["_", "-", ":", "."]
     PARSER_REQUIRED_ELEMENT_ATTRS = {
         "short": None,
@@ -370,13 +370,13 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
             if "version" in attrs:
                 self.item.version = attrs["version"]
             if self._precedingComments:
-                self.item.comments[("ipset", "")] = (self._precedingComments, [])
+                keep_comments(self.item.comments, name, "", self._precedingComments)
         elif name == "short":
             if self._precedingComments:
-                self.item.comments[("short", "")] = (self._precedingComments, [])
+                keep_comments(self.item.comments, name, "", self._precedingComments)
         elif name == "description":
             if self._precedingComments:
-                self.item.comments[("description", "")] = (self._precedingComments, [])
+                keep_comments(self.item.comments, name, "", self._precedingComments)
         elif name == "option":
             value = ""
             if "value" in attrs:
@@ -419,7 +419,7 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
             if attrs["name"] not in self.item.options:
                 self.item.options[attrs["name"]] = value
                 if self._precedingComments:
-                    self.item.comments[("option", attrs["name"])] = (self._precedingComments, [])
+                    keep_comments(self.item.comments, "option", attrs["name"], self._precedingComments)
             else:
                 log.warning("Option %s already set, ignoring.", attrs["name"])
         # nothing to do for entry and entries here
@@ -429,11 +429,10 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
         if name == "entry":
             self.item.entries.append(self._element)
             if self._precedingComments or self._trailingComments:
-                self.item.comments = self.item.comments | {("entry", self._element): (self._precedingComments, self._trailingComments)}
-        if name == "ipset":
+                keep_comments(self.item.comments, "entry", self._element, self._precedingComments, self._trailingComments)
+        elif name == "ipset" or name == "short" or name == "description":
             if self._trailingComments:
-                self.item.comments = self.item.comments | {("ipset", ""): ([], [])}
-                self.item.comments[("ipset", "")] = (self.item.comments[("ipset", "")][0], self._trailingComments)
+                keep_comments(self.item.comments, name, "", [], self._trailingComments)
 
 
 def ipset_reader(filename, path):
@@ -493,9 +492,25 @@ def ipset_reader(filename, path):
     return ipset
 
 
-def write_comments(handler, indent, newline, comments, ptidx, key, value=""):
-    if (key, value) in comments:
-        for comment in comments[(key, value)][ptidx]:
+def comment_key(elname, elid=""):
+    return "%s%s%s" % (elname, "/" if elid != "" else "", elid)
+
+
+def keep_comments(comments, elname, elid, precedingComments, trailingComments=[]):
+    cmtkey = comment_key(elname, elid)
+    if cmtkey not in comments:
+        comments[cmtkey] = (precedingComments, trailingComments)
+    else:
+        if not comments[cmtkey][0] and precedingComments:
+            comments[cmtkey][0] = precedingComments
+        if not comments[cmtkey][1] and trailingComments:
+            comments[cmtkey][1] = trailingComments
+
+
+def write_comments(handler, indent, newline, comments, ptidx, elname, elid=""):
+    cmtkey = comment_key(elname, elid)
+    if cmtkey in comments:
+        for comment in comments[cmtkey][ptidx]:
             handler.ignorableWhitespace(indent)
             handler.comment(comment)
             handler.ignorableWhitespace(newline)

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -48,8 +48,9 @@ class IPSet(IO_Object):
         "type": "",  # s
         "options": {"": ""},  # a{ss}
         "entries": [""],  # as
+        "comments": {("", ""): ([""], [""])},  # a{(ss)(asas)}
     }
-    DBUS_SIGNATURE = "(ssssa{ss}as)"
+    DBUS_SIGNATURE = "(ssssa{ss}asa{(ss)(asas)})"
     ADDITIONAL_ALNUM_CHARS = ["_", "-", ":", "."]
     PARSER_REQUIRED_ELEMENT_ATTRS = {
         "short": None,
@@ -70,6 +71,7 @@ class IPSet(IO_Object):
         self.description = ""
         self.type = ""
         self.entries = []
+        self.comments = {}
         self.options = {}
         self.applied = False
 
@@ -79,6 +81,7 @@ class IPSet(IO_Object):
         self.description = ""
         self.type = ""
         del self.entries[:]
+        self.comments.clear()
         self.options.clear()
         self.applied = False
 
@@ -366,10 +369,14 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
                 self.item.type = attrs["type"]
             if "version" in attrs:
                 self.item.version = attrs["version"]
+            if self._precedingComments:
+                self.item.comments[("ipset", "")] = (self._precedingComments, [])
         elif name == "short":
-            pass
+            if self._precedingComments:
+                self.item.comments[("short", "")] = (self._precedingComments, [])
         elif name == "description":
-            pass
+            if self._precedingComments:
+                self.item.comments[("description", "")] = (self._precedingComments, [])
         elif name == "option":
             value = ""
             if "value" in attrs:
@@ -411,6 +418,8 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
                 raise FirewallError(errors.INVALID_FAMILY, value)
             if attrs["name"] not in self.item.options:
                 self.item.options[attrs["name"]] = value
+                if self._precedingComments:
+                    self.item.comments[("option", attrs["name"])] = (self._precedingComments, [])
             else:
                 log.warning("Option %s already set, ignoring.", attrs["name"])
         # nothing to do for entry and entries here
@@ -419,6 +428,12 @@ class ipset_ContentHandler(IO_Object_ContentHandler):
         IO_Object_ContentHandler.endElement(self, name)
         if name == "entry":
             self.item.entries.append(self._element)
+            if self._precedingComments or self._trailingComments:
+                self.item.comments = self.item.comments | {("entry", self._element): (self._precedingComments, self._trailingComments)}
+        if name == "ipset":
+            if self._trailingComments:
+                self.item.comments = self.item.comments | {("ipset", ""): ([], [])}
+                self.item.comments[("ipset", "")] = (self.item.comments[("ipset", "")][0], self._trailingComments)
 
 
 def ipset_reader(filename, path):
@@ -478,6 +493,14 @@ def ipset_reader(filename, path):
     return ipset
 
 
+def write_comments(handler, indent, newline, comments, ptidx, key, value=""):
+    if (key, value) in comments:
+        for comment in comments[(key, value)][ptidx]:
+            handler.ignorableWhitespace(indent)
+            handler.comment(comment)
+            handler.ignorableWhitespace(newline)
+
+
 def ipset_writer(ipset, path=None):
     _path = path if path else ipset.path
 
@@ -506,11 +529,13 @@ def ipset_writer(ipset, path=None):
     attrs = {"type": ipset.type}
     if ipset.version and ipset.version != "":
         attrs["version"] = ipset.version
+    write_comments(handler, "", "", ipset.comments, 0, "ipset")
     handler.startElement("ipset", attrs)
     handler.ignorableWhitespace("\n")
 
     # short
     if ipset.short and ipset.short != "":
+        write_comments(handler, "  ", "\n", ipset.comments, 0, "short")
         handler.ignorableWhitespace("  ")
         handler.startElement("short", {})
         handler.characters(ipset.short)
@@ -519,6 +544,7 @@ def ipset_writer(ipset, path=None):
 
     # description
     if ipset.description and ipset.description != "":
+        write_comments(handler, "  ", "\n", ipset.comments, 0, "description")
         handler.ignorableWhitespace("  ")
         handler.startElement("description", {})
         handler.characters(ipset.description)
@@ -527,6 +553,7 @@ def ipset_writer(ipset, path=None):
 
     # options
     for key, value in ipset.options.items():
+        write_comments(handler, "  ", "\n", ipset.comments, 0, "option", key)
         handler.ignorableWhitespace("  ")
         if value != "":
             handler.simpleElement("option", {"name": key, "value": value})
@@ -536,13 +563,16 @@ def ipset_writer(ipset, path=None):
 
     # entries
     for entry in ipset.entries:
+        write_comments(handler, "  ", "\n", ipset.comments, 0, "entry", entry)
         handler.ignorableWhitespace("  ")
         handler.startElement("entry", {})
         handler.characters(entry)
+        write_comments(handler, "", "", ipset.comments, 1, "entry", entry)
         handler.endElement("entry")
         handler.ignorableWhitespace("\n")
 
     # end ipset element
+    write_comments(handler, "  ", "\n", ipset.comments, 1, "ipset")
     handler.endElement("ipset")
     handler.ignorableWhitespace("\n")
     handler.endDocument()

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -450,6 +450,7 @@ def ipset_reader(filename, path):
     handler = ipset_ContentHandler(ipset)
     parser = sax.make_parser()
     parser.setContentHandler(handler)
+    parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler)
     name = "%s/%s" % (path, filename)
     with open(name, "rb") as f:
         source = sax.InputSource(None)

--- a/src/firewall/core/io/ipset.py
+++ b/src/firewall/core/io/ipset.py
@@ -508,10 +508,10 @@ def keep_comments(comments, elname, elid, precedingComments, closingComments=[])
             comments[cmtkey][1] = closingComments
 
 
-def write_comments(handler, indent, newline, comments, ptidx, elname, elid=""):
+def write_comments(handler, indent, newline, comments, cmtpos, elname, elid=""):
     cmtkey = comment_key(elname, elid)
     if cmtkey in comments:
-        for comment in comments[cmtkey][ptidx]:
+        for comment in comments[cmtkey][cmtpos]:
             handler.ignorableWhitespace(indent)
             handler.comment(comment)
             handler.ignorableWhitespace(newline)


### PR DESCRIPTION
Addresses: https://github.com/firewalld/firewalld/issues/194

extended `core/io/io_object` code to support basic reading and writing of comments; and a dictionary wrapper to maintain comments linked to a corresponding element
extended `core/io/ipset` to process any read comments and include them back when writing

Supported with this change is what I would call _preceding_ and _closing_ comments. E.g.:

```
<ipset type="...">
  <!-- comment some option -->
  <option name="..." value="..."/>
  ...
  <!-- multi line
          comment
          for entry
  -->
  <!-- second comment for same entry -->
  <entry>...</entry>
  ...
  <!-- closing comment ipset -->
</ipset>

```
multiple comments preceding an element are supported; but when removing the element _all_ comments directly preceding it will be removed as well. Because in the chosen approach comments are always 'linked' to an element.

Not supported is what I would call _trailing_ comments. E.g.:

```
<ipset type="...">
  ...
  <entry>...</entry><!-- trailing comment not supported -->
</ipset>

```
the reason this is not supported is because the used XML reader by default just 'encounters' comments between the start and/or end of elements. So when between elements I have chosen to interpret it as preceding the next element, as I think that is much more common. 
(in theory it is possible to also support trailing comments but that would add substantial further complexity to the content handler)

Final notes: 
- if this PR were to be approved could add processing of comments in other places than ipsets (if/where desired); but let's first see if we can agree on the general approach
- this PR maintains existing comments; I have a [separate PR ready](https://github.com/ArthurRM/firewalld/pull/1/changes) for a `--with-comment` option that can be used together with `--add-entry` in `firewall-cmd` and `firewall-offline-cmd`